### PR TITLE
feat(metrics): add b00t metrics recipe

### DIFF
--- a/justfile
+++ b/justfile
@@ -2145,3 +2145,41 @@ provision-agent role="worker" goal="":
       just ralph-spawn "$GOAL_TEXT" 3 | claude --print --agent "$AGENT_FILE" 2>/dev/null \
         || echo "[provision] agent ready at: $AGENT_FILE (manual launch required if claude not in PATH)"
     fi
+
+# PRD-011 G1
+b00t-metrics:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    datums="$(
+      find _b00t_ -maxdepth 1 -type f -printf '%f\n' \
+        | awk '
+            {
+              ext = "no_ext"
+              if ($0 ~ /\./) {
+                ext = $0
+                sub(/^.*\./, "", ext)
+              }
+              count[ext]++
+            }
+            END {
+              for (ext in count) {
+                printf "%s\t%d\n", ext, count[ext]
+              }
+            }
+          ' \
+        | jq -Rn '
+            reduce inputs as $line (
+              {};
+              ($line | split("\t")) as $row
+              | .[$row[0]] = ($row[1] | tonumber)
+            )
+          '
+    )"
+    train_rows=0
+    if [ -f fine-tune/train.jsonl ]; then
+      train_rows="$(wc -l < fine-tune/train.jsonl | awk '{print $1}')"
+    fi
+    jq -cn \
+      --argjson datums "$datums" \
+      --argjson train_rows "$train_rows" \
+      '{datums: $datums, train_rows: $train_rows, dangling_refs: null, probe_score: null}'


### PR DESCRIPTION
## Summary

- Add the PRD-011 G1 `b00t-metrics` recipe at the end of `justfile`.
- Emit one compact JSON object with top-level `_b00t_` file counts grouped by extension, `fine-tune/train.jsonl` line count, and placeholder `dangling_refs` / `probe_score` fields.

## Validation

- `just b00t-metrics | jq -e .datums` -> exit 0
- `git diff --check` -> exit 0
- `JUST_UNSTABLE=1 just commit-hook` -> `gate ✅  14/14 rules passed (2 gate(s))`
- pre-push -> `[pre-push] no Rust packages affected — skipping test gate`