### PR TITLE
fix(b00t): repair datum graph (78→0 errors) + blessing role-lookup bug

### DIFF
--- a/.github/workflows/datum-validate-graph.yml
+++ b/.github/workflows/datum-validate-graph.yml
@@ -30,7 +30,14 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
+          # Avoid recursive submodule checkout because orphan gitlinks can
+          # break CI checkout before tests run — see rust-k0mmand3r.yml.
           submodules: false
+
+      - name: Init required vendor submodules
+        run: |
+          set -euo pipefail
+          git submodule update --init --depth 1 vendor/ledgrrr
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/datum-validate-graph.yml
+++ b/.github/workflows/datum-validate-graph.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Init required vendor submodules
         run: |
           set -euo pipefail
-          git submodule update --init --depth 1 vendor/ledgrrr
+          git submodule update --init --depth 1 vendor/tomllm vendor/irontology-mcp vendor/embed-anything-b00t vendor/ledgrrr vendor/runpod-sdk
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/_b00t_/ab-experiment-dispatch.skill.toml
+++ b/_b00t_/ab-experiment-dispatch.skill.toml
@@ -1,0 +1,13 @@
+[b00t]
+name = "ab-experiment-dispatch"
+type = "skill"
+type_tags = ["transferable"]
+hint = "Dispatch an A/B experiment across parallel sub-agents with stateless scoring, instead of running variants serially"
+keywords = ["ab-testing", "experiment", "dispatch", "parallel"]
+
+[b00t.learn]
+content = """
+Backed directly by `b00t-cli experiment` ("Dispatch A/B experiments
+with parallel sub-agents and stateless scoring") — the canonical way this
+hive compares two approaches empirically rather than by opinion.
+"""

--- a/_b00t_/agent-delegation.skill.toml
+++ b/_b00t_/agent-delegation.skill.toml
@@ -1,0 +1,15 @@
+# 🦨 unfinished — generic composite of agent/task/job commands, not a single verified feature
+[b00t]
+name = "agent-delegation"
+type = "skill"
+type_tags = ["transferable"]
+hint = "Assign a unit of work to the agent/sub-agent best suited for it, and track it through to completion"
+keywords = ["agent", "delegation", "task-assignment"]
+
+[b00t.learn]
+content = """
+Executive-level agent delegation: choosing which agent (sub-agent,
+Codex, Gemini, a `just` recipe) should own a unit of work, and tracking it
+via `b00t-cli agent`/`task`/`job` rather than losing track once
+delegated.
+"""

--- a/_b00t_/arbor.mcp.toml
+++ b/_b00t_/arbor.mcp.toml
@@ -3,7 +3,6 @@ name = "arbor"
 type = "mcp"
 hint = "Arbor — native agentic coding desktop (worktrees, terminals, diffs, MCP)"
 
-entangled_cli = ["arbor.cli"]
 requires_sudo = false
 
 [[b00t.mcp.stdio]]

--- a/_b00t_/brave-search.mcp.toml
+++ b/_b00t_/brave-search.mcp.toml
@@ -3,8 +3,6 @@ name = "brave-search"
 type = "mcp"
 hint = "Brave Search API integration"
 
-entangled_cli = ["brave-search.cli"]
-
 [[b00t.mcp.stdio]]
 command = "npx"
 args = ["-y", "@modelcontextprotocol/server-brave-search"]

--- a/_b00t_/browser-use.mcp.toml
+++ b/_b00t_/browser-use.mcp.toml
@@ -3,8 +3,6 @@ name = "browser-use"
 type = "mcp"
 hint = "Browser automation MCP server for web interactions"
 
-entangled_cli = ["browser-use.cli"]
-
 [[b00t.gate]]
 env = "OPENAI_API_KEY"
 hint = "Set to real key for OpenAI, or any non-empty string (e.g. 'local') when using vLLM via OPENAI_BASE_URL"

--- a/_b00t_/chrome-mcp.mcp.toml
+++ b/_b00t_/chrome-mcp.mcp.toml
@@ -3,8 +3,6 @@ name = "chrome-mcp"
 type = "mcp"
 hint = "Chrome DevTools automation via local CDP bridge"
 
-entangled_cli = ["chrome-mcp.cli"]
-
 [[b00t.mcp.stdio]]
 requires = ["node"]
 transport = "stdio"

--- a/_b00t_/code.skill.toml
+++ b/_b00t_/code.skill.toml
@@ -1,0 +1,13 @@
+[b00t]
+name = "code"
+type = "skill"
+type_tags = ["transferable"]
+hint = "Write new implementation code that satisfies a stated requirement, following the codebase's existing conventions"
+keywords = ["code", "implementation", "development"]
+
+[b00t.learn]
+content = """
+Core coding-agent action: author new code (as opposed to `refactor`,
+which restructures existing code without changing behavior, or `debug`,
+which diagnoses failures).
+"""

--- a/_b00t_/codebase-memory.mcp.toml
+++ b/_b00t_/codebase-memory.mcp.toml
@@ -3,7 +3,6 @@ name = "codebase-memory"
 type = "mcp"
 hint = "Codebase memory MCP server - knowledge graph for code indexing, search, and analysis"
 
-entangled_cli = ["codebase-memory.cli"]
 # 🤓 upstream package version 0.8.1. Literal `version` removed from here: it
 #    collided with the version-detection command below (duplicate [b00t] key →
 #    TOML parse error: "Failed to parse MCP config TOML"). Keep ONE version key.

--- a/_b00t_/codex mcp orchestration.skill.toml
+++ b/_b00t_/codex mcp orchestration.skill.toml
@@ -1,0 +1,13 @@
+[b00t]
+name = "codex mcp orchestration"
+type = "skill"
+type_tags = ["transferable"]
+hint = "Route heavy implementation work to Codex via MCP rather than implementing it directly in the executive's own context"
+keywords = ["codex", "mcp", "orchestration", "delegation"]
+
+[b00t.learn]
+content = """
+Delegating implementation-heavy work to Codex through the hive's
+existing openai-codex-mcp.mcp datum, keeping the executive role focused on
+decisions rather than code authorship.
+"""

--- a/_b00t_/cognitive-tier-routing.skill.toml
+++ b/_b00t_/cognitive-tier-routing.skill.toml
@@ -1,0 +1,18 @@
+# 🦨 unfinished — the b00t-cli model link to tier-routing logic is inferred, not confirmed; harness-level cognitive routing isn't fully solved yet per the operator
+[b00t]
+name = "cognitive-tier-routing"
+type = "skill"
+type_tags = ["transferable"]
+hint = "Route a task to sm0l/ch0nky/frontier by complexity, not by habit — cheap models for tests/lint/classify, frontier only for architecture/security/novel design"
+keywords = ["cognitive-tier", "routing", "sm0l", "ch0nky", "frontier", "model-selection"]
+
+[b00t.learn]
+content = """
+Cognitive-tier routing is the hive's model-selection contract (see hive
+CLAUDE.md "Cognitive Tiers" table): sm0l (qwen2.5-3B, haiku) for tests/lint/
+classify/grep with a PASS/FAIL output contract; ch0nky (qwen3-coder-next)
+for implement/refactor/debug with a diff+test-result contract; frontier
+(claude-opus/sonnet) for architecture/security/novel design with a
+structured-decision contract. Never pass full sub-agent output to a higher
+tier — always compress. Backed operationally by `b00t-cli model`.
+"""

--- a/_b00t_/compliance enforcement.skill.toml
+++ b/_b00t_/compliance enforcement.skill.toml
@@ -1,0 +1,15 @@
+[b00t]
+name = "compliance enforcement"
+type = "skill"
+type_tags = ["transferable"]
+hint = "Enforce guard/gate policy before privileged or destructive actions execute — backed by b00t-cli guard, bouncer, and observability"
+keywords = ["compliance", "enforcement", "guard", "policy", "audit"]
+
+[b00t.learn]
+content = """
+Compliance enforcement is not a separate subsystem — it is the composition
+of `b00t-cli guard` (session/agent authority gates), `b00t-cli bouncer`
+(input/output validation), and `b00t-cli observability` (guard-violation
+telemetry). An executive role enforces compliance by routing privileged
+actions through these three rather than trusting agent self-report.
+"""

--- a/_b00t_/context budget preservation.skill.toml
+++ b/_b00t_/context budget preservation.skill.toml
@@ -1,0 +1,15 @@
+# 🦨 unfinished — same as context budget tracking — inferred behavior, not confirmed implemented
+[b00t]
+name = "context budget preservation"
+type = "skill"
+type_tags = ["transferable"]
+hint = "Avoid burning shared context budget on work a sub-agent could do in its own isolated context"
+keywords = ["context", "budget", "preservation", "delegation"]
+
+[b00t.learn]
+content = """
+Complementary to [[context budget tracking]]: an orchestrator
+preserves its own context budget by pushing exploratory/verbose work into
+sub-agents with isolated context rather than pulling raw output back into
+its own window. Backed by `b00t-cli context` and `b00t-cli budget`.
+"""

--- a/_b00t_/context budget tracking.skill.toml
+++ b/_b00t_/context budget tracking.skill.toml
@@ -1,0 +1,16 @@
+# 🦨 unfinished — budget/context commands exist but the specific track-and-compress behavior described is inferred, not confirmed implemented
+[b00t]
+name = "context budget tracking"
+type = "skill"
+type_tags = ["transferable"]
+hint = "Track how much context/token budget remains for the current task and compress or delegate before it runs out"
+keywords = ["context", "budget", "tracking", "tokens"]
+
+[b00t.learn]
+content = """
+Context budget tracking watches remaining context/token headroom for
+the current task and triggers compression (summarize, delegate to a
+sub-agent, drop stale history) before the budget is exhausted rather than
+after. Backed by `b00t-cli budget` and `b00t-cli context` (agent context
+snapshots).
+"""

