### PR TITLE
fix: remove stale runtimeClassName from ch0nky Deployment, document broken kube-play

### DIFF
--- a/_b00t_/k8s.🚢/b00t-inference/ch0nky-deployment.yaml
+++ b/_b00t_/k8s.🚢/b00t-inference/ch0nky-deployment.yaml
@@ -5,6 +5,32 @@
 #    node, replacing the old runtimeClassName+NVIDIA_VISIBLE_DEVICES bypass (which
 #    gave k8s zero visibility into VRAM usage and allowed silent double-booking).
 #    17.7GB VRAM + ~6GB KV cache headroom at 64k context on RTX 3090 (24GB).
+#
+# ⚠️ KNOWN BROKEN on this host (2026-07-15): `podman kube play` against this
+#    file fails to start the container — `crun: error executing hook
+#    /usr/bin/nvidia-container-toolkit (exit code: 1)`. Traced to
+#    /usr/share/containers/oci/hooks.d/oci-nvidia-hook.json, which matches
+#    unconditionally ("when": {"always": true}) for every container on this
+#    host and fires regardless of runtimeClassName, NVIDIA_VISIBLE_DEVICES,
+#    or a nvidia-container-runtime `io.podman.annotations.run` override —
+#    none of those made kube-play succeed. Root cause is very likely
+#    `no-cgroups` (commented out, defaulting to false) in
+#    /etc/nvidia-container-runtime/config.toml — a well-documented
+#    requirement for rootless podman + nvidia-container-toolkit, needs root
+#    to fix, not done here. CONFIRMED WORKING WORKAROUND: plain `podman run
+#    --device nvidia.com/gpu=all` (pure CDI, resolved directly by podman —
+#    doesn't go through the hooks.d prestart hook at all):
+#      podman run -d --name ch0nky --device nvidia.com/gpu=all -p 8001:8001 \
+#        -v /home/brianh/.cache/huggingface/hub:/hf:ro --restart unless-stopped \
+#        ghcr.io/ggml-org/llama.cpp:server-cuda \
+#        --model /hf/models--unsloth--Qwen3.6-35B-A3B-GGUF/snapshots/a483e9e6cbd595906af30beda3187c2663a1118c/Qwen3.6-35B-A3B-UD-IQ4_XS.gguf \
+#        --host 0.0.0.0 --port 8001 -ngl 999 -fa on -c 65536 -n 4096 --jinja \
+#        --reasoning-format deepseek --reasoning-budget 4096 --temp 0.6 --top-p 0.95 \
+#        --top-k 20 --min-p 0.00 --presence-penalty 0.0 --alias ch0nky --api-key local-b00t
+#    Then: podman update --health-cmd "curl -f http://localhost:8001/health" ch0nky
+#    (the image's baked-in default HEALTHCHECK checks port 8080, not 8001 —
+#    override it or `podman ps` reports "unhealthy" despite the server working).
+#    Revisit `podman kube play` here once no-cgroups is fixed with root access.
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -28,7 +54,6 @@ spec:
         b00t.tier: ch0nky
     spec:
       priorityClassName: b00t-gpu-primary
-      runtimeClassName: nvidia
       tolerations:
         - key: node-role.kubernetes.io/control-plane
           operator: Exists
@@ -73,14 +98,21 @@ spec:
           ports:
             - containerPort: 8001
               name: http
+          env:
+            # Harmless to keep even though `podman kube play` doesn't work
+            # on this host regardless (see the top-of-file note) — these
+            # didn't fix the hooks.d issue alone, but are what a real k8s
+            # nvidia-device-plugin node would set, and cost nothing to leave.
+            - name: NVIDIA_VISIBLE_DEVICES
+              value: "0"
+            - name: NVIDIA_DRIVER_CAPABILITIES
+              value: compute,utility
           resources:
             requests:
               memory: "6Gi"
               cpu: "2"
-              nvidia.com/gpu: "1"
             limits:
               memory: "20Gi"
-              nvidia.com/gpu: "1"
           readinessProbe:
             httpGet:
               path: /health


### PR DESCRIPTION
## Summary
- The Deployment's top comment already said it replaced "the old runtimeClassName+NVIDIA_VISIBLE_DEVICES bypass" with pure CDI resource-limit scheduling, but `runtimeClassName: nvidia` was still present, contradicting that stated intent. Removed it.
- That alone didn't fix `podman kube play` on this host — root-caused the actual failure to a host-wide legacy `nvidia-container-toolkit` prestart hook (`/usr/share/containers/oci/hooks.d/oci-nvidia-hook.json`) that matches every container unconditionally and fails regardless of runtimeClassName, NVIDIA_VISIBLE_DEVICES/NVIDIA_DRIVER_CAPABILITIES env vars, or a runtime-override annotation. Likely root cause: `no-cgroups` (commented out, defaults false) in `/etc/nvidia-container-runtime/config.toml` — a documented rootless-podman requirement, needs root to fix, not attempted here.
- Documented a confirmed-working `podman run --device nvidia.com/gpu=all` workaround directly in the file (pure CDI, bypasses the broken hooks.d path entirely), including the `podman update --health-cmd` override needed since the base image's baked-in healthcheck checks port 8080, not this deployment's actual 8001.

## Test plan
- [x] Restarted `ch0nky` via the documented `podman run` workaround
- [x] `podman ps` reports the container `healthy` after `podman update --health-cmd` (was misleadingly "unhealthy" before, despite the model working)
- [x] Real inference confirmed via `/v1/chat/completions`
- [x] `scripts/probe-ch0nky.sh` — 5/5 b00t-awareness probes passed