### PR TITLE
fix(ooda): read native b00t task store

### DIFF
--- a/_b00t_/ralph/ralph/entrypoint.py
+++ b/_b00t_/ralph/ralph/entrypoint.py
@@ -25,6 +25,8 @@ __version__ = "0.1.0"
 
 
 def _project_root() -> Path:
+    if project_root := os.environ.get("PROJECT_ROOT"):
+        return Path(project_root).expanduser().resolve()
     # Prefer the git root of the current working directory so `ralph` can be used
     # as a tool against *any* repo, not just this package's source checkout.
     cwd = Path.cwd().resolve()
@@ -35,43 +37,39 @@ def _project_root() -> Path:
 
 
 def _tasks_file(root: Path) -> Path:
-    return root / ".taskmaster" / "tasks" / "tasks.json"
+    return root / ".b00t" / "tasks.json"
 
 
 def _print_tasks_missing_instructions() -> None:
     # Keep this short and copy/paste friendly. It is printed from both bash and python
     # entrypoints to keep behavior consistent regardless of invocation method.
     sys.stderr.write("\n")
-    sys.stderr.write("To create tasks with the ralph-prd skill, run your designated agent with this prompt:\n\n")
+    sys.stderr.write("To create native b00t tasks, run:\n\n")
     sys.stderr.write(
-        "Use the ralph-prd skill to generate TaskMaster tasks.json for this repo.\n"
-        "Requirements:\n"
-        "- Output must be TaskMaster format with tasks[] and metadata.\n"
-        "- Include 3-7 small, actionable tasks with acceptance criteria.\n"
-        "- Use IETF 2119 MUST/SHOULD/MAY in acceptance criteria.\n"
-        "- Set metadata.project and metadata.branchName appropriately.\n"
+        "b00t task add \"<small actionable task>\"\n"
+        "Tasks are stored at .b00t/tasks.json with a top-level tasks[] array.\n"
     )
-    sys.stderr.write("\nThen re-run: ./ralph.sh --agent <amp|claude|codex> [max_iterations]\n\n")
+    sys.stderr.write("\nThen re-run: b00t ooda run --agent <claude|codex|opencode> [--max-iter N]\n\n")
 
 
 def _require_tasks(root: Path) -> bool:
     """Return True if tasks exist and are non-empty; otherwise print instructions and return False."""
     tasks_path = _tasks_file(root)
     if not tasks_path.exists():
-        LOGGER.warning("TaskMaster tasks.json not found; nothing to do.")
+        LOGGER.warning(".b00t/tasks.json not found; nothing to do.")
         _print_tasks_missing_instructions()
         return False
 
     try:
         payload = json.loads(tasks_path.read_text())
     except json.JSONDecodeError:
-        LOGGER.warning("TaskMaster tasks.json is invalid JSON; nothing to do.")
+        LOGGER.warning("%s is invalid JSON; nothing to do.", tasks_path)
         _print_tasks_missing_instructions()
         return False
 
     tasks = payload.get("tasks") if isinstance(payload, dict) else None
     if not tasks:
-        LOGGER.warning("TaskMaster tasks.json is empty; nothing to do.")
+        LOGGER.warning("%s is empty; nothing to do.", tasks_path)
         _print_tasks_missing_instructions()
         return False
 
@@ -276,7 +274,7 @@ def main(argv: list[str] | None = None) -> int:
     """
     Ralph runtime execution.
 
-    Note: Preflight checks (uv sync, .taskmaster setup, .gitignore) are handled
+    Note: Preflight checks (uv sync, .b00t/tasks.json setup, .gitignore) are handled
     by ralph.sh wrapper. This function focuses on execution only.
     """
     if argv is None:
@@ -422,51 +420,40 @@ def get_ralph_status() -> dict[str, Any]:
 
 @mcp.tool()
 def get_task_status() -> dict[str, Any]:
-    """Get TaskMaster completion status via task-master CLI."""
+    """Get native b00t task completion status from .b00t/tasks.json."""
+    root = _project_root()
+    tasks_path = _tasks_file(root)
+    if not tasks_path.exists():
+        return {"status": "missing", "message": f"{tasks_path} not found"}
     try:
