### PR TITLE
feat(contract): run service contracts with evidence

### DIFF
--- a/b00t-cli/src/commands/contract.rs
+++ b/b00t-cli/src/commands/contract.rs
@@ -1,0 +1,285 @@
+//! `b00t contract run` — deterministic service-contract reward path.
+
+use anyhow::{Result, anyhow, bail};
+use chrono::Utc;
+use clap::Parser;
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::Instant;
+
+use crate::ServiceContract;
+
+const DEFAULT_EVIDENCE_LOG: &str = ".b00t/evidence.jsonl";
+
+#[derive(Parser, Debug)]
+pub enum ContractCommands {
+    #[clap(about = "Execute a datum [[service_contract]] handler and append EvidenceRecord")]
+    Run {
+        #[clap(help = "Datum key or base name (e.g. qwen3-coder-local)")]
+        datum: String,
+
+        #[clap(long, help = "Select a service_contract by capability")]
+        capability: Option<String>,
+
+        #[clap(
+            long,
+            help = "Override evidence JSONL path (default: .b00t/evidence.jsonl)"
+        )]
+        evidence_log: Option<PathBuf>,
+    },
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct EvidenceRecord {
+    pub contract_id: String,
+    pub handler: String,
+    pub exit_code: i32,
+    pub evidence_match: bool,
+    pub duration_ms: u128,
+    pub tokens: u64,
+    pub git_sha: String,
+    pub ts: String,
+}
+
+pub fn handle_contract_command(args: &ContractCommands, datum_path: &str) -> Result<()> {
+    match args {
+        ContractCommands::Run {
+            datum,
+            capability,
+            evidence_log,
+        } => {
+            let evidence_path = evidence_log
+                .clone()
+                .unwrap_or_else(|| PathBuf::from(DEFAULT_EVIDENCE_LOG));
+            let record = run_contract(datum_path, datum, capability.as_deref(), &evidence_path)?;
+            println!(
+                "{}: contract_id={} exit_code={} evidence_match={} duration_ms={}",
+                if record.exit_code == 0 && record.evidence_match {
+                    "PASS"
+                } else {
+                    "FAIL"
+                },
+                record.contract_id,
+                record.exit_code,
+                record.evidence_match,
+                record.duration_ms
+            );
+            if record.exit_code != 0 || !record.evidence_match {
+                bail!("contract failed: {}", record.contract_id);
+            }
+            Ok(())
+        }
+    }
+}
+
+pub fn run_contract(
+    datum_path: &str,
+    datum: &str,
+    capability: Option<&str>,
+    evidence_log: &Path,
+) -> Result<EvidenceRecord> {
+    let (config, filename) = crate::get_config(datum, datum_path)
+        .map_err(|e| anyhow!("datum '{}' not found at {}: {}", datum, datum_path, e))?;
+    let datum_key = datum_key_from_filename(&filename);
+    let contract = select_contract(&config.service_contract, capability)?;
+    let contract_id = format!("{}:{}", datum_key, contract.capability);
+    let evidence_re = Regex::new(&contract.evidence)
+        .map_err(|e| anyhow!("invalid evidence regex for {contract_id}: {e}"))?;
+    let argv = shlex::split(&contract.handler).ok_or_else(|| {
+        anyhow!(
+            "cannot parse handler for {contract_id}: {}",
+            contract.handler
+        )
+    })?;
+    if argv.is_empty() {
+        bail!("empty handler for {contract_id}");
+    }
+
+    let start = Instant::now();
+    let output = Command::new(&argv[0])
+        .args(&argv[1..])
+        .output()
+        .map_err(|e| anyhow!("handler spawn failed for {contract_id}: {e}"))?;
+    let duration_ms = start.elapsed().as_millis();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let exit_code = output.status.code().unwrap_or(1);
+    let evidence_match = evidence_re.is_match(&stdout);
+    let record = EvidenceRecord {
+        contract_id,
+        handler: contract.handler.clone(),
+        exit_code,
+        evidence_match,
+        duration_ms,
+        tokens: 0,
+        git_sha: current_git_sha(),
+        ts: Utc::now().to_rfc3339(),
+    };
+    append_evidence_record(evidence_log, &record)?;
+    Ok(record)
+}
+
+fn select_contract<'a>(
+    contracts: &'a [ServiceContract],
+    capability: Option<&str>,
+) -> Result<&'a ServiceContract> {
+    if contracts.is_empty() {
+        bail!("datum has no [[service_contract]] entries");
+    }
+    if let Some(capability) = capability {
+        return contracts
+            .iter()
+            .find(|contract| contract.capability == capability)
+            .ok_or_else(|| anyhow!("no service_contract capability '{}'", capability));
+    }
+    if contracts.len() == 1 {
+        Ok(&contracts[0])
+    } else {
+        bail!(
+            "datum has {} service_contract entries; specify --capability",
+            contracts.len()
+        );
+    }
+}
+
+fn append_evidence_record(path: &Path, record: &EvidenceRecord) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let mut file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)?;
+    serde_json::to_writer(&mut file, record)?;
+    file.write_all(b"\n")?;
+    Ok(())
+}
+
+fn datum_key_from_filename(filename: &str) -> String {
+    filename
+        .trim_end_matches(".tomllmd")
+        .trim_end_matches(".tomllm")
+        .trim_end_matches(".toml")
+        .to_string()
+}
+
+fn current_git_sha() -> String {
+    Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .output()
+        .ok()
+        .filter(|output| output.status.success())
+        .map(|output| String::from_utf8_lossy(&output.stdout).trim().to_string())
+        .filter(|sha| !sha.is_empty())
+        .unwrap_or_else(|| "unknown".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn write_datum(dir: &TempDir, body: &str) {
+        std::fs::write(dir.path().join("fixture.cli.toml"), body).unwrap();
+    }
+
+    #[test]
+    fn contract_run_appends_passing_evidence_record() {
+        let dir = TempDir::new().unwrap();
+        write_datum(
+            &dir,
+            r#"
+[b00t]
+name = "fixture"
+type = "cli"
+hint = "fixture"
+
+[[service_contract]]
+capability = "smoke"
+handler = "printf 'PASS: smoke\n'"
+evidence = "PASS: smoke"
+"#,
+        );
+        let evidence_log = dir.path().join(".b00t/evidence.jsonl");
+
+        let record =
+            run_contract(dir.path().to_str().unwrap(), "fixture", None, &evidence_log).unwrap();
+
+        assert_eq!(record.contract_id, "fixture.cli:smoke");
+        assert_eq!(record.exit_code, 0);
+        assert!(record.evidence_match);
+        let line = std::fs::read_to_string(evidence_log).unwrap();
+        let parsed: EvidenceRecord = serde_json::from_str(line.trim()).unwrap();
+        assert_eq!(parsed.contract_id, "fixture.cli:smoke");
+        assert!(parsed.evidence_match);
+    }
+
+    #[test]
+    fn contract_run_records_missing_evidence_match() {
+        let dir = TempDir::new().unwrap();
+        write_datum(
+            &dir,
+            r#"
+[b00t]
+name = "fixture"
+type = "cli"
+hint = "fixture"
+
+[[service_contract]]
+capability = "smoke"
+handler = "printf 'NOPE\n'"
+evidence = "PASS: smoke"
+"#,
+        );
+        let evidence_log = dir.path().join(".b00t/evidence.jsonl");
+
+        let err = handle_contract_command(
+            &ContractCommands::Run {
+                datum: "fixture".to_string(),
+                capability: None,
+                evidence_log: Some(evidence_log.clone()),
+            },
+            dir.path().to_str().unwrap(),
+        )
+        .unwrap_err();
+
+        assert!(err.to_string().contains("contract failed"));
+        let line = std::fs::read_to_string(evidence_log).unwrap();
+        let parsed: EvidenceRecord = serde_json::from_str(line.trim()).unwrap();
+        assert_eq!(parsed.exit_code, 0);
+        assert!(!parsed.evidence_match);
+    }
+
+    #[test]
+    fn contract_run_requires_capability_for_multiple_contracts() {
+        let dir = TempDir::new().unwrap();
+        write_datum(
+            &dir,
+            r#"
+[b00t]
+name = "fixture"
+type = "cli"
+hint = "fixture"
+
+[[service_contract]]
+capability = "a"
+handler = "printf a"
+evidence = "a"
+
+[[service_contract]]
+capability = "b"
+handler = "printf b"
+evidence = "b"
+"#,
+        );
+        let evidence_log = dir.path().join(".b00t/evidence.jsonl");
+
+        let err =
+            run_contract(dir.path().to_str().unwrap(), "fixture", None, &evidence_log).unwrap_err();
+
+        assert!(err.to_string().contains("specify --capability"));
+        assert!(!evidence_log.exists());
+    }
+}

--- a/b00t-cli/src/commands/grok.rs
+++ b/b00t-cli/src/commands/grok.rs
@@ -975,7 +975,7 @@ fn assimilate_github_repo(parsed: &ParsedRepo, topic: &str, _tags: &[String]) ->
         poly_cfg.sources = Some(sources);
         polyseme_datum.polyseme = Some(poly_cfg);
 
-        let unified = UnifiedConfig { b00t: polyseme_datum, env: None, sections: None };
+        let unified = UnifiedConfig { b00t: polyseme_datum, service_contract: vec![], env: None, sections: None };
         std::fs::write(&poly_path, format!("{}\n", toml::to_string_pretty(&unified)?))?;
         eprintln!("  ✅ polyseme: {}", poly_path.display());
 

--- a/b00t-cli/src/commands/mod.rs
+++ b/b00t-cli/src/commands/mod.rs
@@ -66,6 +66,8 @@ pub mod zellij;
 pub use zellij::ZellijCommand;
 pub mod context;
 pub use context::ContextCommands;
+pub mod contract;
+pub use contract::ContractCommands;
 
 pub use agent::AgentCommands;
 pub use bouncer::{BouncerArgs, BouncerCommands};

--- a/b00t-cli/src/config_types.rs
+++ b/b00t-cli/src/config_types.rs
@@ -26,9 +26,22 @@ pub struct McpConfig {
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
 pub struct UnifiedConfig {
     pub b00t: BootDatum,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub service_contract: Vec<ServiceContract>,
     pub env: Option<std::collections::HashMap<String, String>>,
     #[serde(default)]
     pub sections: Option<std::collections::HashMap<String, serde_json::Value>>,
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Default)]
+pub struct ServiceContract {
+    pub capability: String,
+    pub handler: String,
+    pub evidence: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tier: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub verifiable: Option<bool>,
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Default)]

