### PR TITLE
fix(b00t-mcp): skip registry-bridge spawn in stdio mode

### DIFF
--- a/b00t-mcp/src/main.rs
+++ b/b00t-mcp/src/main.rs
@@ -141,8 +141,15 @@ async fn main() -> Result<()> {
 
     // 🤓 Registry bridge spawn — sync official MCP registry and launch bridges
     //    for registered stdio-based servers. Bridges convert MCP notifications to NATS.
-    if let Err(e) = spawn_registry_bridges_on_startup().await {
-        eprintln!("⚠️  Registry bridge spawn failed: {} (continuing)", e);
+    //    Skipped in stdio mode: it syncs over the network and shells out to `npx`
+    //    for every stdio-transport registry entry (some gated behind paid/x402
+    //    credentials), which previously blocked the Claude Code handshake past
+    //    its 30s connect timeout. Stdio mode is a single-client tool proxy, not
+    //    a hive notification relay — this only belongs to the HTTP/daemon modes.
+    if !is_stdio_mode || is_llm_mode {
+        if let Err(e) = spawn_registry_bridges_on_startup().await {
+            eprintln!("⚠️  Registry bridge spawn failed: {} (continuing)", e);
+        }
     }
 
     if is_stdio_mode && !is_llm_mode {


### PR DESCRIPTION
## Summary
- `b00t-mcp --stdio` was hanging past Claude Code's 30s MCP connect timeout and never responding to the `initialize` handshake.
- Root cause: `spawn_registry_bridges_on_startup()` in `b00t-mcp/src/main.rs` ran unconditionally before serving stdio. It syncs the official MCP registry over the network, then shells out to `npx -y <pkg>` for every stdio-transport server it finds (38 in this case) to start NATS notification bridges — including packages gated behind paid/x402 credentials nobody had provisioned (e.g. `@agentutility/mcp-web-probe`). Each cold `npx`/npm start is slow on its own; doing this for every registry entry routinely exceeds the client's connect timeout.
- Registry-bridge spawning relays MCP notifications to NATS, which is a hive-wide daemon concern unrelated to serving a single Claude Code client over stdio. This fix skips it in stdio mode and leaves it running for the HTTP/LLM daemon modes where it belongs.

## Test plan
- [x] Reproduced the hang: `echo '<initialize>' | b00t-mcp --stdio` never returned (traced via `strace` — confirmed it was blocked spawning `npx` processes for registry-discovered servers before ever reading/writing the JSON-RPC handshake).
- [x] Rebuilt from `origin/main` with the fix applied in an isolated worktree.
- [x] Re-ran the same `initialize` handshake against the rebuilt binary — responds in <1s instead of hanging:
  ```
  {"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2024-11-05", ...}}
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)