-        result = subprocess.run(
-            ["task-master", "list", "--format", "json"],
-            capture_output=True,
-            text=True,
-            check=True,
-        )
-        task_data = json.loads(result.stdout)
+        task_data = json.loads(tasks_path.read_text())
+    except json.JSONDecodeError as exc:
+        return {"status": "error", "message": f"invalid JSON in {tasks_path}: {exc}"}
 
-        total = len(task_data.get("tasks", []))
-        completed = sum(1 for t in task_data.get("tasks", []) if t.get("status") == "done")
-        in_progress = sum(1 for t in task_data.get("tasks", []) if t.get("status") == "in-progress")
-        pending = sum(1 for t in task_data.get("tasks", []) if t.get("status") == "pending")
+    tasks = task_data.get("tasks", []) if isinstance(task_data, dict) else []
+    total = len(tasks)
+    completed = sum(1 for t in tasks if t.get("status") == "done")
+    in_progress = sum(1 for t in tasks if t.get("status") == "in-progress")
+    pending = sum(1 for t in tasks if t.get("status") == "pending")
 
-        return {
-            "status": "loaded",
-            "project": task_data.get("metadata", {}).get("project", "Unknown"),
-            "total_tasks": total,
-            "completed": completed,
-            "in_progress": in_progress,
-            "pending": pending,
-            "completion_percentage": round((completed / total) * 100, 1) if total > 0 else 0,
-        }
-    except subprocess.CalledProcessError as e:
-        return {"status": "error", "message": f"task-master CLI error: {e}"}
-    except FileNotFoundError:
-        return {"status": "error", "message": "task-master CLI not found. Install taskmaster-ai first."}
+    return {
+        "status": "loaded",
+        "project": root.name,
+        "total_tasks": total,
+        "completed": completed,
+        "in_progress": in_progress,
+        "pending": pending,
+        "completion_percentage": round((completed / total) * 100, 1) if total > 0 else 0,
+    }
 
 
 @mcp.resource("ralph://tasks")
 def get_tasks_resource() -> str:
-    """Get current tasks via task-master CLI (not direct file access)."""
-    try:
-        result = subprocess.run(
-            ["task-master", "list", "--format", "json"],
-            capture_output=True,
-            text=True,
-            check=True,
-        )
-        return result.stdout
-    except subprocess.CalledProcessError:
-        return json.dumps({"error": "Failed to fetch tasks from task-master"})
-    except FileNotFoundError:
-        return json.dumps({"error": "task-master CLI not found"})
+    """Get current native b00t tasks."""
+    tasks_path = _tasks_file(_project_root())
+    if not tasks_path.exists():
+        return json.dumps({"error": f"{tasks_path} not found"})
+    return tasks_path.read_text()
 
 
 @mcp.resource("ralph://progress")

