### PR TITLE
fix: rmcp-rust-sdk submodule URL + worktree git-identity stamping

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -40,7 +40,7 @@
 
 [submodule "rmcp-rust-sdk"]
 	path = rmcp-rust-sdk
-	url = git@github.com:modelcontextprotocol/rust-sdk.git
+	url = https://github.com/modelcontextprotocol/rust-sdk.git
 
 [submodule "vendor/agent-framework"]
 	path = vendor/agent-framework

--- a/_b00t_/agent-hooks/events/agent.start.sh
+++ b/_b00t_/agent-hooks/events/agent.start.sh
@@ -31,6 +31,11 @@ if [ "${B00T_NO_WORKTREE:-0}" != "1" ] && [ -n "${PROJECT_ROOT}" ] && [ -f "${PR
     if [ -n "${REF}" ]; then
       git -C "${PROJECT_ROOT}" worktree add --detach "${WT_DIR}" "${REF}" 2>/dev/null && {
         ln -sf "${PROJECT_ROOT}/.git/🥾.tomllmd" "${WT_DIR}/.git/🥾.tomllmd" 2>/dev/null || true
+        # Stamp per-worktree git identity with the b00t agent + session id so
+        # commits made here are attributable, instead of silently inheriting
+        # whatever default (or stale placeholder) sits in the shared repo config.
+        git -C "${WT_DIR}" config user.name "b00t-agent[${AGENT_TYPE}]" || true
+        git -C "${WT_DIR}" config user.email "${AGENT_ID}.${SESSION_ID}@b00t.local" || true
         echo "b00t agent.start: worktree ${WT_DIR}" >&2
       } || echo "b00t agent.start: worktree creation failed (non-fatal)" >&2
     fi

--- a/_b00t_/agent-hooks/events/worktree.create.sh
+++ b/_b00t_/agent-hooks/events/worktree.create.sh
@@ -7,6 +7,7 @@
 set -euo pipefail
 
 AGENT_ID="${1:-${B00T_AGENT_ID:-unknown}}"
+SESSION_ID="${B00T_SESSION_ID:-unknown}"
 PROJECT_ROOT="${B00T_PROJECT_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || echo "$PWD")}"
 WORKTREE_DIR="${PROJECT_ROOT}/.b00t/worktrees/${AGENT_ID}"
 
@@ -45,6 +46,12 @@ fi
 
 # Symlink the project soul into the worktree's .git/
 ln -sf "${PROJECT_ROOT}/.git/🥾.tomllmd" "${WORKTREE_DIR}/.git/🥾.tomllmd" 2>/dev/null || true
+
+# Stamp per-worktree git identity with the b00t agent + session id so commits
+# made here are attributable, instead of silently inheriting whatever default
+# (or stale placeholder) sits in the shared repo config.
+git -C "${WORKTREE_DIR}" config user.name "b00t-agent[${AGENT_ID}]" || true
+git -C "${WORKTREE_DIR}" config user.email "${AGENT_ID}.${SESSION_ID}@b00t.local" || true
 
 echo "[worktree.create] created ${WORKTREE_DIR}"
 echo "B00T_WORKTREE=${WORKTREE_DIR}"

--- a/justfile
+++ b/justfile
@@ -894,6 +894,9 @@ validate-mcp:
 			echo "✅ pi --mode rpc: supported"
 		else
 			echo "⚠️ pi --mode rpc: NOT found (datum gap in _b00t_/pi.agent.toml)"
+		fi
+	else
+		echo "⚠️ pi: not installed; skipping --mode rpc smoke test"
 	fi
 
 # ── Obsidian MCP proxy ───────────────────────────────────────────────────
@@ -902,11 +905,8 @@ validate-mcp:
 # Connects via mcp-remote → https://${OBSIDIAN_HOST}:3443/mcp with Bearer auth.
 obsidian-proxy:
     npx -y mcp-remote \
-	  https://$(OBSIDIAN_HOST:=windows-host.lan):$(OBSIDIAN_PORT:=3443)/mcp \
-	  --header "Authorization: Bearer $(OBSIDIAN_MCP_KEY)"
-	else
-		echo "⚠️ pi: not installed; skipping --mode rpc smoke test"
-	fi
+      https://$(OBSIDIAN_HOST:=windows-host.lan):$(OBSIDIAN_PORT:=3443)/mcp \
+      --header "Authorization: Bearer $(OBSIDIAN_MCP_KEY)"
 
 # Lint: NTFS invalid character scan — fail if paths contain reserved chars
 # Policy: pwsh.🪟/NTFS_RESERVED_CHARS.md


### PR DESCRIPTION
## Summary
- `.gitmodules`: `rmcp-rust-sdk`'s scp-style SSH URL (`git@github.com:...`) breaks Cargo's git-dependency fetch for *any* crate that depends on this repo (fails recursive submodule init with "relative URL without a base", even with `git-fetch-with-cli`). Switched to the equivalent HTTPS URL — it's a read-only vendor mirror. Found while wiring `ufo-types` as a git dependency into app4dog's `critter-keeper` crate (`_b00t_/PIPELINE-DATUM-UFO-FOUNDATION.tomllmd` Task 4).
- `justfile`: same class of `obsidian-proxy` merge corruption as #782 (still open/unmerged), plus a newer, separate whitespace-consistency break in that same recipe. Restores parseability; converges with #782 once that lands.
- `_b00t_/agent-hooks/events/{agent.start,worktree.create}.sh`: neither script stamps per-worktree git identity after creating a worktree, so agent-authored commits silently inherit whatever's in the shared repo `.git/config` — currently a stale `Test User <test@example.com>` placeholder, which had been misattributing commits across worktrees this session. Now sets `user.name`/`user.email` from the agent id + session id already available to these hooks, following the existing `<handle>@b00t.local` convention (`b00t-skill-loop <loop@b00t.local>`).

## Test plan
- [x] `just --list` parses cleanly (was failing before the justfile fix)
- [x] `git submodule sync -- rmcp-rust-sdk && git submodule update --init rmcp-rust-sdk` succeeds over HTTPS
- [x] `bash -n` on both patched hook scripts
- [x] `git push` — pre-push gate ran (`no Rust packages affected — skipping test gate`), no regressions