### PR TITLE
feat(datum): validate graph references

### DIFF
--- a/.github/workflows/datum-validate-graph.yml
+++ b/.github/workflows/datum-validate-graph.yml
@@ -1,0 +1,42 @@
+name: Datum graph validator
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'b00t-cli/src/datum_store.rs'
+      - 'b00t-cli/src/commands/datum.rs'
+      - '_b00t_/**'
+      - 'justfile'
+      - '.github/workflows/datum-validate-graph.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'b00t-cli/src/datum_store.rs'
+      - 'b00t-cli/src/commands/datum.rs'
+      - '_b00t_/**'
+      - 'justfile'
+      - '.github/workflows/datum-validate-graph.yml'
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  validate:
+    name: validate graph references
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: false
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+
+      - name: Run datum graph validator tests
+        run: cargo test -p b00t-cli --lib validate_references -- --nocapture

--- a/b00t-cli/src/commands/datum.rs
+++ b/b00t-cli/src/commands/datum.rs
@@ -1,4 +1,5 @@
 use crate::DatumType;
+use crate::datum_store::{DatumStore, HashMapStore};
 use crate::datum_utils::{self, DatumFilter};
 use anyhow::{Context, Result};
 use clap::Parser;
@@ -106,13 +107,16 @@ pub enum DatumCommands {
     #[clap(about = "Validate a datum TOML file against BootDatum schema")]
     Validate {
         #[clap(help = "Path to .toml file or datum key (e.g., mold.cli)")]
-        target: String,
+        target: Option<String>,
 
         #[clap(
             long,
             help = "check extension/type consistency (e.g. .cli suffix vs type=cli)"
         )]
         strict: bool,
+
+        #[clap(long, help = "validate cross-datum graph references")]
+        graph: bool,
     },
 
     #[clap(about = "Emit a minimal valid datum TOML for the given type")]
@@ -249,7 +253,16 @@ pub fn handle_datum_command(path: &str, datum_command: &DatumCommands) -> Result
             .join()
             .map_err(|_| anyhow::anyhow!("semantic-search thread panicked"))?
         }
-        DatumCommands::Validate { target, strict } => handle_validate(path, target, *strict),
+        DatumCommands::Validate { target, strict, graph } => {
+            if *graph {
+                handle_validate_graph(path)
+            } else {
+                let Some(target) = target else {
+                    anyhow::bail!("specify datum key, file path, or --graph");
+                };
+                handle_validate(path, target, *strict)
+            }
+        }
         DatumCommands::Scaffold { datum_type, name } => handle_scaffold(datum_type, name),
         DatumCommands::Delegate {
             datum_type,
@@ -1052,6 +1065,21 @@ fn handle_validate(datum_path: &str, target: &str, strict: bool) -> Result<()> {
     }
 
     print_validation_result(&errors, &warnings)
+}
+
+fn handle_validate_graph(datum_path: &str) -> Result<()> {
+    let store = HashMapStore::from_path(datum_path)?;
+    let errors = store.validate_references();
+
+    if errors.is_empty() {
+        println!("datum graph: valid ({} datums)", store.len());
+        return Ok(());
+    }
+
+    for error in &errors {
+        eprintln!("  ERROR: {error}");
+    }
+    anyhow::bail!("datum graph validation failed: {} reference error(s)", errors.len());
 }
 
 fn print_validation_result(errors: &[String], warnings: &[String]) -> Result<()> {

--- a/b00t-cli/src/datum_store.rs
+++ b/b00t-cli/src/datum_store.rs
@@ -99,7 +99,7 @@ pub trait DatumStore: Send + Sync {
     }
 
     /// Phase 2 — Coherence: validate cross-datum references (Chalk coherence analogy).
-    /// Reports: missing depends_on targets, self-deps, empty dep strings, missing members.
+    /// Reports: missing graph references, self-deps, empty ref strings, missing members.
     /// Override in bulk-query backends (e.g. SQL JOIN) for efficiency.
     fn validate_references(&self) -> Vec<ReferenceError> {
         let key_set: HashSet<String> = self.iter().map(|d| d.key.as_ref().to_owned()).collect();
@@ -130,6 +130,70 @@ pub trait DatumStore: Send + Sync {
                     }
                 }
             }