--- a/_b00t_/copaw.mcp.toml
+++ b/_b00t_/copaw.mcp.toml
@@ -3,7 +3,6 @@ name = "copaw"
 type = "mcp"
 hint = "Copaw memory provider - PDF, chat, agent memory via MCP. Preferred b00t memory backend when available. See: https://copaw.agentscope.io/docs/memory"
 
-entangled_cli = ["copaw.cli"]
 desires = "latest"
 
 install = '''

--- a/_b00t_/crawl4ai-mcp.mcp.toml
+++ b/_b00t_/crawl4ai-mcp.mcp.toml
@@ -3,8 +3,6 @@ name = "crawl4ai-mcp"
 type = "mcp"
 hint = "MCP server"
 
-entangled_cli = ["crawl4ai-mcp.cli"]
-
 [b00t.env]
 CRAWL4AI_MCP_LOG = "INFO"
 

--- a/_b00t_/crew-scaling.skill.toml
+++ b/_b00t_/crew-scaling.skill.toml
@@ -1,0 +1,14 @@
+# 🦨 unfinished — b00t-cli crew exists; size-scaling logic is not confirmed implemented
+[b00t]
+name = "crew-scaling"
+type = "skill"
+type_tags = ["transferable"]
+hint = "Grow or shrink a crew's agent count to match the work's parallelism, bounded by one-pizza-team-enforcement"
+keywords = ["crew", "scaling", "team-size"]
+
+[b00t.learn]
+content = """
+Crew scaling adjusts how many agents an Operator-Player-Captain crew
+runs concurrently based on available parallel work, bounded above by
+[[one-pizza-team-enforcement]]. Backed by `b00t-cli crew`.
+"""

--- a/_b00t_/crw.mcp.toml
+++ b/_b00t_/crw.mcp.toml
@@ -3,8 +3,6 @@ name = "crw"
 type = "mcp"
 hint = "CRW — 6MB Rust web scraper. Self-hosted, no Docker, 85ms cold start."
 
-entangled_cli = ["crw.cli"]
-
 # 🤓 crw = "crawl". Single binary, embeds HTTP client — no Chrome/headless browser.
 #    Two modes: embedded (local, no API key) and cloud (fastcrw.com, adds web search).
 #    Comparison: Firecrawl self-hosted (4GB, 5 containers, 30s cold) vs CRW (6MB, 0, 85ms).

--- a/_b00t_/css.mcp.toml
+++ b/_b00t_/css.mcp.toml
@@ -3,8 +3,6 @@ name = "css"
 type = "mcp"
 hint = "MCP server"
 
-entangled_cli = ["css.cli"]
-
 [[b00t.mcp.stdio]]
 transport = "stdio"
 args = ["-y", "css-mcp"]

--- a/_b00t_/datum dependency validation.skill.toml
+++ b/_b00t_/datum dependency validation.skill.toml
@@ -1,0 +1,16 @@
+[b00t]
+name = "datum dependency validation"
+type = "skill"
+type_tags = ["transferable"]
+hint = "Run the datum graph validator after touching depends_on/skills/entangled_* references — a dangling reference blocks the commit-hook gate"
+keywords = ["datum", "validation", "graph", "dependency", "dangling-reference"]
+
+[b00t.learn]
+content = """
+Backed directly by `b00t-cli datum validate --graph`, which checks the
+whole `_b00t_/` store's cross-references (depends_on, skills,
+entangled_cli, entangled_mcp, entangled_agents, stack members) resolve to
+real datums. An orchestrator should run this before handing a datum
+change back for commit — it is the graph-integrity counterpart to
+`cargo test` for Rust code.
+"""

--- a/_b00t_/datum.skill.toml
+++ b/_b00t_/datum.skill.toml
@@ -1,0 +1,17 @@
+[b00t]
+name = "datum"
+type = "skill"
+type_tags = ["transferable"]
+hint = "Read/write/validate typed .toml capability records in _b00t_/ — the hive's single source of truth for what tools, skills, roles, and agents exist"
+keywords = ["datum", "b00t", "capability", "toml", "cmdb"]
+
+[b00t.learn]
+content = """
+The datum system is the hive CMDB: every CLI/MCP/skill/role/agent is a
+typed `[b00t]` TOML record under `_b00t_/`, subject-keyed as
+`<name>.<type>`. Backed by the full `b00t-cli datum` command family
+(show/tree/search/filter/graph/neighbors/validate/scaffold/...). Always
+run `datum validate --graph` after adding or editing a datum's
+depends_on/skills/entangled_* references — dangling references block the
+commit-hook gate.
+"""

--- a/_b00t_/debug.skill.toml
+++ b/_b00t_/debug.skill.toml
@@ -1,0 +1,13 @@
+[b00t]
+name = "debug"
+type = "skill"
+type_tags = ["transferable"]
+hint = "Diagnose a failure's root cause from evidence (logs, test output, repro) before proposing a fix — never guess-and-check"
+keywords = ["debug", "diagnosis", "root-cause"]
+
+[b00t.learn]
+content = """
+Core coding-agent action: reproduce a failure, gather evidence, and
+identify root cause before changing code — matches the hive's
+systematic-debugging discipline (fix root causes, not symptoms).
+"""

--- a/_b00t_/delegation-first decision-making.skill.toml
+++ b/_b00t_/delegation-first decision-making.skill.toml
@@ -1,0 +1,15 @@
+# 🦨 unfinished — generic executive principle; no single tool backs this directly
+[b00t]
+name = "delegation-first decision-making"
+type = "skill"
+type_tags = ["transferable"]
+hint = "Default to delegating a task to a sub-agent or specialist tool before doing it yourself — direct execution is the fallback, not the default"
+keywords = ["delegation", "decision-making", "executive", "orchestration"]
+
+[b00t.learn]
+content = """
+An executive's default decision on receiving a task is "who/what
+should do this" (Codex, Gemini, a sm0l/ch0nky sub-agent, a `just`
+recipe) before "should I do this myself". Backed by `b00t-cli agent`,
+`b00t-cli crew`, and `b00t-cli task` for dispatch.
+"""

--- a/_b00t_/docker.cli.toml
+++ b/_b00t_/docker.cli.toml
@@ -1,0 +1,34 @@
+# docker.cli.toml — minimal reference datum for the Docker Engine CLI.
+# @tribal: created to close a dangling `depends_on = ["docker.cli"]`
+#   reference (k3d.cli) found during a datum-graph audit. This store
+#   otherwise only models individual containers (postgres-enhanced.docker,
+#   redis.docker, ...); this datum is the engine/CLI those depend on being
+#   present, not another container. No install script is fabricated —
+#   Docker vs Podman vs Docker Desktop is a host choice.
+
+[b00t]
+name = "docker"
+type = "cli"
+hint = "Docker Engine CLI — required by tools (k3d, container-backed datums) that shell out to `docker`."
+version = "docker --version"
+version_regex = 'Docker version (\d+\.\d+\.\d+)'
+docs = "https://docs.docker.com/engine/install/"
+
+[validate]
+command = "docker --version"
+regex = "^Docker version"
+
+[[usage]]
+description = "Check Docker version"
+command = "docker --version"
+
+[[usage]]
+description = "Check the Docker daemon is reachable"
+command = "docker info"
+
+# b00t:map v1
+# summary: docker — minimal detect-only datum, no fabricated install script
+# tags: docker, container, engine, cli
+# tier: sm0l
+# cmds: docker --version
+# complexity: 1

--- a/_b00t_/edit.skill.toml
+++ b/_b00t_/edit.skill.toml
@@ -1,0 +1,13 @@
+[b00t]
+name = "edit"
+type = "skill"
+type_tags = ["transferable"]
+hint = "Modify an existing file with a precise, minimal diff after reading it — never rewrite a whole file to change one thing"
+keywords = ["edit", "file", "diff", "modify"]
+
+[b00t.learn]
+content = """
+Core coding-agent action: apply a targeted, minimal change to an
+existing file (read first). Prefer `Edit` over `Write` whenever the file
+already exists, to keep diffs reviewable.
+"""

--- a/_b00t_/eureka.cli.toml
+++ b/_b00t_/eureka.cli.toml
@@ -8,7 +8,7 @@ install = { cargo = "eureka" }
 update = "cargo install eureka --force"
 version = "eureka --version"
 version_regex = 'eureka (\d+\.\d+\.\d+)'
-depends_on = ["cargo.cli", "git.cli"]
+depends_on = ["rustc.cli", "git.cli"]
 
 [b00t.skill]
 type_tags = ["cli", "productivity", "notes", "ideas", "git", "markdown", "rust"]

--- a/_b00t_/executive.toml
+++ b/_b00t_/executive.toml
@@ -11,7 +11,7 @@ skills = [
     "parallel agent fan-out",
     "context budget tracking",
     "compliance enforcement",
-    "tdd/verification gating",
+    "tdd-verification-gating",
 ]
 compliance = [
     "Delegate >50 LOC or research tasks to Codex/Gemini via b00t MCP",

--- a/_b00t_/filesystem.mcp.toml
+++ b/_b00t_/filesystem.mcp.toml
@@ -3,8 +3,6 @@ name = "filesystem"
 type = "mcp"
 hint = "MCP server"
 
-entangled_cli = ["filesystem.cli"]
-
 [[b00t.gate]]
 command = "npx"
 

--- a/_b00t_/firecrawl.mcp.toml
+++ b/_b00t_/firecrawl.mcp.toml
@@ -3,7 +3,6 @@ name = "firecrawl"
 type = "mcp"
 hint = "Web scraping and crawling MCP server - cloud and self-hosted support"
 
-entangled_cli = ["firecrawl.cli"]
 requires_sudo = false
 
 [[b00t.mcp.stdio]]

--- a/_b00t_/gemini research delegation.skill.toml
+++ b/_b00t_/gemini research delegation.skill.toml
@@ -1,0 +1,13 @@
+[b00t]
+name = "gemini research delegation"
+type = "skill"
+type_tags = ["transferable"]
+hint = "Delegate open-ended research/investigation to Gemini via its MCP tooling instead of doing broad web research inline"
+keywords = ["gemini", "research", "delegation", "mcp"]
+
+[b00t.learn]
+content = """
+Delegating broad research tasks to Gemini through the hive's existing
+gemini-mcp-tool.mcp and geminicli.cli datums, keeping the executive's own
+context budget for synthesis rather than raw search.
+"""

--- a/_b00t_/glob.skill.toml
+++ b/_b00t_/glob.skill.toml
@@ -1,0 +1,13 @@
+[b00t]
+name = "glob"
+type = "skill"
+type_tags = ["transferable"]
+hint = "Find files by name/path pattern before reading or editing them, instead of guessing paths"
+keywords = ["glob", "file", "search", "pattern"]
+
+[b00t.learn]
+content = """
+Core coding-agent action: locate files by name/path pattern (e.g.
+`src/**/*.rs`) as the first step before Read/Edit, rather than guessing a
+single path.
+"""

--- a/_b00t_/governance-safety-gate.skill.toml
+++ b/_b00t_/governance-safety-gate.skill.toml
@@ -1,0 +1,14 @@
+[b00t]
+name = "governance-safety-gate"
+type = "skill"
+type_tags = ["transferable"]
+hint = "Block a privileged or destructive action until it passes the hive's governance/safety gate — never silently bypass"
+keywords = ["governance", "safety", "gate", "guard"]
+
+[b00t.learn]
+content = """
+Every privileged or destructive worker action must clear a
+governance/safety gate before executing, not after. Backed by
+`b00t-cli guard` (guard management — list/reset/add session guards) and
+`b00t-cli gates` (list `[[b00t.gate]]` declarations across MCP datums).
+"""

--- a/_b00t_/handoff.skill.toml
+++ b/_b00t_/handoff.skill.toml
@@ -1,0 +1,29 @@
+# Renamed from "bouncer" (skill-naming layer only) to match current
+# multi-agent nomenclature: control/context transfer between agents, or
+# between an agent and a validation boundary, is called a "handoff" (OpenAI
+# Agents SDK / Swarm usage). The underlying b00t-cli command is still
+# literally named `bouncer` ([b00t.agent.bouncer] tables, `b00t-cli bouncer`
+# subcommand) — that is a separate, larger rename NOT done here.
+# 🦨 unfinished — CLI/command surface still says "bouncer"; only the skill
+#    concept name changed. Renaming b00t-cli itself needs its own PR.
+
+[b00t]
+name = "handoff"
+type = "skill"
+type_tags = ["transferable"]
+hint = "Hand off control/context to another agent or to a validation boundary at a trust edge — currently implemented via the bouncer input/output gate mechanism"
+keywords = ["handoff", "bouncer", "gatekeeper", "validation", "guard", "boundary", "agent-transfer"]
+
+[b00t.learn]
+content = """
+Handoff: transferring control (or validating a transfer) at a trust
+boundary — agent-to-agent, agent-to-human, or input/output crossing into a
+downstream system. Today this hive implements the validation side of
+handoff via the bouncer pattern: `b00t-cli bouncer` (validate/audit/config)
+and `[b00t.agent.bouncer]` input/output gate tables on individual agent
+datums (see alpha.agent.toml, operator.agent.toml). The agent-to-agent
+control-transfer side (as in OpenAI's Agents SDK "handoff" primitive) is
+not yet a first-class b00t-cli concept — routing a task to a different
+agent today goes through `b00t-cli agent`/`crew`/`task`, not a dedicated
+handoff verb.
+"""

--- a/_b00t_/hf-ecosystem.skill.toml
+++ b/_b00t_/hf-ecosystem.skill.toml
@@ -1,0 +1,14 @@
+# 🦨 unfinished — same as model-architecture — ai-wizard practice is early/aspirational
+[b00t]
+name = "hf-ecosystem"
+type = "skill"
+type_tags = ["transferable"]
+hint = "Navigate the Hugging Face model/dataset/training ecosystem (hub, transformers, PEFT) when a provider job targets hf"
+keywords = ["huggingface", "hf", "ml-ecosystem", "training"]
+
+[b00t.learn]
+content = """
+HuggingFace-ecosystem literacy for provider-backed training/inference
+jobs. Backed by `b00t-cli provider` ("Multi-provider compute — inference
+endpoints + training jobs (runpod, hf)") — the `hf` provider target.
+"""

--- a/_b00t_/hive maintenance triage.skill.toml
+++ b/_b00t_/hive maintenance triage.skill.toml
@@ -1,0 +1,14 @@
+[b00t]
+name = "hive maintenance triage"
+type = "skill"
+type_tags = ["transferable"]
+hint = "Diagnose which hive maintenance signal (exercise reminder, governance boot check, research queue item) actually needs action now"
+keywords = ["hive", "maintenance", "triage"]
+
+[b00t.learn]
+content = """
+Triage for the hive maintenance daemon's output — deciding which
+maintenance signal (exercise reminders, governance boot checks, research
+queue backlog) is actionable now versus safely deferrable. Backed by
+`b00t-cli maintenance`.
+"""

--- a/_b00t_/hive-cmdb-query.skill.toml
+++ b/_b00t_/hive-cmdb-query.skill.toml
@@ -1,0 +1,14 @@
+[b00t]
+name = "hive-cmdb-query"
+type = "skill"
+type_tags = ["transferable"]
+hint = "Query the hive's live resource/profile state (RAM/GPU/CPU, active profile) rather than assuming it from stale docs"
+keywords = ["hive", "cmdb", "query", "resource-state"]
+
+[b00t.learn]
+content = """
+Backed directly by `b00t-cli hive status`/`list` — the Hive CMDB
+command family. An operator queries this before activating a profile or
+making a resource-sensitive scheduling decision, rather than trusting
+memory of a previous state.
+"""

--- a/_b00t_/hive-cmdb.skill.toml
+++ b/_b00t_/hive-cmdb.skill.toml
@@ -1,0 +1,15 @@
+[b00t]
+name = "hive-cmdb"
+type = "skill"
+type_tags = ["transferable"]
+hint = "The Hive CMDB itself — system resource state, active profile, and command guards, queried via b00t-cli hive"
+keywords = ["hive", "cmdb", "resource-state", "guards"]
+
+[b00t.learn]
+content = """
+The Hive CMDB (`b00t-cli hive`) tracks system resource state
+(RAM/GPU/CPU), the currently active hive profile, and command guards.
+`hive status`/`list`/`plan`/`activate`/`run` are the operational surface;
+`_b00t_/*.hive.toml` profiles declare resources/exclusion groups/services/
+guards.
+"""

--- a/_b00t_/intra-agent chat monitoring.skill.toml
+++ b/_b00t_/intra-agent chat monitoring.skill.toml
@@ -1,0 +1,15 @@
+[b00t]
+name = "intra-agent chat monitoring"
+type = "skill"
+type_tags = ["transferable"]
+hint = "Watch the Agent Coordination Protocol (ACP) message stream between agents for stalls, errors, or governance violations"
+keywords = ["chat", "monitoring", "acp", "agent-coordination"]
+
+[b00t.learn]
+content = """
+Intra-agent chat monitoring watches the message stream agents use to
+coordinate with each other (not user-facing chat) for stalled
+conversations, error loops, or policy violations. Backed by `b00t-cli
+chat` ("Agent Coordination Protocol (ACP) - send messages to agents") and
+`b00t-cli observability` for violation telemetry.
+"""

--- a/_b00t_/irontology-mcp.mcp.toml
+++ b/_b00t_/irontology-mcp.mcp.toml
@@ -3,7 +3,6 @@ name = "irontology-mcp"
 type = "mcp"
 hint = "Enterprise knowledge ingestion and ontology discovery MCP server"
 
-entangled_cli = ["irontology-mcp.cli"]
 requires_sudo = false
 
 [[b00t.mcp.stdio]]

--- a/_b00t_/k0mmand3r-dispatch.skill.toml
+++ b/_b00t_/k0mmand3r-dispatch.skill.toml
@@ -1,0 +1,14 @@
+[b00t]
+name = "k0mmand3r-dispatch"
+type = "skill"
+type_tags = ["transferable"]
+hint = "Dispatch a structured command through the k0mmand3r crate's parser/dispatch pipeline instead of hand-rolled argv parsing"
+keywords = ["k0mmand3r", "dispatch", "command", "rust"]
+
+[b00t.learn]
+content = """
+k0mmand3r is a workspace crate (`~/.dotfiles/k0mmand3r`) providing
+structured command parsing/dispatch used across the hive's Rust tooling.
+Operators route command execution through it rather than re-implementing
+argv parsing per tool.
+"""

--- a/_b00t_/langchain-tool-routing.skill.toml
+++ b/_b00t_/langchain-tool-routing.skill.toml
@@ -1,0 +1,16 @@
+# 🦨 unfinished — inferred from a single example datum (langchain-agent-pm2.cli); not confirmed as a hive-wide pattern
+[b00t]
+name = "langchain-tool-routing"
+type = "skill"
+type_tags = ["transferable"]
+hint = "Route a tool call through LangChain's agent/tool abstraction when a datum is fronted by a LangChain-based agent process"
+keywords = ["langchain", "tool-routing", "agent"]
+
+[b00t.learn]
+content = """
+Tool routing for the LangChain-backed agent processes already present
+in this store (e.g. langchain-agent-pm2.cli.toml) — dispatching a tool
+call to the correct LangChain tool binding rather than calling the
+underlying API directly, so LangChain's own tracing/memory stays
+consistent.
+"""

--- a/_b00t_/ledgrrr-mcp.mcp.toml
+++ b/_b00t_/ledgrrr-mcp.mcp.toml
@@ -3,7 +3,6 @@ name = "ledgrrr-mcp"
 type = "mcp"
 hint = "MCP server"
 
-entangled_cli = ["ledgrrr-mcp.cli"]
 requires_sudo = false
 
 [[b00t.mcp.stdio]]

--- a/_b00t_/ledgrrr.desktop.toml
+++ b/_b00t_/ledgrrr.desktop.toml
@@ -1,0 +1,44 @@
+# ledgrrr.desktop.toml — native Windows desktop packaging target (PRD-10 §3.2).
+# @tribal: `type = "vendor"` — this datum tracks a vendored-but-not-yet-built
+#   packaging target (MSIX/external-location installer), not a runnable
+#   binary. `detect` intentionally fails until the installer project exists;
+#   do NOT change this to a fake-success check just to turn the datum green.
+
+[b00t]
+name = "ledgrrr"
+type = "vendor"
+hint = "Native Windows installer target for the ledgrrr desktop stack (ledgrrr-service.exe, ledgrrr-tray.exe, ledgrrr-mcp.exe, model/runtime assets, WebView2 prereqs). Missing — PRD-10 §3.2/§8. MCPB is explicitly not this installer (PRD-10 §10)."
+depends_on = ["ledgrrr.cli", "ledgrrr.mcp", "ledgrrr.service"]
+
+detect = [
+    "test -f vendor/ledgrrr/installer/ledgrrr.wxs || test -f vendor/ledgrrr/installer/AppxManifest.xml",
+    "echo 'not-built'",
+]
+
+[b00t.install]
+status = "missing"
+privilege_required = "elevated"
+owns = [
+  "ledgrrr-service.exe",
+  "ledgrrr-tray.exe",
+  "ledgrrr-mcp.exe",
+  "local model/runtime assets",
+  "Start Menu entries",
+  "repair/uninstall registration",
+  "update channel metadata",
+]
+
+[[b00t.references]]
+name = "PRD-10 §3.2 Native Windows Installer"
+url = "vendor/ledgrrr/PRD-10.md"
+
+[[b00t.references]]
+name = "PRD-10 §8 CI and Release Requirements"
+url = "vendor/ledgrrr/PRD-10.md"
+
+# b00t:map v1
+# summary: ledgrrr desktop installer — MSIX/native Windows package, not yet built
+# tags: vendor, windows, installer, msix, prd-10
+# tier: frontier
+# cmds: none — no installer artifact exists yet
+# complexity: 8

--- a/_b00t_/ledgrrr.mcp.toml
+++ b/_b00t_/ledgrrr.mcp.toml
@@ -1,0 +1,60 @@
+# ledgrrr.mcp.toml — the Claude Desktop MCPB controller surface (PRD-10 §3.1).
+# @tribal: NOT the same MCP surface as ledgrrr.cli's [b00t.providers.mcp]
+#   block (tool_prefix "ledgerr_", binary ledgerr-mcp-server — the domain
+#   bookkeeping tools). This datum is the desktop/controller binary
+#   ledgrrr-mcp, tool_prefix "ledgrrr_", vendored at
+#   vendor/ledgrrr/crates/ledgerr-desktop-agent/. It inspects/plans local
+#   host state; it is explicitly NOT the privileged installer (PRD-10 §10).
+
+[b00t]
+name = "ledgrrr"
+type = "mcp"
+hint = "Claude Desktop MCPB controller — status/plan/render/simulate/export-office over stdio JSON-RPC. Thin wrapper; delegates domain work to ledgerr_* tools, never installs privileged state itself."
+depends_on = ["ledgrrr.cli"]
+
+[b00t.learn]
+topic = "ledgrrr-desktop-agent"
+auto_digest = false
+
+[[b00t.mcp.stdio]]
+transport = "stdio"
+command = "ledgrrr-mcp"
+
+[b00t.providers.mcp]
+tool_prefix = "ledgrrr_"
+tools = [
+  "ledgrrr_status",
+  "ledgrrr_install_plan",
+  "ledgrrr_install_desktop",
+  "ledgrrr_start_service",
+  "ledgrrr_stop_service",
+  "ledgrrr_open_tray",
+  "ledgrrr_render_diagram",
+  "ledgrrr_simulate_pipeline",
+  "ledgrrr_export_office_artifact",
+  "ledgrrr_repair",
+  "ledgrrr_uninstall",
+]
+
+[[b00t.usage]]
+description = "Build the controller binary from the vendored checkout"
+command = "cd vendor/ledgrrr && cargo build -p ledgerr-desktop-agent --bin ledgrrr-mcp"
+
+[[b00t.usage]]
+description = "Run stdio transport locally"
+command = "vendor/ledgrrr/target/debug/ledgrrr-mcp"
+
+[[b00t.usage]]
+description = "Register with Claude Desktop (stdio) — Phase 1, pre-MCPB packaging"
+command = "claude mcp add ledgrrr -- vendor/ledgrrr/target/debug/ledgrrr-mcp"
+
+[[b00t.references]]
+name = "PRD-10: Desktop Agent, MCPB Bootstrapper, Office Playbook, Local Simulation Runtime"
+url = "vendor/ledgrrr/PRD-10.md"
+
+# b00t:map v1
+# summary: ledgrrr-mcp controller — Claude Desktop stdio MCP surface, plan-first for privileged actions
+# tags: mcp, desktop, controller, claude, stdio, prd-10
+# tier: ch0nky
+# cmds: vendor/ledgrrr/target/debug/ledgrrr-mcp
+# complexity: 4

--- a/_b00t_/ledgrrr.model-runtime.toml
+++ b/_b00t_/ledgrrr.model-runtime.toml
@@ -1,0 +1,33 @@
+# ledgrrr.model-runtime.toml — local CPU inference profile for playbook
+# generation/mutation (PRD-10 §3.1, §6.3, §9).
+# @tribal: `type = "ai"` (parallels ollama.ai.toml). Missing — Phase 1 has
+#   no bundled model weights or runtime; ledgrrr_status always reports
+#   `model_runtime.configured = false` until LEDGRRR_MODEL_RUNTIME_PROFILE
+#   is set to something real. Do NOT wire a fake/hardcoded "configured=true"
+#   just to make this datum look done — PRD-10 §7 requires model use to be
+#   honestly visible in status output.
+
+[b00t]
+name = "ledgrrr"
+type = "ai"
+hint = "Local CPU fine-tuned model runtime for generative playbook modelling and the local-cpu simulation profile. Missing — no bundled weights/runtime yet; deterministic (non-LLM) simulation is the only working profile in Phase 1 (PRD-10 §6.3)."
+depends_on = ["ledgrrr.mcp"]
+trigger_words = ["ledgrrr", "playbook", "local-cpu", "simulation"]
+
+[b00t.env]
+LEDGRRR_MODEL_RUNTIME_PROFILE = ""
+
+[[b00t.usage]]
+description = "Check whether a model runtime profile is configured"
+command = "b00t exec ledgrrr_status"
+
+[[b00t.references]]
+name = "PRD-10 §6.3 Simulation"
+url = "vendor/ledgrrr/PRD-10.md"
+
+# b00t:map v1
+# summary: ledgrrr local model runtime — missing, deterministic simulation is the only Phase 1 profile
+# tags: ai, model-runtime, local-cpu, simulation, prd-10
+# tier: frontier
+# cmds: b00t exec ledgrrr_status
+# complexity: 7

--- a/_b00t_/ledgrrr.office-addin.toml
+++ b/_b00t_/ledgrrr.office-addin.toml
@@ -1,0 +1,29 @@
+# ledgrrr.office-addin.toml — OneNote/Office task pane surface (PRD-10 §3.3).
+# @tribal: `type = "overlay"` — an Office add-in overlays generated/refreshed
+#   diagram artifacts onto Office UI; ledgrrr's local service remains the
+#   source of truth. Missing — no manifest, no task-pane build exists yet.
+#   Requires a real Microsoft 365 tenant to deploy/test; out of scope for a
+#   local-only Phase 1 build.
+
+[b00t]
+name = "ledgrrr"
+type = "overlay"
+hint = "OneNote/Office task pane for generating, previewing, inserting, and refreshing ledgrrr playbook diagram artifacts. Missing — needs Office add-in manifest + task-pane build + a Microsoft 365 tenant to deploy against (PRD-10 §3.3, §9)."
+depends_on = ["ledgrrr.mcp"]
+
+[b00t.overlay]
+status = "missing"
+host_surface = "onenote+office"
+publishes = "versioned diagram/playbook artifacts via ledgrrr_export_office_artifact"
+requires_external = ["Microsoft 365 developer tenant", "Office add-in centralized deployment"]
+
+[[b00t.references]]
+name = "PRD-10 §3.3 Microsoft 365 Surfaces"
+url = "vendor/ledgrrr/PRD-10.md"
+
+# b00t:map v1
+# summary: ledgrrr Office add-in — OneNote task pane, missing, needs M365 tenant
+# tags: overlay, office, onenote, addin, prd-10
+# tier: frontier
+# cmds: none — no manifest/build exists yet
+# complexity: 6

--- a/_b00t_/ledgrrr.service.toml
+++ b/_b00t_/ledgrrr.service.toml
@@ -1,0 +1,36 @@
+# ledgrrr.service.toml — Phase 1 user-level background runtime (PRD-10 §3.2).
+# @tribal: this is NOT an OS service registration yet. `type = "runtime"`
+#   because today it is a plain spawned/killed child process with a
+#   heartbeat file, controlled by ledgrrr.mcp's start/stop tools. Real
+#   systemd unit / Windows Service Control Manager registration is native
+#   installer scope (PRD-10 §3.2, §7) and does not exist yet — do not
+#   promote this datum's semantics past what ledgrrr_status actually
+#   measures (pid liveness + heartbeat freshness).
+
+[b00t]
+name = "ledgrrr"
+type = "runtime"
+hint = "ledgrrr-service — user-level long-lived heartbeat process. Phase 1 has no OS service manager; start/stop/status flow through ledgrrr_start_service/ledgrrr_stop_service/ledgrrr_status."
+depends_on = ["ledgrrr.mcp"]
+
+[b00t.runtime]
+binary = "ledgrrr-service"
+
+[[b00t.usage]]
+description = "Build the service binary from the vendored checkout"
+command = "cd vendor/ledgrrr && cargo build -p ledgerr-desktop-agent --bin ledgrrr-service"
+
+[[b00t.usage]]
+description = "Start via the controller (preferred — updates the heartbeat contract)"
+command = "b00t exec ledgrrr_start_service"
+
+[[b00t.references]]
+name = "PRD-10 §3.2 Native Windows Installer"
+url = "vendor/ledgrrr/PRD-10.md"
+
+# b00t:map v1
+# summary: ledgrrr-service — Phase 1 user-level heartbeat process, no OS service manager yet
+# tags: runtime, service, heartbeat, prd-10
+# tier: sm0l
+# cmds: b00t exec ledgrrr_start_service
+# complexity: 2

--- a/_b00t_/ledgrrr.sharepoint-webpart.toml
+++ b/_b00t_/ledgrrr.sharepoint-webpart.toml
@@ -1,0 +1,28 @@
+# ledgrrr.sharepoint-webpart.toml — SharePoint SPFx rendering surface (PRD-10 §3.3).
+# @tribal: `type = "overlay"` — same rationale as ledgrrr.office-addin: this
+#   renders published playbook artifacts inside SharePoint pages, it does
+#   not own the artifacts. Missing — no SPFx package exists yet, and
+#   deploying/testing needs a real SharePoint tenant.
+
+[b00t]
+name = "ledgrrr"
+type = "overlay"
+hint = "SharePoint SPFx web part that renders published ledgrrr playbook artifacts on SharePoint pages/libraries. Missing — needs an SPFx package + a SharePoint tenant to deploy against (PRD-10 §3.3, §9)."
+depends_on = ["ledgrrr.mcp"]
+
+[b00t.overlay]
+status = "missing"
+host_surface = "sharepoint"
+publishes = "read-only render of artifacts exported via ledgrrr_export_office_artifact"
+requires_external = ["SharePoint tenant", "SPFx toolchain (Node/Yeoman/gulp)"]
+
+[[b00t.references]]
+name = "PRD-10 §3.3 Microsoft 365 Surfaces"
+url = "vendor/ledgrrr/PRD-10.md"
+
+# b00t:map v1
+# summary: ledgrrr SharePoint web part — SPFx render surface, missing, needs SharePoint tenant
+# tags: overlay, sharepoint, spfx, prd-10
+# tier: frontier
+# cmds: none — no SPFx package exists yet
+# complexity: 6

--- a/_b00t_/lora-hyperparams.skill.toml
+++ b/_b00t_/lora-hyperparams.skill.toml
@@ -1,0 +1,16 @@
+# 🦨 unfinished — same as model-architecture — ai-wizard practice is early/aspirational
+[b00t]
+name = "lora-hyperparams"
+type = "skill"
+type_tags = ["transferable"]
+hint = "Pick LoRA rank/alpha/dropout/target-modules for a fine-tuning run based on the base model and dataset size, not defaults copied blindly"
+keywords = ["lora", "hyperparameters", "fine-tuning", "ml"]
+
+[b00t.learn]
+content = """
+LoRA hyperparameter selection (rank, alpha, dropout, target modules,
+learning rate) for the ai-wizard role's fine-tuning work. Backed by
+`b00t-cli provider` ("Multi-provider compute — inference endpoints +
+training jobs (runpod, hf)") and the existing `ai-finetune.skill.toml`
+methodology skill.
+"""

--- a/_b00t_/lsp.mcp.toml
+++ b/_b00t_/lsp.mcp.toml
@@ -3,8 +3,6 @@ name = "lsp"
 type = "mcp"
 hint = "Language Server Protocol via Docker - Provides LSP functionality through Docker container"
 
-entangled_cli = ["lsp.cli"]
-
 [[b00t.mcp.stdio]]
 command = "docker"
 args = ["run", "-i", "--rm", "docker.io/jonrad/lsp-mcp:0.3.1"]

--- a/_b00t_/mcp-assimilation.skill.toml
+++ b/_b00t_/mcp-assimilation.skill.toml
@@ -1,0 +1,15 @@
+[b00t]
+name = "mcp-assimilation"
+type = "skill"
+type_tags = ["transferable"]
+hint = "Install, register, and validate a new MCP server into the hive so agents can discover and call it — not just install the binary"
+keywords = ["mcp", "assimilation", "install", "registration"]
+
+[b00t.learn]
+content = """
+"Assimilation" is this store's term for fully onboarding an MCP
+server: install it, register it as a `.mcp.toml` datum with a working
+`[[b00t.mcp.stdio]]` block, and confirm `tools/list` succeeds — see the
+"b00t assimilation complete" markers already present in datums like
+zellij-mcp-server.mcp.toml. Backed by `b00t-cli mcp`.
+"""

--- a/_b00t_/memory.mcp.toml
+++ b/_b00t_/memory.mcp.toml
@@ -3,8 +3,6 @@ name = "memory"
 type = "mcp"
 hint = "MCP server"
 
-entangled_cli = ["memory.cli"]
-
 [[b00t.mcp.stdio]]
 transport = "stdio"
 command = "npx"

--- a/_b00t_/model-architecture.skill.toml
+++ b/_b00t_/model-architecture.skill.toml
@@ -1,0 +1,15 @@
+# 🦨 unfinished — the ai-wizard role and its fine-tuning practice are early/aspirational in this hive
+[b00t]
+name = "model-architecture"
+type = "skill"
+type_tags = ["transferable"]
+hint = "Understand the model architecture being fine-tuned (layers, attention, context length) well enough to pick sane LoRA targets"
+keywords = ["model", "architecture", "fine-tuning", "ml"]
+
+[b00t.learn]
+content = """
+Model-architecture literacy for the ai-wizard role: knowing which
+layers/modules a given base model exposes for LoRA adaptation before
+setting hyperparameters. Backed by `b00t-cli model` (AI model datum
+management) and `finetune.hive.toml`.
+"""

--- a/_b00t_/node.cli.toml
+++ b/_b00t_/node.cli.toml
@@ -1,0 +1,33 @@
+# node.cli.toml — minimal reference datum for the Node.js runtime.
+# @tribal: created to close dangling `depends_on = ["node.cli"]`/["node"]
+#   references (geminicli.cli, zellij-mcp-server.mcp, qwen-code.cli) found
+#   during a datum-graph audit. No install script is fabricated here — Node
+#   version management (nvm/fnm/pkgx/system package manager) is an
+#   environment choice, not something b00t should silently pick for you.
+
+[b00t]
+name = "node"
+type = "cli"
+hint = "Node.js JavaScript runtime — required by several npx/npm-based MCP servers in this store."
+version = "node --version"
+version_regex = 'v(\d+\.\d+\.\d+)'
+docs = "https://nodejs.org/en/download"
+
+[validate]
+command = "node --version"
+regex = "^v\\d+"
+
+[[usage]]
+description = "Check Node.js version"
+command = "node --version"
+
+[[usage]]
+description = "Check npm version"
+command = "npm --version"
+
+# b00t:map v1
+# summary: node — minimal detect-only datum, no fabricated install script
+# tags: node, nodejs, npm, npx, runtime, cli
+# tier: sm0l
+# cmds: node --version
+# complexity: 1

--- a/_b00t_/nomic-embed.api.toml
+++ b/_b00t_/nomic-embed.api.toml
@@ -7,7 +7,7 @@ desires = "latest"
 protocol = "openai-embeddings-v1"
 implements = ["openai-compat-base"]
 
-depends_on = ["llama-server"]
+depends_on = ["llama-cpp-server.container"]
 
 [b00t.provides]
 capability = "embeddings"

--- a/_b00t_/one-pizza-team-enforcement.skill.toml
+++ b/_b00t_/one-pizza-team-enforcement.skill.toml
@@ -1,0 +1,17 @@
+# 🦨 unfinished — b00t-cli crew exists; no confirmed enforcement of any team-size cap
+[b00t]
+name = "one-pizza-team-enforcement"
+type = "skill"
+type_tags = ["transferable"]
+hint = "Keep a crew small enough that one pizza feeds it — cap crew/agent-team size rather than letting delegation sprawl"
+keywords = ["crew", "team-size", "scaling", "constraint"]
+
+[b00t.learn]
+content = """
+Adapts Amazon's "two-pizza team" rule to agent crews: an operator
+enforces a hard cap on how many concurrent agents/sub-agents a crew grows
+to, preventing coordination overhead from outgrowing the value of
+parallel work. Enforced alongside `b00t-cli crew` (Operator-Player-Captain
+hierarchy) and any `hive.exclusion.group` constraints in the active hive
+profile.
+"""

--- a/_b00t_/openai-codex-mcp.mcp.toml
+++ b/_b00t_/openai-codex-mcp.mcp.toml
@@ -3,7 +3,6 @@ name = "openai-codex-mcp"
 type = "mcp"
 hint = "OpenAI Codex MCP server for agentic AI coding sessions"
 
-entangled_cli = ["openai-codex-mcp.cli"]
 lfmf_category = "codex"
 
 [b00t.learn]

--- a/_b00t_/operator.role.toml
+++ b/_b00t_/operator.role.toml
@@ -13,7 +13,7 @@ skills = [
     "hive-cmdb-query",
     "one-pizza-team-enforcement",
     "langchain-tool-routing",
-    "bouncer",
+    "handoff",
     "sm0l",
     "datum",
     "wrkflw.cli",

--- a/_b00t_/parallel agent fan-out.skill.toml
+++ b/_b00t_/parallel agent fan-out.skill.toml
@@ -1,0 +1,17 @@
+# 🦨 unfinished — composite inference from experiment+crew/agent; the stated concurrency-ceiling enforcement is not confirmed implemented
+[b00t]
+name = "parallel agent fan-out"
+type = "skill"
+type_tags = ["transferable"]
+hint = "Dispatch the same or related work to multiple sub-agents concurrently, then collect and reconcile their results"
+keywords = ["parallel", "agent", "fan-out", "concurrency", "delegation"]
+
+[b00t.learn]
+content = """
+Fan-out dispatches independent units of work to multiple sub-agents at
+once rather than serially, then reconciles results. Backed by
+`b00t-cli experiment` ("Dispatch A/B experiments with parallel
+sub-agents") and `b00t-cli crew`/`agent` for general multi-agent
+coordination. Respect the hive's stated concurrency ceiling (e.g. "at
+most 2 concurrent sub-agents") — fan-out is not unlimited.
+"""

--- a/_b00t_/pgadmin.docker.toml
+++ b/_b00t_/pgadmin.docker.toml
@@ -1,0 +1,34 @@
+# pgadmin.docker.toml — closes a dangling stack member reference:
+# postgres-dev-stack.stack listed "pgadmin.docker" but the datum never
+# existed. Mirrors the shape of postgres-enhanced.docker.toml/redis.docker.toml.
+
+[b00t]
+name = "pgadmin"
+depends_on = ["b00t.cli"]
+type = "docker"
+hint = "pgAdmin4 web UI for PostgreSQL — paired with postgres-enhanced.docker in postgres-dev-stack"
+desires = "latest"
+keywords = ["database", "postgres", "sql", "admin", "ui"]
+
+image = "dpage/pgadmin4:latest"
+oci_uri = "docker.io/dpage/pgadmin4:latest"
+resource_path = "docker.🐳/postgres-stack"
+
+docker_args = [
+    "-e", "PGADMIN_DEFAULT_EMAIL=admin@localhost",
+    "-e", "PGADMIN_DEFAULT_PASSWORD=admin",
+    "-p", "5050:80",
+    "-v", "pgadmin_data:/var/lib/pgadmin",
+]
+
+[b00t.env]
+PGADMIN_DEFAULT_EMAIL = "admin@localhost"
+PGADMIN_DEFAULT_PASSWORD = ""
+PGADMIN_PORT = "5050"
+
+# b00t:map v1
+# summary: pgadmin — pgAdmin4 container, postgres-dev-stack member
+# tags: postgres, pgadmin, database, docker, admin-ui
+# tier: sm0l
+# cmds: docker run dpage/pgadmin4
+# complexity: 2

--- a/_b00t_/phygital-status-reporting.skill.toml
+++ b/_b00t_/phygital-status-reporting.skill.toml
@@ -1,0 +1,15 @@
+# 🦨 unfinished — 'phygital' terminology also appears in reviewer.role.toml's hint, but no confirmed phygital-status implementation exists yet
+[b00t]
+name = "phygital-status-reporting"
+type = "skill"
+type_tags = ["transferable"]
+hint = "Report status across both physical/hardware state (hive CMDB: RAM/GPU/CPU) and digital/agent state in one unified dashboard"
+keywords = ["phygital", "status", "reporting", "dashboard", "cmdb"]
+
+[b00t.learn]
+content = """
+"Phygital" = physical + digital: worker status reports should cover
+both hardware/resource state (`b00t-cli hive status`, RAM/GPU/CPU) and
+agent/task state (`b00t-cli status`, the tools/services dashboard) in one
+place, not two disconnected reports.
+"""

--- a/_b00t_/plantuml.mcp.toml
+++ b/_b00t_/plantuml.mcp.toml
@@ -3,7 +3,6 @@ name = "plantuml"
 type = "mcp"
 hint = "PlantUML MCP server for diagram generation (SVG, PNG) via b00t jobs and TOGAF workflows"
 
-entangled_cli = ["plantuml.cli"]
 lfmf_category = "plantuml-mcp"
 
 [b00t.learn]

--- a/_b00t_/playwright.mcp.toml
+++ b/_b00t_/playwright.mcp.toml
@@ -3,8 +3,6 @@ name = "playwright"
 type = "mcp"
 hint = "MCP server"
 
-entangled_cli = ["playwright.cli"]
-
 [[b00t.gate]]
 command = "npx"
 

--- a/_b00t_/pm2-mcp.mcp.toml
+++ b/_b00t_/pm2-mcp.mcp.toml
@@ -3,7 +3,6 @@ name = "pm2-mcp"
 type = "mcp"
 hint = "PM2 process manager MCP — start/stop/restart/status/logs for b00t background services"
 
-entangled_cli = ["pm2-mcp.cli"]
 icon = "⚡"
 tier = "dev"
 status = "active"

--- a/_b00t_/read.skill.toml
+++ b/_b00t_/read.skill.toml
@@ -1,0 +1,13 @@
+[b00t]
+name = "read"
+type = "skill"
+type_tags = ["transferable"]
+hint = "Read a file's contents before editing it — the mandatory precondition for every Edit action in this hive's tooling"
+keywords = ["read", "file", "inspect"]
+
+[b00t.learn]
+content = """
+Core coding-agent action: inspect a file's current content. Required
+before `Edit` in this hive's tool contract — you cannot safely change what
+you have not read.
+"""

--- a/_b00t_/refactor.skill.toml
+++ b/_b00t_/refactor.skill.toml
@@ -1,0 +1,14 @@
+[b00t]
+name = "refactor"
+type = "skill"
+type_tags = ["transferable"]
+hint = "Restructure existing code without changing its observable behavior — verified by the same tests passing before and after"
+keywords = ["refactor", "restructure", "code-quality"]
+
+[b00t.learn]
+content = """
+Core coding-agent action: change code structure/naming/organization
+while keeping behavior identical, proven by an unchanged test-pass
+result before and after. Never bundle a refactor with a behavior
+change in the same edit.
+"""

--- a/_b00t_/resource-scheduling.skill.toml
+++ b/_b00t_/resource-scheduling.skill.toml
@@ -1,0 +1,16 @@
+# 🦨 unfinished — budget/scheduler/runpod commands exist but cross-resource scheduling logic as described here is not confirmed implemented
+[b00t]
+name = "resource-scheduling"
+type = "skill"
+type_tags = ["transferable"]
+hint = "Allocate budget/compute/time across competing tasks by priority and availability, not first-come-first-served"
+keywords = ["resource", "scheduling", "budget", "allocation"]
+
+[b00t.learn]
+content = """
+Resource scheduling covers both compute (RunPod GPU pods, training
+jobs) and attention/token budget. Backed by `b00t-cli budget`
+(budget-aware scheduling and tracking), `b00t-cli scheduler`
+(SQLite-backed job scheduler), and `b00t-cli runpod` for GPU cloud
+allocation.
+"""

--- a/_b00t_/role-scoped capability loading.skill.toml
+++ b/_b00t_/role-scoped capability loading.skill.toml
@@ -1,0 +1,16 @@
+[b00t]
+name = "role-scoped capability loading"
+type = "skill"
+type_tags = ["transferable"]
+hint = "Load only the blessings/skills a role is authorized for — no learning without authorization, no authorization without the role's manifest"
+keywords = ["role", "blessing", "capability", "authorization", "scoping"]
+
+[b00t.learn]
+content = """
+A role's capability surface is not implicit — it comes from
+`b00t-cli blessing --manifest --role=<R>`, which walks the role's
+`depends_on` graph to produce a tool-authorization manifest. Learning a
+skill datum unlocks the tools in its `unlocks` field; no learning means no
+authorization. An orchestrator must load capabilities per-role, not grant
+everything to every sub-agent.
+"""

--- a/_b00t_/rust-crate-docs-docker.mcp.toml
+++ b/_b00t_/rust-crate-docs-docker.mcp.toml
@@ -3,8 +3,6 @@ name = "rust-crate-docs-docker"
 type = "mcp"
 hint = "MCP server"
 
-entangled_cli = ["rust-crate-docs-docker.cli"]
-
 [[b00t.mcp.stdio]]
 priority = 0
 transport = "stdio"

--- a/_b00t_/rust-doc.mcp.toml
+++ b/_b00t_/rust-doc.mcp.toml
@@ -3,8 +3,6 @@ name = "rust-doc"
 type = "mcp"
 hint = "Rust crate documentation via semantic search — b00t vendor submodule. Per-crate MCP server with OpenAI embeddings + cosine similarity RAG"
 
-entangled_cli = ["rust-doc.cli"]
-
 [b00t.learn]
 topic = "rust-docs"
 

--- a/_b00t_/rustfs-mcp.mcp.toml
+++ b/_b00t_/rustfs-mcp.mcp.toml
@@ -3,7 +3,6 @@ name = "rustfs-mcp"
 type = "mcp"
 hint = "RustFS distributed object storage MCP server for S3-compatible storage operations"
 
-entangled_cli = ["rustfs-mcp.cli"]
 lfmf_category = "rustfs"
 
 [b00t.learn]

--- a/_b00t_/sm0l.skill.toml
+++ b/_b00t_/sm0l.skill.toml
@@ -1,0 +1,15 @@
+[b00t]
+name = "sm0l"
+type = "skill"
+type_tags = ["transferable"]
+hint = "The cheapest cognitive tier (qwen2.5-3B, haiku) — tests, lint, classify, grep; output contract is PASS or FAIL with a 5-line excerpt"
+keywords = ["sm0l", "tier", "cheap-model", "cognitive-tier"]
+
+[b00t.learn]
+content = """
+sm0l is the smallest cognitive tier in the hive's routing table (see
+[[cognitive-tier-routing]]): reserved for mechanical, low-judgment tasks
+(tests, lint, classify, grep) with a strict `PASS` or `FAIL: <5-line
+excerpt>` output contract — never given a task that needs judgment or
+novel design.
+"""

--- a/_b00t_/specialist.role.toml
+++ b/_b00t_/specialist.role.toml
@@ -4,7 +4,7 @@ trigger_words = ["implement", "refactor", "debug", "build", "delegate", "sm0l", 
 type = "role"
 hint = "Hive specialist role: sm0l-tier subagent with delegate skill, CMDB hygiene, 🍰 cake accrual"
 
-depends_on = ["playbook.skill", "delegate.skill", "opencode.agent", "b00t.cli", "git.cli", "just.cli", "bash.cli", "cargo.cli"]
+depends_on = ["playbook.skill", "delegate.skill", "opencode.agent", "b00t.cli", "git.cli", "just.cli", "bash.cli", "rustc.cli"]
 
 skills = [
     "delegate",

--- a/_b00t_/stateless-scoring.skill.toml
+++ b/_b00t_/stateless-scoring.skill.toml
@@ -1,0 +1,16 @@
+[b00t]
+name = "stateless-scoring"
+type = "skill"
+type_tags = ["transferable"]
+hint = "Score an experiment/run without carrying hidden state between trials — every score must be reproducible from its own inputs alone"
+keywords = ["stateless", "scoring", "experiment", "ab-testing", "evaluation"]
+
+[b00t.learn]
+content = """
+Stateless scoring means a scoring function takes only the run's own
+recorded inputs/outputs and produces a score with no dependency on prior
+runs, ordering, or mutable shared state — required for A/B experiment
+results to be comparable and replayable. Backed by `b00t-cli experiment`
+("Dispatch A/B experiments with parallel sub-agents and stateless
+scoring").
+"""

--- a/_b00t_/sub-agent delegation and supervision.skill.toml
+++ b/_b00t_/sub-agent delegation and supervision.skill.toml
@@ -1,0 +1,16 @@
+# 🦨 unfinished — composite of agent/crew/task commands; the 'supervision' half specifically is not confirmed as implemented behavior
+[b00t]
+name = "sub-agent delegation and supervision"
+type = "skill"
+type_tags = ["transferable"]
+hint = "Spawn a sub-agent for an independent unit of work, then supervise it to completion rather than doing the work directly"
+keywords = ["sub-agent", "delegation", "supervision", "orchestration"]
+
+[b00t.learn]
+content = """
+Delegation-first orchestration: an orchestrator role spawns sub-agents
+for independent, parallelizable work and supervises them to completion —
+checking in, not micromanaging. Backed by `b00t-cli agent`
+(coordination/management), `b00t-cli crew` (Operator-Player-Captain
+hierarchy), and `b00t-cli task`/`job` for tracking delegated work.
+"""

--- a/_b00t_/tdd-verification-gating.skill.toml
+++ b/_b00t_/tdd-verification-gating.skill.toml
@@ -1,0 +1,16 @@
+[b00t]
+name = "tdd-verification-gating"
+type = "skill"
+type_tags = ["transferable"]
+hint = "Write the failing test first; a task is not done until tests pass and the verification command's evidence line is pasted — never claim solved without running it"
+keywords = ["tdd", "verification", "gating", "checkpoint", "evidence"]
+
+[b00t.learn]
+content = """
+TDD-first + verification gating is a Core Law (see hive CLAUDE.md): red
+test before implementation, and closing a task requires executing its
+declared verification handler and pasting the PASS/FAIL evidence line
+verbatim. Backed operationally by `b00t-cli checkpoint` (commit + run
+tests) and the `contract` command family (deterministic service-contract
+handlers with evidence).
+"""

--- a/_b00t_/tomllm.skill.toml
+++ b/_b00t_/tomllm.skill.toml
@@ -1,0 +1,17 @@
+[b00t]
+name = "tomllm"
+type = "skill"
+type_tags = ["transferable"]
+hint = "The .tomllm/.tomllmd compound document format — valid TOML plus enriched # comment conventions and summary-level distillation (verbatim/executive/epigram)"
+keywords = ["tomllm", "tomllmd", "format", "compound-document"]
+
+[b00t.learn]
+content = """
+.tomllm = valid TOML + `# @tribal:`/`# 🤓` (non-obvious knowledge) and
+`# @example:` conventions, tail-mapped with a `# b00t:map v1` block
+(summary/tags/tier/cmds/complexity). `.tomllmd` extends this into a
+compound document format that can merge multiple datums at different
+summary levels (verbatim/executive/epigram) into one higher-order
+meta-learn datum. Used pervasively across this store (e.g.
+qwen-code.cli.tomllm, wow-check.wow.tomllmd).
+"""

--- a/_b00t_/worker-execution.skill.toml
+++ b/_b00t_/worker-execution.skill.toml
@@ -1,0 +1,15 @@
+# 🦨 unfinished — references ooda, which per the operator isn't fully figured out yet for scripting harnesses
+[b00t]
+name = "worker-execution"
+type = "skill"
+type_tags = ["transferable"]
+hint = "Execute one delegated unit of work to completion and report a compressed PASS/FAIL result to the caller, not a narrative"
+keywords = ["worker", "execution", "task", "delegation"]
+
+[b00t.learn]
+content = """
+A worker's job is narrow: take one dispatched task, run it to
+completion, and hand back a compressed result (evidence line, diff, or
+structured decision) — not a running commentary. Backed by
+`b00t-cli task`/`job`/`ooda` for dispatch and lifecycle tracking.
+"""

--- a/_b00t_/write.skill.toml
+++ b/_b00t_/write.skill.toml
@@ -1,0 +1,13 @@
+[b00t]
+name = "write"
+type = "skill"
+type_tags = ["transferable"]
+hint = "Create a new file with fully-specified content — the coding-agent primitive underlying most specialist.role tasks"
+keywords = ["write", "file", "create"]
+
+[b00t.learn]
+content = """
+Core coding-agent action: create a new file with complete content in one
+shot. In this hive it maps to the agent host's `Write` tool, used when no
+prior version of the file exists (prefer `Edit` for existing files).
+"""

--- a/_b00t_/zellij-mcp-server.mcp.toml
+++ b/_b00t_/zellij-mcp-server.mcp.toml
@@ -56,7 +56,7 @@ echo "✅ Zellij MCP Server uninstalled"
 version = "echo '1.0.0'"
 version_regex = "(\\d+\\.\\d+\\.\\d+)"
 
-depends_on = ["node", "zellij.cli"]
+depends_on = ["node.cli", "zellij.cli"]
 
 [[b00t.mcp.stdio]]
 command = "npx"

--- a/b00t-cli/src/commands/blessing.rs
+++ b/b00t-cli/src/commands/blessing.rs
@@ -13,8 +13,9 @@
 //! ```
 
 use crate::datum_utils::get_all_datums;
-use crate::DatumType;
+use crate::{BootDatum, DatumType};
 use anyhow::Result;
+use std::collections::HashMap;
 use std::path::PathBuf;
 
 fn find_b00t_dir() -> Result<PathBuf> {
@@ -130,28 +131,54 @@ fn list_roles(b00t_path: &str) -> Result<()> {
     Ok(())
 }
 
+/// Resolve the datum for a role name.
+///
+/// Datum keys are `<name>.<type>` derived from filename (e.g.
+/// `operator.role.toml` -> key `"operator.role"`), so a bare role name
+/// like `"operator"` never matches the map directly except by luck — that
+/// was the bug here: `--role operator` silently returned an empty
+/// manifest despite `operator.role.toml` having real `depends_on`, while
+/// `--role executive` only worked because a workaround bare-named
+/// `executive.toml` happened to exist alongside the real
+/// `executive.role.toml`.
+///
+/// Priority:
+///   1. exact `"{role}.role"` — the canonical role-datum key.
+///   2. exact bare `role` — legacy/non-standard datum naming.
+///   3. any key starting with `"{role}."`, preferring one whose
+///      `datum_type` is `Role`; candidates are sorted by key first so the
+///      result is deterministic regardless of `HashMap` iteration order.
+///
+/// Never falls back to "any Role-typed datum in the store" — a role
+/// lookup that finds no match for `role` returns `None`, not an
+/// unrelated role's manifest. Returning the wrong role's tool-
+/// authorization manifest is worse than returning none.
+fn find_role_datum<'a>(datums: &'a HashMap<String, BootDatum>, role: &str) -> Option<&'a BootDatum> {
+    if let Some(d) = datums.get(&format!("{role}.role")) {
+        return Some(d);
+    }
+    if let Some(d) = datums.get(role) {
+        return Some(d);
+    }
+    let prefix = format!("{role}.");
+    let mut candidates: Vec<(&String, &BootDatum)> =
+        datums.iter().filter(|(k, _)| k.starts_with(&prefix)).collect();
+    candidates.sort_by(|(a, _), (b, _)| a.cmp(b));
+    candidates
+        .iter()
+        .find(|(_, d)| {
+            d.datum_type
+                .as_ref()
+                .map(|t| matches!(t, DatumType::Role))
+                .unwrap_or(false)
+        })
+        .or_else(|| candidates.first())
+        .map(|(_, d)| *d)
+}
+
 fn emit_manifest(b00t_path: &str, role: &str, fmt: &str) -> Result<()> {
     let datums = get_all_datums(b00t_path)?;
-
-    // Find role datum — prefer typed Role, then exact match, then prefix match.
-    // Mirror whoami.rs load_role_datum() type-preference behaviour.
-    let role_datum = datums
-        .get(role)
-        .or_else(|| {
-            // Prefer any datum whose datum_type is Role
-            datums.values().find(|d| {
-                d.datum_type
-                    .as_ref()
-                    .map(|t| matches!(t, DatumType::Role))
-                    .unwrap_or(false)
-            })
-        })
-        .or_else(|| {
-            datums
-                .iter()
-                .find(|(k, _)| k.starts_with(role))
-                .map(|(_, v)| v)
-        });
+    let role_datum = find_role_datum(&datums, role);
 
     let direct_deps: Vec<String> = role_datum
         .and_then(|d| d.depends_on.clone())
@@ -282,5 +309,63 @@ mod tests {
         let rust = datums.get("rust.skill").unwrap();
         let expected = vec!["cargo.*".to_string(), "rustfmt".to_string()];
         assert_eq!(rust.unlocks.as_deref(), Some(expected.as_slice()));
+    }
+
+    /// Regression test for the "operator" bug: a role that exists ONLY as
+    /// `<name>.role.toml` (no bare `<name>.toml` workaround file) must
+    /// still resolve to its real depends_on via the exact `"{role}.role"`
+    /// key, not silently come back empty.
+    #[test]
+    fn test_find_role_datum_resolves_canonical_role_key_without_bare_file() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().to_str().unwrap().to_string();
+        fs::write(
+            dir.path().join("operator.role.toml"),
+            "[b00t]\nname = \"operator\"\ntype = \"role\"\nhint = \"Operator\"\ndepends_on = [\"git.cli\"]\n",
+        )
+        .unwrap();
+        fs::write(
+            dir.path().join("git.cli.toml"),
+            "[b00t]\nname = \"git\"\ntype = \"cli\"\nhint = \"Git\"\nunlocks = [\"git *\"]\n",
+        )
+        .unwrap();
+
+        let datums = get_all_datums(&path).unwrap();
+        let found = find_role_datum(&datums, "operator").expect("operator role must resolve");
+        assert_eq!(found.depends_on.as_deref(), Some(["git.cli".to_string()].as_slice()));
+    }
+
+    /// Regression test: with multiple Role-typed datums in the store,
+    /// requesting one role must never silently return a different role's
+    /// manifest (the old unfiltered `datums.values().find(Role)` fallback
+    /// could do exactly that).
+    #[test]
+    fn test_find_role_datum_does_not_cross_contaminate_between_roles() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().to_str().unwrap().to_string();
+        fs::write(
+            dir.path().join("frontend.role.toml"),
+            "[b00t]\nname = \"frontend\"\ntype = \"role\"\nhint = \"Frontend\"\ndepends_on = [\"npm.cli\"]\n",
+        )
+        .unwrap();
+        fs::write(
+            dir.path().join("backend.role.toml"),
+            "[b00t]\nname = \"backend\"\ntype = \"role\"\nhint = \"Backend\"\ndepends_on = [\"cargo.cli\"]\n",
+        )
+        .unwrap();
+
+        let datums = get_all_datums(&path).unwrap();
+        let frontend = find_role_datum(&datums, "frontend").expect("frontend role must resolve");
+        assert_eq!(frontend.depends_on.as_deref(), Some(["npm.cli".to_string()].as_slice()));
+        let backend = find_role_datum(&datums, "backend").expect("backend role must resolve");
+        assert_eq!(backend.depends_on.as_deref(), Some(["cargo.cli".to_string()].as_slice()));
+    }
+
+    #[test]
+    fn test_find_role_datum_unknown_role_returns_none_not_a_guess() {
+        let dir = TempDir::new().unwrap();
+        let path = make_b00t(&dir);
+        let datums = get_all_datums(&path).unwrap();
+        assert!(find_role_datum(&datums, "totally-unknown-role").is_none());
     }
 }

--- a/b00t-cli/src/commands/provider.rs
+++ b/b00t-cli/src/commands/provider.rs
@@ -953,13 +953,13 @@ async fn handle_runpod(cmd: RunpodSubCommands) -> Result<()> {
         RunpodSubCommands::Status { id } => {
             let pod = client.get_pod(&id, Default::default()).await?;
             let st = pod.desired_status.map(|s| format!("{s:?}")).unwrap_or_default();
-            let cost = pod.cost_per_hr.unwrap_or(0.0);
+            let cost = pod.cost_per_hr;
             println!("pod={id}  status={st}  cost_per_hr=${cost:.2}");
         }
         RunpodSubCommands::List => {
             for p in client.list_pods(Default::default()).await? {
                 let st = p.desired_status.map(|s| format!("{s:?}")).unwrap_or_default();
-                let cost = p.cost_per_hr.unwrap_or(0.0);
+                let cost = p.cost_per_hr;
                 println!("{}  {st}  ${cost:.2}/hr", p.id);
             }
         }


### PR DESCRIPTION
## Summary

Three commits, building on each other:

1. **PRD-10 Phase 1 desktop agent** (`b678b7b2`) — bumps the `vendor/ledgrrr` submodule to its `ledgrrr-mcp` controller implementation (all 11 `ledgrrr_*` MCP tools, real status/render/simulate/export-office, 17/17 tests) and publishes the 6 required `ledgrrr.*` b00t datums.
2. **Datum graph repair + blessing.rs fix** (`77b30a46`) — the commit-hook's `datum validate --graph` check was already failing with 78 dangling references before this branch touched anything (confirmed by removing the new ledgrrr datums and getting the identical count). This commit takes it to 0, and fixes a related Rust bug discovered along the way.

## What's in the datum-graph fix

- **22× removed** `entangled_cli = ["X.cli"]` self-references on MCP datums where no such CLI datum was ever created (copy-paste cruft).
- **Reference corrections**: `cargo.cli` → `rustc.cli` (×2), `llama-server` → `llama-cpp-server.container` (this store keys subject references by filename-derived type token, not the internal `type =` field — the two disagree on that file), bare `"node"` → `"node.cli"`.
- **3 new minimal datums** for real gaps: `node.cli`, `docker.cli` (detect-only, no fabricated install script) and `pgadmin.docker` (mirrors `postgres-enhanced.docker.toml`).
- **41 new skill datums** closing the `skills = [...]` cluster across role datums. Every one maps to a real, verifiable b00t-cli command, workspace crate, or documented hive concept (see each datum's `[b00t.learn]` content). **17 of the 41 are marked `# 🦨 unfinished`** with a stated reason where the mapping is inferred rather than a literal match — tracked so they're easy to find and firm up later.
- **`bouncer` → `handoff`** rename at the skill-naming layer only, per current multi-agent nomenclature. The real `b00t-cli bouncer` subcommand and `[b00t.agent.bouncer]` gate tables are untouched (flagged on `handoff.skill.toml` as a separate, larger rename).
- One reference (`"tdd/verification gating"`) contained a literal slash that can't be a filename — confirmed the graph loader doesn't scan subdirectories, so the reference was renamed to `tdd-verification-gating` rather than faking a path.

## Rust fix: `b00t-cli/src/commands/blessing.rs`

`blessing --manifest --role=X` resolved role datums via `datums.get(role)` — a bare-name key that never matches this store's `name.type` keying — then fell back to `datums.values().find(datum_type == Role)` **with no name filter at all**.

Verified live before the fix: `--role operator` silently returned an empty manifest despite `operator.role.toml` having a real `depends_on`, while `--role executive` only worked because a bare-named `executive.toml` workaround happened to exist. The unfiltered fallback is worse than empty — it can silently hand back an *unrelated* role's tool-authorization manifest.

Replaced with `find_role_datum()`: exact `"{role}.role"` key first, then bare key, then a name-prefix search that deterministically prefers a Role-typed match (sorted, not `HashMap`-iteration-order-dependent). 3 new regression tests. Confirmed fixed live — `operator` and `worker` now resolve correctly.

## Surfaced but not resolved (needs a product decision)

`"executive"` has **three divergent definitions**: `executive.toml` (bare workaround), `executive.role.toml` (original, has `depends_on`), and `executive.role.tomllm` (richer/more current, shadows the `.toml` per this store's `.tomllmd > .tomllm > .toml` precedence, but is missing `depends_on` — which is why `--role executive` still comes up empty even after the blessing.rs fix). Not merged here — reconciling three human-authored drafts isn't a call I should make unilaterally.

## Test plan

- [x] `cargo test -p b00t-cli --lib commands::blessing::` — 7/7 pass (4 existing + 3 new regression tests)
- [x] `./target/debug/b00t-cli --path _b00t_ datum validate --graph` — `datum graph: valid (490 datums)`, 0 errors (down from 78)
- [x] Live verification: `blessing --manifest --role operator/worker` now return real manifests; `--role executive` still empty (documented, separate issue)
- [x] `cargo test -p ledgerr-desktop-agent` (submodule) — 17/17 pass
- [x] Pre-commit hook passed cleanly (no `--no-verify`) on the final commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)