### PR TITLE
fix: convert remaining scp-style submodule URLs to https

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -64,7 +64,7 @@
 
 [submodule "vendor/hermes-agent-b00t"]
 	path = vendor/hermes-agent-b00t
-	url = git@github.com:PromptExecution/hermes-agent-b00t.git
+	url = https://github.com/PromptExecution/hermes-agent-b00t.git
 
 [submodule "vendor/irontology-mcp"]
 	path = vendor/irontology-mcp
@@ -85,11 +85,11 @@
 
 [submodule "vendor/moltis-b00t"]
 	path = vendor/moltis-b00t
-	url = git@github.com:elasticdotventures/moltis-b00t.git
+	url = https://github.com/elasticdotventures/moltis-b00t.git
 
 [submodule "vendor/opencode-b00t"]
 	path = vendor/opencode-b00t
-	url = git@github.com:PromptExecution/opencode-b00t.git
+	url = https://github.com/PromptExecution/opencode-b00t.git
 
 [submodule "vendor/rust-docs-mcp-server"]
 	path = vendor/rust-docs-mcp-server


### PR DESCRIPTION
Cargo's git backend cannot parse scp-style submodule URLs during recursive submodule init of a git dependency (`relative URL without a base`). Same bug class as rmcp-rust-sdk (fc646284, #797); converts the remaining three: vendor/hermes-agent-b00t, vendor/moltis-b00t, vendor/opencode-b00t (all public).

Unblocks `ufo-types` as a git dependency in app4dog critter-keeper (PHOTO-CRITTER-GENERATION-PIPELINE.tomllmd §11 item 0 → Task 4).

Evidence: `grep -c 'git@' .gitmodules` → 0; commit gate 14/14 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)