+            validate_graph_references(
+                &mut errors,
+                &key_set,
+                key,
+                "skills",
+                d.datum.skills.as_deref(),
+                Some(".skill"),
+            );
+            validate_graph_references(
+                &mut errors,
+                &key_set,
+                key,
+                "entangled_agents",
+                d.datum.entangled_agents.as_deref(),
+                None,
+            );
+            validate_graph_references(
+                &mut errors,
+                &key_set,
+                key,
+                "entangled_cli",
+                d.datum.entangled_cli.as_deref(),
+                None,
+            );
+            validate_graph_references(
+                &mut errors,
+                &key_set,
+                key,
+                "entangled_mcp",
+                d.datum.entangled_mcp.as_deref(),
+                None,
+            );
+            validate_graph_references(
+                &mut errors,
+                &key_set,
+                key,
+                "entangled_ai_models",
+                d.datum.entangled_ai_models.as_deref(),
+                None,
+            );
+            validate_graph_references(
+                &mut errors,
+                &key_set,
+                key,
+                "entangled_apis",
+                d.datum.entangled_apis.as_deref(),
+                None,
+            );
+            validate_graph_references(
+                &mut errors,
+                &key_set,
+                key,
+                "entangled_docker",
+                d.datum.entangled_docker.as_deref(),
+                None,
+            );
+            validate_graph_references(
+                &mut errors,
+                &key_set,
+                key,
+                "entangled_k8s",
+                d.datum.entangled_k8s.as_deref(),
+                None,
+            );
         }
         errors
     }
@@ -144,10 +208,52 @@ pub trait DatumStore: Send + Sync {
                     !allowlist.contains(missing_key.as_str()),
                 ReferenceError::MissingMember { missing_member, .. } =>
                     !allowlist.contains(missing_member.as_str()),
+                ReferenceError::MissingReference { missing_key, .. } =>
+                    !allowlist.contains(missing_key.as_str()),
                 _ => true,
             })
             .collect()
     }
+}
+
+fn validate_graph_references(
+    errors: &mut Vec<ReferenceError>,
+    key_set: &HashSet<String>,
+    datum: &str,
+    field: &'static str,
+    references: Option<&[String]>,
+    fallback_suffix: Option<&'static str>,
+) {
+    let Some(references) = references else {
+        return;
+    };
+
+    for reference in references {
+        if reference.is_empty() {
+            errors.push(ReferenceError::EmptyReference { datum: datum.to_string(), field });
+        } else if !reference_resolves(key_set, reference, fallback_suffix) {
+            errors.push(ReferenceError::MissingReference {
+                datum: datum.to_string(),
+                field,
+                missing_key: reference.clone(),
+            });
+        }
+    }
+}
+
+fn reference_resolves(
+    key_set: &HashSet<String>,
+    reference: &str,
+    fallback_suffix: Option<&'static str>,
+) -> bool {
+    if key_set.contains(reference) {
+        return true;
+    }
+
+    fallback_suffix
+        .filter(|_| !reference.contains('.'))
+        .map(|suffix| key_set.contains(&format!("{reference}{suffix}")))
+        .unwrap_or(false)
 }
 
 // ── ReferenceError ────────────────────────────────────────────────────────────
