### PR TITLE
fix: close all cargo test -p b00t-cli/-p b00t-mcp pre-push gate failures

### DIFF
--- a/b00t-cli/src/commands/pipeline_cost.rs
+++ b/b00t-cli/src/commands/pipeline_cost.rs
@@ -284,10 +284,17 @@ mod tests {
     }
 
     #[test]
-    fn handle_forecast_unknown_pipeline() {
+    fn handle_forecast_unrecognized_name_falls_back_gracefully() {
+        // #823 — this used to assert an error for any unrecognized name, but
+        // sample_stages_for_unknown_id and build_report_unknown_pipeline
+        // (both below) establish, by design, that an unrecognized name is
+        // treated as a "custom pipeline" with a synthetic 1-stage fallback
+        // rather than a hard failure — forecasting works for any
+        // user-supplied name, known or not. Aligning this test with that
+        // established, doubly-confirmed behavior instead of contradicting it.
         let config = CostConfig::default();
         let result = handle_forecast("nonexistent-pipeline-xyz", &config);
-        assert!(result.is_err());
+        assert!(result.is_ok());
     }
 
     #[test]

--- a/b00t-cli/src/pipeline_flowctl.rs
+++ b/b00t-cli/src/pipeline_flowctl.rs
@@ -95,7 +95,15 @@ impl FlowControl {
                 if *max_bytes_per_sec == 0 {
                     return false;
                 }
-                self.current_bytes_sec < *max_bytes_per_sec as f64
+                // Compare the raw bytes accumulated in the current (<=1s)
+                // window directly against the limit, not an elapsed-based
+                // rate (bytes / elapsed_seconds) — that extrapolation is
+                // unstable right after construction or a window reset,
+                // when elapsed is microseconds: dividing by a near-zero
+                // duration turns any nonzero byte count into an apparent
+                // rate of hundreds of thousands of bytes/sec, blocking
+                // traffic that's actually well under the limit (#819).
+                self.throttle_window_bytes < *max_bytes_per_sec
             }
             FlowStrategy::Windowed { max_in_flight } => self.in_flight < *max_in_flight,
         }
@@ -339,6 +347,13 @@ mod tests {
         assert!(fc.can_accept(), "buffer has data");
         fc.record_accept(10);
         assert!(fc.can_emit(), "after accept, buffer has room again");
+        assert!(fc.can_accept(), "2/3 still buffered after accepting 1 of 3");
+
+        // Drain the rest to actually reach the empty state (#820 — this
+        // used to assert emptiness after accepting only 1 of 3, which
+        // doesn't match the buffer's real state).
+        fc.record_accept(10);
+        fc.record_accept(10);
         assert!(!fc.can_accept(), "buffer is now empty");
     }
 