--- a/_b00t_/ralph/tests/test_entrypoint.py
+++ b/_b00t_/ralph/tests/test_entrypoint.py
@@ -25,9 +25,9 @@ def test_parse_args_valid_agent() -> None:
 def test_progress_file_created_on_run(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     monkeypatch.chdir(tmp_path)
     (tmp_path / "prompt.md").write_text("# Test prompt\n")
-    (tmp_path / ".taskmaster" / "tasks").mkdir(parents=True)
-    (tmp_path / ".taskmaster" / "tasks" / "tasks.json").write_text(
-        '{"tasks":[{"id":"task-001","title":"t","description":"d","status":"pending","priority":1}],"metadata":{"project":"t","branchName":"b","taskMasterVersion":"1.0"}}'
+    (tmp_path / ".b00t").mkdir(parents=True)
+    (tmp_path / ".b00t" / "tasks.json").write_text(
+        '{"tasks":[{"id":"task-001","title":"t","description":"d","status":"pending","priority":1}]}'
     )
 
     def fake_run(_cmd: Sequence[str], stdin_path: Path | None = None) -> str:
@@ -106,13 +106,24 @@ def test_main_mcp_calls_run_with_http(monkeypatch: pytest.MonkeyPatch) -> None:
 # ── OODA loop tests ──────────────────────────────────────────────────────────
 
 def _make_tasks_dir(tmp_path: Path) -> None:
-    (tmp_path / ".taskmaster" / "tasks").mkdir(parents=True)
-    (tmp_path / ".taskmaster" / "tasks" / "tasks.json").write_text(
-        '{"tasks":[{"id":"t1","title":"t","description":"d","status":"pending","priority":1}],'
-        '"metadata":{"project":"test","branchName":"b","taskMasterVersion":"1.0"}}'
+    (tmp_path / ".b00t").mkdir(parents=True)
+    (tmp_path / ".b00t" / "tasks.json").write_text(
+        '{"tasks":[{"id":"t1","title":"t","description":"d","status":"pending","priority":1}]}'
     )
     (tmp_path / "CLAUDE.md").write_text("# mission\n")
     (tmp_path / "prompt.md").write_text("# mission\n")
+
+
+def test_project_root_honors_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("PROJECT_ROOT", str(tmp_path))
+    assert entrypoint._project_root() == tmp_path.resolve()
+
+
+def test_tasks_file_prefers_native_b00t_store(tmp_path: Path) -> None:
+    (tmp_path / ".b00t").mkdir()
+    native = tmp_path / ".b00t" / "tasks.json"
+    native.write_text('{"tasks":[]}')
+    assert entrypoint._tasks_file(tmp_path) == native
 
 
 def test_ooda_flag_parsed() -> None:

--- a/b00t-cli/src/commands/ooda.rs
+++ b/b00t-cli/src/commands/ooda.rs
@@ -11,7 +11,7 @@
 //!   b00t ooda status                    # show task backlog summary
 //!   b00t ooda phase                     # show current phase from OodaLoop
 
-use anyhow::{Result, bail};
+use anyhow::{Context, Result, bail};
 use clap::Subcommand;
 use std::path::PathBuf;
 use std::process::Command;
@@ -56,6 +56,8 @@ pub enum OodaCommands {
     Review {
         #[arg(long, help = "Task ID to review (default: next pending)")]
         task: Option<String>,
+        #[arg(long, help = "Project root (default: git root)")]
+        root: Option<PathBuf>,
         #[arg(long, help = "Emit JSON verdict")]
         json: bool,
         #[arg(long, help = "Skip interactive prompts — auto-PASS heuristic checks only")]
@@ -70,7 +72,7 @@ pub async fn handle_ooda(cmd: OodaCommands) -> Result<()> {
         }
         OodaCommands::Status { root } => ooda_status(root),
         OodaCommands::Phase { json } => ooda_phase(json),
-        OodaCommands::Review { task, json, auto } => ooda_review(task.as_deref(), json, auto),
+        OodaCommands::Review { task, root, json, auto } => ooda_review(task.as_deref(), root, json, auto),
     }
 }
 
@@ -153,25 +155,12 @@ fn run_ooda_loop(
 
 fn ooda_status(root: Option<PathBuf>) -> Result<()> {
     let project_root = find_project_root(root);
-    let ralph_dir = project_root.join("_b00t_/ralph");
-
-    if !ralph_dir.exists() {
-        bail!(
-            "ralph not found at {}. Run 'git submodule update --init --recursive'",
-            ralph_dir.display()
-        );
-    }
-
-    let status = Command::new("uv")
-        .args(["run", "ralph", "status"])
-        .current_dir(&ralph_dir)
-        .env("PROJECT_ROOT", project_root.to_str().unwrap_or("."))
-        .status()
-        .map_err(|e| anyhow::anyhow!("uv exec failed: {e}"))?;
-
-    if !status.success() {
-        bail!("ralph status exited with code {:?}", status.code());
-    }
+    let tasks = load_b00t_tasks(&project_root)?;
+    let total = tasks.len();
+    let pending = tasks.iter().filter(|t| task_status(t) == "pending").count();
+    let in_progress = tasks.iter().filter(|t| task_status(t) == "in-progress").count();
+    let done = tasks.iter().filter(|t| task_status(t) == "done").count();
+    println!("tasks: total={total} pending={pending} in-progress={in_progress} done={done}");
     Ok(())
 }
 
@@ -210,37 +199,10 @@ fn ooda_phase(json: bool) -> Result<()> {
 /// the output into `b00t-cli advice`.
 ///
 /// Output contract (sm0l tier): `PASS` or `FAIL: <≤5 lines>`
-fn ooda_review(task_id: Option<&str>, as_json: bool, auto: bool) -> Result<()> {
-    // Read tasks from .b00t/tasks.json
-    let tasks_path = dirs::home_dir()
-        .unwrap_or_else(|| PathBuf::from("."))
-        .join(".b00t/tasks.json");
-
-    let task_desc = if tasks_path.exists() {
-        let raw = std::fs::read_to_string(&tasks_path)?;
-        let tasks: serde_json::Value = serde_json::from_str(&raw).unwrap_or(serde_json::json!([]));
-        let arr = tasks.as_array().cloned().unwrap_or_default();
-
-        if let Some(id) = task_id {
-            arr.iter()
-                .find(|t| t["id"].as_str() == Some(id) || t["id"].as_u64().map(|n| n.to_string()).as_deref() == Some(id))
-                .and_then(|t| t["description"].as_str().map(|s| s.to_string()))
-                .unwrap_or_else(|| format!("task {id} not found"))
-        } else {
-            arr.iter()
-                .find(|t| t["status"].as_str() == Some("pending"))
-                .and_then(|t| t["description"].as_str().map(|s| s.to_string()))
-                .unwrap_or_else(|| "no pending tasks".into())
-        }
-    } else {
-        // Fall back to b00t-cli task next stdout
-        let out = Command::new("b00t-cli")
-            .args(["task", "next"])
-            .output()
-            .map(|o| String::from_utf8_lossy(&o.stdout).to_string())
-            .unwrap_or_else(|_| "unknown task".into());
-        out.trim().to_string()
-    };
+fn ooda_review(task_id: Option<&str>, root: Option<PathBuf>, as_json: bool, auto: bool) -> Result<()> {
+    let project_root = find_project_root(root);
+    let tasks = load_b00t_tasks(&project_root)?;
+    let task_desc = select_task_for_review(&tasks, task_id)?;
 
     // Karpathy 4-principle heuristic checks (no LLM needed for basic gate)
     let mut issues: Vec<&str> = vec![];
@@ -294,10 +256,65 @@ fn ooda_review(task_id: Option<&str>, as_json: bool, auto: bool) -> Result<()> {
     Ok(())
 }
 
+fn b00t_tasks_path(project_root: &std::path::Path) -> PathBuf {
+    project_root.join(".b00t/tasks.json")
+}
+
+fn load_b00t_tasks(project_root: &std::path::Path) -> Result<Vec<serde_json::Value>> {
+    let tasks_path = b00t_tasks_path(project_root);
+    if !tasks_path.exists() {
+        return Ok(vec![]);
+    }
+    let raw = std::fs::read_to_string(&tasks_path)
+        .with_context(|| format!("read {}", tasks_path.display()))?;
+    let parsed: serde_json::Value = serde_json::from_str(&raw)
+        .with_context(|| format!("parse {}", tasks_path.display()))?;
+    Ok(parsed
+        .get("tasks")
+        .and_then(|tasks| tasks.as_array())
+        .cloned()
+        .or_else(|| parsed.as_array().cloned())
+        .unwrap_or_default())
+}
+
+fn task_status(task: &serde_json::Value) -> &str {
+    task.get("status").and_then(|s| s.as_str()).unwrap_or("pending")
+}
+
+fn task_id_matches(task: &serde_json::Value, id: &str) -> bool {
+    task.get("id").and_then(|v| {
+        v.as_str().map(|s| s.to_string()).or_else(|| v.as_u64().map(|n| n.to_string()))
+    }).as_deref() == Some(id)
+}
+
+fn task_text(task: &serde_json::Value) -> Option<String> {
+    let title = task.get("title").and_then(|v| v.as_str()).unwrap_or("");
+    let description = task.get("description").and_then(|v| v.as_str()).unwrap_or("");
+    let text = match (title.is_empty(), description.is_empty()) {
+        (true, true) => return None,
+        (false, true) => title.to_string(),
+        (true, false) => description.to_string(),
+        (false, false) => format!("{title}: {description}"),
+    };
+    Some(text)
+}
+
+fn select_task_for_review(tasks: &[serde_json::Value], task_id: Option<&str>) -> Result<String> {
+    let task = if let Some(id) = task_id {
+        tasks.iter().find(|t| task_id_matches(t, id))
+            .ok_or_else(|| anyhow::anyhow!("task {id} not found"))?
+    } else {
+        tasks.iter().find(|t| task_status(t) == "pending")
+            .ok_or_else(|| anyhow::anyhow!("no pending tasks"))?
+    };
+    task_text(task).ok_or_else(|| anyhow::anyhow!("selected task has no title or description"))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::path::PathBuf;
+    use tempfile::TempDir;
 
     #[test]
     fn test_find_project_root_override() {
@@ -327,9 +344,50 @@ mod tests {
 
     #[test]
     fn test_ooda_review_pass_specific_task() {
-        // A well-scoped task passes the Karpathy gate without LLM
-        let result = ooda_review(None, true, true);
-        // No tasks.json in test env → falls back to b00t task next (may fail) — just no panic
-        assert!(result.is_ok() || result.is_err());
+        let tmp = TempDir::new().unwrap();
+        let tasks_dir = tmp.path().join(".b00t");
+        std::fs::create_dir_all(&tasks_dir).unwrap();
+        std::fs::write(tasks_dir.join("tasks.json"), r#"{"tasks":[{
+            "id": 42,
+            "title": "Fix ooda.rs task lookup",
+            "description": "Add test coverage and verify PASS output",
+            "status": "pending"
+        }]}"#).unwrap();
+
+        let result = ooda_review(Some("42"), Some(tmp.path().to_path_buf()), true, true);
+
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_load_b00t_tasks_reads_object_shape() {
+        let tmp = TempDir::new().unwrap();
+        let tasks_dir = tmp.path().join(".b00t");
+        std::fs::create_dir_all(&tasks_dir).unwrap();
+        std::fs::write(tasks_dir.join("tasks.json"), r#"{"tasks":[
+            {"id":155,"title":"Fix OODA","description":"Use .b00t/tasks.json","status":"pending"},
+            {"id":156,"title":"Done","status":"done"}
+        ]}"#).unwrap();
+
+        let tasks = load_b00t_tasks(tmp.path()).unwrap();
+
+        assert_eq!(tasks.len(), 2);
+        assert_eq!(task_status(&tasks[0]), "pending");
+        assert_eq!(task_status(&tasks[1]), "done");
+    }
+
+    #[test]
+    fn test_select_task_for_review_matches_numeric_id() {
+        let tasks = vec![serde_json::json!({
+            "id": 155,
+            "title": "Fix OODA",
+            "description": "Resolve task by id from project root",
+            "status": "pending"
+        })];
+
+        let text = select_task_for_review(&tasks, Some("155")).unwrap();
+
+        assert!(text.contains("Fix OODA"));
+        assert!(text.contains("Resolve task by id"));
     }
 }


### PR DESCRIPTION
## Summary

- Point `b00t ooda status` at native project-root `.b00t/tasks.json` and count `tasks[]` directly.
- Point `b00t ooda review` at the same native store, including numeric task-id matching and object-shaped task JSON.
- Update Ralph task status/resource handling and tests to use `.b00t/tasks.json` instead of the purged taskmaster store.

## Root Cause

OODA and Ralph still read legacy taskmaster paths, while b00t task authority now stores native task data in `.b00t/tasks.json`.

## Validation

- `uv run pytest tests/test_entrypoint.py -q` -> `18 passed in 6.53s`
- `cargo test -p b00t-cli --lib commands::ooda -- --nocapture` -> `6 passed; 0 failed`
- `cargo run -p b00t-cli --bin b00t-cli -- ooda status --root /home/brianh/.b00t` -> `tasks: total=155 pending=47 in-progress=1 done=107`
- `cargo run -p b00t-cli --bin b00t-cli -- ooda review --task 155 --root /home/brianh/.b00t --json --auto` -> `{"verdict":"PASS",...}`
- pre-push -> `✅ pre-push: tests pass`