@@ -163,6 +269,10 @@ pub enum ReferenceError {
     EmptyDependency { datum: String },
     /// A `members` key references a datum not in this store (stacks).
     MissingMember { stack: String, missing_member: String },
+    /// A graph edge field references a datum not in this store.
+    MissingReference { datum: String, field: &'static str, missing_key: String },
+    /// Empty string in a graph edge field.
+    EmptyReference { datum: String, field: &'static str },
 }
 
 impl fmt::Display for ReferenceError {
@@ -176,6 +286,10 @@ impl fmt::Display for ReferenceError {
                 write!(f, "'{datum}' has empty string in depends_on"),
             Self::MissingMember { stack, missing_member } =>
                 write!(f, "stack '{stack}' member '{missing_member}' is not in this store"),
+            Self::MissingReference { datum, field, missing_key } =>
+                write!(f, "'{datum}' {field} '{missing_key}' which is not in this store"),
+            Self::EmptyReference { datum, field } =>
+                write!(f, "'{datum}' has empty string in {field}"),
         }
     }
 }
@@ -499,9 +613,13 @@ mod tests {
     fn store_with_refs() -> HashMapStore {
         let mut s = HashMapStore::default();
         s.intern("git.cli", BootDatum { name: "git".to_string(), hint: "git".to_string(), ..Default::default() });
+        s.intern("kaizen.skill", BootDatum { name: "kaizen".to_string(), hint: "kaizen".to_string(), ..Default::default() });
+        s.intern("b00t-mcp.mcp", BootDatum { name: "b00t-mcp".to_string(), hint: "mcp".to_string(), ..Default::default() });
         s.intern("worker.role", BootDatum {
             name: "worker".to_string(), hint: "worker".to_string(),
             depends_on: Some(vec!["git.cli".to_string()]),
+            skills: Some(vec!["kaizen".to_string()]),
+            entangled_mcp: Some(vec!["b00t-mcp.mcp".to_string()]),
             ..Default::default()
         });
         s.intern("ml-stack.stack", BootDatum {
@@ -570,6 +688,48 @@ mod tests {
         assert!(errs.iter().any(|e| matches!(e, ReferenceError::MissingMember {
             stack, missing_member
         } if stack == "broken-stack.stack" && missing_member == "phantom.cli")));
+    }
+
+    #[test]
+    fn validate_references_missing_skill() {
+        let mut store = store_with_refs();
+        store.intern("missing-skill.agent", BootDatum {
+            name: "missing-skill".to_string(), hint: "agent".to_string(),
+            skills: Some(vec!["phantom".to_string()]),
+            ..Default::default()
+        });
+        let errs = store.validate_references();
+        assert!(errs.iter().any(|e| matches!(e, ReferenceError::MissingReference {
+            datum, field, missing_key
+        } if datum == "missing-skill.agent" && *field == "skills" && missing_key == "phantom")));
+    }
+
+    #[test]
+    fn validate_references_missing_entangled_ref() {
+        let mut store = store_with_refs();
+        store.intern("missing-entangled.agent", BootDatum {
+            name: "missing-entangled".to_string(), hint: "agent".to_string(),
+            entangled_mcp: Some(vec!["phantom.mcp".to_string()]),
+            ..Default::default()
+        });
+        let errs = store.validate_references();
+        assert!(errs.iter().any(|e| matches!(e, ReferenceError::MissingReference {
+            datum, field, missing_key
+        } if datum == "missing-entangled.agent" && *field == "entangled_mcp" && missing_key == "phantom.mcp")));
+    }
+
+    #[test]
+    fn validate_references_empty_skill() {
+        let mut store = store_with_refs();
+        store.intern("empty-skill.agent", BootDatum {
+            name: "empty-skill".to_string(), hint: "agent".to_string(),
+            skills: Some(vec!["".to_string()]),
+            ..Default::default()
+        });
+        let errs = store.validate_references();
+        assert!(errs.iter().any(|e| matches!(e, ReferenceError::EmptyReference {
+            datum, field
+        } if datum == "empty-skill.agent" && *field == "skills")));
     }
 
     #[test]

--- a/justfile
+++ b/justfile
@@ -621,6 +621,19 @@ commit-hook:
             exit 1
         fi
     fi
+    # Hard-gate datum graph coherence when staged changes touch datum files.
+    STAGED_DATUMS="$(git diff --cached --name-only --diff-filter=ACMR | grep -E '^_b00t_/.*\.tomll?m?d?$' || true)"
+    if [[ -n "${STAGED_DATUMS}" ]]; then
+        echo "🕸️  datum graph gate active — validating staged datum changes..."
+        if ! JUST_UNSTABLE=1 just datum-validate-graph; then
+            echo "❌ Datum graph validation failed. Fix dangling refs and try again."
+            exit 1
+        fi
+        echo "✅ Datum graph validation passed"
+    fi
+
+datum-validate-graph path="_b00t_":
+    cargo run -p b00t-cli --bin b00t-cli -- --path {{path}} datum validate --graph
 
 commit-hook2:
     #!/bin/bash


### PR DESCRIPTION
## Summary

Adds `b00t datum validate --graph` as a strict cross-datum coherence check. The validator now resolves `depends_on[]`, `members[]`, `skills[]`, and modeled `entangled_*[]` fields through the shared `DatumStore::validate_references` path. Bare skill names resolve to `<name>.skill` so existing role-style skill references work without requiring every role to spell the full datum key.

The local commit hook now invokes the graph validator when staged `_b00t_` datum files change, and CI runs the focused validator regression tests.

## Validation

- `cargo test -p b00t-cli --lib validate_references -- --nocapture`
- `cargo run -p b00t-cli --bin b00t-cli -- --path /tmp/b00t-datum-graph-clean datum validate --graph`
- `cargo run -p b00t-cli --bin b00t-cli -- --path /tmp/b00t-datum-graph-bad datum validate --graph` exits 1 and names `missing-skill`
- `git diff --check`
- `JUST_UNSTABLE=1 just commit-hook`
- pre-push hook: `✅ pre-push: tests pass`

## Caveat

The live `_b00t_` corpus currently reports existing dangling references, so the command is intentionally strict while the hook is scoped to staged datum changes. The follow-on datum cleanup task can use this output to patch the current corpus.