--- a/b00t-cli/src/pipeline_k8s.rs
+++ b/b00t-cli/src/pipeline_k8s.rs
@@ -419,7 +419,11 @@ pub fn generate_deployment(capsule: &CapsuleDefinition) -> String {
             let mut resources = serde_json::Map::new();
             resources.insert("requests".into(), serde_json::Value::Object(requests));
 
-            if res.requires_gpu {
+            // A stage needs GPU limits if either its own profile requires
+            // it, or the capsule's overall resource budget does (#821 — the
+            // capsule-level `requires_gpu` was never consulted here, so
+            // setting it had no effect on the generated container limits).
+            if res.requires_gpu || capsule.spec.resources.requires_gpu {
                 let mut limits = serde_json::Map::new();
                 limits.insert("nvidia.com/gpu".into(), serde_json::json!(1));
                 resources.insert("limits".into(), serde_json::Value::Object(limits));

--- a/b00t-cli/src/pipeline_nats.rs
+++ b/b00t-cli/src/pipeline_nats.rs
@@ -213,23 +213,43 @@ impl NatsSubscription for NatsClientAdapterSubscription {
     }
 }
 
+/// Run a future to completion from a sync context, regardless of whether
+/// the calling thread is itself a tokio runtime worker thread already
+/// driving other tasks (`Handle::current().block_on()` panics — "Cannot
+/// start a runtime from within a runtime" — in exactly that case, which is
+/// the real call path for `NatsClientAdapter` from `PipelineExecutor::
+/// execute`'s own async logic, #824). Spawning a fresh OS thread and
+/// calling `block_on` *there* sidesteps the nesting problem entirely: that
+/// thread isn't driving any tokio task, so blocking it is always safe,
+/// independent of the runtime's flavor (current_thread vs multi_thread) or
+/// the caller's own sync/async context.
+fn block_on_fresh_thread<F, T>(handle: tokio::runtime::Handle, fut: F) -> T
+where
+    F: std::future::Future<Output = T> + Send,
+    T: Send,
+{
+    std::thread::scope(|s| s.spawn(|| handle.block_on(fut)).join().expect("nats adapter thread panicked"))
+}
+
 impl NatsTransport for NatsClientAdapter {
     fn publish(&self, subject: &str, payload: &[u8]) -> Result<()> {
         let client = self.client.clone();
         let subject = subject.to_string();
         let payload = payload.to_vec();
-        tokio::runtime::Handle::current()
-            .block_on(async move { client.publish(&subject, payload).await })
-            .context("NatsClient publish failed")?;
+        block_on_fresh_thread(tokio::runtime::Handle::current(), async move {
+            client.publish(&subject, payload).await
+        })
+        .context("NatsClient publish failed")?;
         Ok(())
     }
 
     fn subscribe(&self, subject: &str) -> Result<Box<dyn NatsSubscription>> {
         let client = self.client.clone();
         let subject = subject.to_string();
-        let data = tokio::runtime::Handle::current()
-            .block_on(async move { client.subscribe(&subject).await })
-            .context("NatsClient subscribe failed")?;
+        let data = block_on_fresh_thread(tokio::runtime::Handle::current(), async move {
+            client.subscribe(&subject).await
+        })
+        .context("NatsClient subscribe failed")?;
         let buffer = data.into_iter().collect::<Vec<Vec<u8>>>();
         Ok(Box::new(NatsClientAdapterSubscription {
             buffer: buffer.into_iter(),

--- a/b00t-cli/src/pipeline_nats.rs
+++ b/b00t-cli/src/pipeline_nats.rs
@@ -151,7 +151,14 @@ struct MockNatsSubscription {
 
 impl NatsSubscription for MockNatsSubscription {
     fn next(&mut self) -> Option<Vec<u8>> {
-        self.rx.recv().ok()
+        // try_recv, not recv: this mock is fully in-memory and synchronous —
+        // publish() has already delivered any pending message by the time
+        // next() is called, so there's nothing to block-wait for. A blocking
+        // recv() here hangs forever on the (deliberately, by-design) empty
+        // case — messages published before subscribe(), or genuinely no
+        // message sent — because the sender lives inside the still-alive
+        // MockNatsTransport and never gets dropped to unblock recv().
+        self.rx.try_recv().ok()
     }
 }
 
@@ -352,11 +359,14 @@ mod tests {
         let transport = MockNatsTransport::new();
         let subject = "pipeline.test-run.stage-a.output.video";
 
+        // Subscribe *before* publish: per the mock's documented semantics
+        // (see mock_transport_publish_before_subscribe_lost below), a
+        // subscriber only receives messages published after it subscribes.
+        let mut sub = transport.subscribe(subject).expect("subscribe");
         transport
             .publish(subject, b"hello-nats")
             .expect("publish");
 
-        let mut sub = transport.subscribe(subject).expect("subscribe");
         let msg = sub.next().expect("should receive message");
         assert_eq!(msg, b"hello-nats");
     }
@@ -485,17 +495,27 @@ mod tests {
 
     #[tokio::test]
     async fn nats_client_adapter_round_trip() {
+        // NatsClientAdapter's methods are sync-but-block_on-internally (see
+        // the module doc) — calling them directly from this #[tokio::test]
+        // async fn would nest block_on inside the runtime already driving
+        // this test ("Cannot start a runtime from within a runtime").
+        // spawn_blocking moves the whole sync sequence onto a blocking-pool
+        // thread, where that internal block_on is safe.
         let mock_nats = Arc::new(crate::pipeline_executor::MockNatsClient::new())
             as Arc<dyn NatsClient>;
         let adapter = NatsClientAdapter::new(mock_nats.clone());
         let subject = "pipeline.adapter-test.stage.output.bytes";
 
-        adapter
-            .publish(subject, b"adapter-payload")
-            .expect("adapter publish");
+        let msg = tokio::task::spawn_blocking(move || {
+            adapter
+                .publish(subject, b"adapter-payload")
+                .expect("adapter publish");
+            let mut sub = adapter.subscribe(subject).expect("adapter subscribe");
+            sub.next().expect("should receive from adapter")
+        })
+        .await
+        .expect("blocking task panicked");
 
-        let mut sub = adapter.subscribe(subject).expect("adapter subscribe");
-        let msg = sub.next().expect("should receive from adapter");
         assert_eq!(msg, b"adapter-payload");
     }
 
@@ -563,36 +583,46 @@ mod tests {
 
     #[tokio::test]
     async fn nats_client_adapter_no_message() {
+        // See nats_client_adapter_round_trip for why this is spawn_blocking.
         let mock_nats = Arc::new(crate::pipeline_executor::MockNatsClient::new())
             as Arc<dyn NatsClient>;
         let adapter = NatsClientAdapter::new(mock_nats);
 
-        let mut sub = adapter
-            .subscribe("pipeline.empty.sub.output.bytes")
-            .expect("subscribe to empty");
-        assert!(
-            sub.next().is_none(),
-            "no message should be available"
-        );
+        let received = tokio::task::spawn_blocking(move || {
+            let mut sub = adapter
+                .subscribe("pipeline.empty.sub.output.bytes")
+                .expect("subscribe to empty");
+            sub.next()
+        })
+        .await
+        .expect("blocking task panicked");
+
+        assert!(received.is_none(), "no message should be available");
     }
 
     // ── NatsClientAdapter: subject isolation ────────────────────────────
 
     #[tokio::test]
     async fn nats_client_adapter_subject_isolation() {
+        // See nats_client_adapter_round_trip for why this is spawn_blocking.
         let mock_nats = Arc::new(crate::pipeline_executor::MockNatsClient::new())
             as Arc<dyn NatsClient>;
         let adapter = NatsClientAdapter::new(mock_nats);
 
-        adapter
-            .publish("pipeline.isolation.a.output.bytes", b"data-a")
-            .expect("publish a");
+        let received = tokio::task::spawn_blocking(move || {
+            adapter
+                .publish("pipeline.isolation.a.output.bytes", b"data-a")
+                .expect("publish a");
 
-        let mut sub_b = adapter
-            .subscribe("pipeline.isolation.b.output.bytes")
-            .expect("subscribe b");
+            let mut sub_b = adapter
+                .subscribe("pipeline.isolation.b.output.bytes")
+                .expect("subscribe b");
+            sub_b.next()
+        })
+        .await
+        .expect("blocking task panicked");
 
         // Subject B should have no messages (isolation).
-        assert!(sub_b.next().is_none(), "subjects must be isolated");
+        assert!(received.is_none(), "subjects must be isolated");
     }
 }

--- a/b00t-cli/src/pipeline_statemachine.rs
+++ b/b00t-cli/src/pipeline_statemachine.rs
@@ -336,9 +336,12 @@ mod tests {
         let state = sm.transition(PipelineEvent::StageComplete(2)).unwrap();
         assert_eq!(state, PipelineState::Completed);
 
-        // History must have 7 entries: Validate, Schedule, Execute,
-        // StageComplete(0), StageComplete(1), StageComplete(2)
-        assert_eq!(sm.history().len(), 7);
+        // History has 6 entries, one per transition() call: Validate,
+        // Schedule, Execute, StageComplete(0), StageComplete(1),
+        // StageComplete(2) — confirmed one-entry-per-call by the sibling
+        // history_tracks_all_transitions test (#822 — this used to assert
+        // 7, off by one from its own 6-item breakdown above).
+        assert_eq!(sm.history().len(), 6);
     }
 
     // ── Pause / Resume cycle ────────────────────────────────────────────

--- a/b00t-mcp/src/mcp_tools.rs
+++ b/b00t-mcp/src/mcp_tools.rs
@@ -17,7 +17,7 @@ pub struct McpListCommand {
     pub json: bool,
 }
 
-impl_mcp_tool!(McpListCommand, "mcp_list", ["mcp", "list"]);
+impl_mcp_tool!(McpListCommand, "b00t_mcp_list", ["mcp", "list"]);
 
 /// Add MCP server
 #[derive(Parser, Clone)]
@@ -53,7 +53,7 @@ pub struct CliDetectCommand {
     pub command: String,
 }
 
-impl_mcp_tool!(CliDetectCommand, "cli_detect", ["cli", "detect"]);
+impl_mcp_tool!(CliDetectCommand, "b00t_cli_detect", ["cli", "detect"]);
 
 /// Show desired CLI version
 #[derive(Parser, Clone)]
@@ -173,7 +173,7 @@ pub struct WhoamiCommand {
     pub json: bool,
 }
 
-impl_mcp_tool!(WhoamiCommand, "whoami", ["whoami"]);
+impl_mcp_tool!(WhoamiCommand, "b00t_whoami", ["whoami"]);
 
 /// Show system status
 #[derive(Parser, Clone)]
@@ -188,7 +188,7 @@ pub struct StatusCommand {
     pub available: bool,
 }
 
-impl_mcp_tool!(StatusCommand, "status", ["status"]);
+impl_mcp_tool!(StatusCommand, "b00t_status", ["status"]);
 
 /// List AI providers
 #[derive(Parser, Clone)]
@@ -1167,7 +1167,7 @@ pub struct LearnCommand {
     pub topic: Option<String>,
 }
 
-impl_mcp_tool!(LearnCommand, "learn", ["learn"]);
+impl_mcp_tool!(LearnCommand, "b00t_learn", ["learn"]);
 
 /// Checkpoint command
 // 🤓 ENTANGLED: b00t-cli/src/main.rs Commands::Checkpoint
@@ -2419,7 +2419,10 @@ mod tests {
     #[test]
     fn test_tool_schema_generation() {
         let tool = McpListCommand::to_mcp_tool();
-        assert_eq!(tool.name.as_ref(), "mcp_list");
+        // #827 — was "mcp_list" (unprefixed), contradicting test_registry_creation's
+        // "b00t_mcp_list" expectation; the documented, external tool-name contract
+        // (b00t_quick_reference.md, b00t-mcp-cloudflare/README.md) uses the prefix.
+        assert_eq!(tool.name.as_ref(), "b00t_mcp_list");
 
         // Check schema has expected properties
         let schema = tool.input_schema.as_ref();


### PR DESCRIPTION
## Summary

Full sequence: the mock-transport hang → 6 more real bugs surfaced by running the full gate once unhung → 1 more surfaced by the reverse-dependency-closure gate on push (b00t-mcp depends on b00t-cli's pipeline types). Every fix here is root-caused, not a suppression — see individual issues for the evidence trail.

- Closes #819 — pipeline_flowctl Throttled: unstable elapsed-based rate calc near t=0
- Closes #820 — pipeline_flowctl buffered_blocks_when_full: test-only, wrong post-condition
- Closes #821 — pipeline_k8s: capsule-level requires_gpu never consulted for Deployment limits
- Closes #822 — pipeline_statemachine: test-only, off-by-one history-length assertion
- Closes #823 — pipeline_cost: test-only, contradicted its own sibling tests' established fallback behavior
- Closes #824 — pipeline_nats NatsClientAdapter: nested block_on panic in real (not just test) pipeline execution
- Closes #827 — b00t-mcp: 5 core MCP tools missing their documented `b00t_` prefix (a real, live defect — clients following the documented tool names would have failed)

Plus the original mock-transport-hang fix (MockNatsSubscription blocking recv() + a test ordering bug + 3 nested-block_on test fixes) from the first commit on this branch.

Checked all 3 other open PRs (#782, #783, #678) before starting — none touch any of the files this PR fixes.

## Test plan
- [x] `cargo test -p b00t-cli --lib`: 1302 passed, 0 failed, 4 ignored (was hanging indefinitely, then 6 failures after the hang was fixed)
- [x] `cargo test -p b00t-mcp --lib`: 51 passed, 0 failed (was 1 failure)
- [x] Local pre-push gate passed cleanly (reverse-dependency closure covering both crates)