--- a/b00t-cli/src/lifecycle.rs
+++ b/b00t-cli/src/lifecycle.rs
@@ -28,6 +28,7 @@ pub fn create_ai_toml_config(ai_config: &AiConfig, path: &str) -> Result<()> {
 pub fn create_unified_toml_config(datum: &BootDatum, path: &str) -> Result<()> {
     let config = UnifiedConfig {
         b00t: datum.clone(),
+        service_contract: vec![],
         env: None,
         sections: None,
     };

--- a/b00t-cli/src/main.rs
+++ b/b00t-cli/src/main.rs
@@ -99,6 +99,7 @@ use b00t_cli::commands::{
     PipelineCommands,
     StageCommands,
     StoreCommands,
+    ContractCommands,
     GrokCommands, HiveCommands,
     InitCommands,
     JobCommands,
@@ -604,6 +605,11 @@ The system will:
         long_about = "Audited execution: Allow→run, Warn→run with warning, Block→reject first time / force on re-submit within 5min.\nAll executions logged to ~/.b00t/exec-log.jsonl.\n\n`b00t sh -- <cmd>` is the task-work alias: same audited path, exec-log artifacts feed ledgrrr verification + 🍰 allocation.\nUse --sleep=<duration> for background execution (returns immediately)."
     )]
     Exec(b00t_cli::commands::exec::ExecArgs),
+    #[clap(about = "Run deterministic service-contract handlers and append evidence")]
+    Contract {
+        #[clap(subcommand)]
+        contract_command: ContractCommands,
+    },
     #[clap(about = "Schema datum management (generate, validate)")]
     Schema {
         #[clap(subcommand)]
@@ -2945,6 +2951,12 @@ async fn main() {
         }
         Some(Commands::Exec(args)) => {
             if let Err(e) = b00t_cli::commands::exec::handle_exec(args, &cli.path) {
+                eprintln!("Error: {}", e);
+                std::process::exit(1);
+            }
+        }
+        Some(Commands::Contract { contract_command }) => {
+            if let Err(e) = b00t_cli::commands::contract::handle_contract_command(contract_command, &cli.path) {
                 eprintln!("Error: {}", e);
                 std::process::exit(1);
             }


### PR DESCRIPTION
## Summary

Adds `b00t contract run` as a deterministic reward path for datum `[[service_contract]]` entries. The command resolves a datum, selects a service contract by `--capability` or the sole declared contract, executes the declared handler without invoking an LLM, matches the declared `evidence` regex against stdout, and appends an `EvidenceRecord` JSONL row.

Evidence rows include `contract_id`, `handler`, `exit_code`, `evidence_match`, `duration_ms`, `tokens`, `git_sha`, and `ts`.

## Validation

- `cargo test -p b00t-cli --lib contract_run -- --nocapture`
- `cargo run -p b00t-cli --bin b00t-cli -- --path /tmp/b00t-contract-fixture contract run fixture --evidence-log /tmp/b00t-contract-fixture/evidence.jsonl`
- `sed -n '1p' /tmp/b00t-contract-fixture/evidence.jsonl`
- `git diff --check`
- `JUST_UNSTABLE=1 just commit-hook`
- pre-push hook: `✅ pre-push: tests pass`