### PR TITLE
docs(learn): minio is archived — RustFS/Garage/SeaweedFS/Ceph comparison

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -179,19 +179,19 @@ complexity: 8
 
 ---
 
-## MCP-Down/Type-Up Bridge Pattern (genericized 2026-07-23, `b00t lfmf architecture`)
+## ledgrrr (corrected 2026-07-23)
 
-Two architectural currents, combined:
-- **thin-down**: MCP-facing actions are thin wrappers (<=10 lines) over typed
-  `Satisfies<Constraint>` checks
-- **types-up**: a domain-types crate grounds all concepts in a standard type
-  system (e.g. ISO/ontology stereotypes)
-The `Satisfies<T>` trait is the bridge — its checks emit audit-evidence nodes
-on every pass, giving auditable correctness without bloating action handlers.
-Project-specific PRDs and issue trackers live in that project's own datums —
-check the current repo's `_b00t_/datums/` before assuming this applies.
-`b00t lfmf architecture` holds the durable, repo-agnostic version of this
-lesson.
+`ledgrrr` (github.com/PromptExecution/ledgrrr, vendored at
+`~/.dotfiles/vendor/ledgrrr`) is a real, separate project — a local-first
+bookkeeping/cost-tracking control plane (typed ontology graph + Rhai rules +
+MCP tools + Mermaid/isometric visualization) — co-developed alongside b00t as
+an independently reusable component, and used heavily at PromptExecution.
+
+A prior entry here ("Tax-Lawyer Platform", `Satisfies<Constraint>`/UFO-stereotype
+bridge, PRD-TAX-LAWYER-UFO-SDD.tomllmd, issues #510-#517) was a hallucinated
+architecture summary — none of those names, traits, or issues exist in the
+real repo. Do not cite it. For actual ledgrrr architecture, read its own
+`README.md`/`AGENTS.md` in the vendored checkout, not this file.
 
 ## Playable-First Pattern (genericized 2026-07-23, `b00t lfmf mvp`)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -179,32 +179,33 @@ complexity: 8
 
 ---
 
-## Tax-Lawyer Architecture (recorded 2026-06-20)
+## MCP-Down/Type-Up Bridge Pattern (genericized 2026-07-23, `b00t lfmf architecture`)
 
-The Tax-Lawyer Platform combines two architectural currents:
-- **MCP-down**: ledgerr_tax actions are thin wrappers (<=10 lines) over Satisfies<Constraint> checks
-- **UFO-up**: ufo-types crate grounds all domain concepts in UFO stereotypes with ISO standard types
-The Satisfies<T> trait is the bridge — produces arc-kit-au evidence nodes for audit trail.
-See _b00t_/datums/PRD-TAX-LAWYER-UFO-SDD.tomllmd and issues #510-#517.
+Two architectural currents, combined:
+- **thin-down**: MCP-facing actions are thin wrappers (<=10 lines) over typed
+  `Satisfies<Constraint>` checks
+- **types-up**: a domain-types crate grounds all concepts in a standard type
+  system (e.g. ISO/ontology stereotypes)
+The `Satisfies<T>` trait is the bridge — its checks emit audit-evidence nodes
+on every pass, giving auditable correctness without bloating action handlers.
+Project-specific PRDs and issue trackers live in that project's own datums —
+check the current repo's `_b00t_/datums/` before assuming this applies.
+`b00t lfmf architecture` holds the durable, repo-agnostic version of this
+lesson.
 
-## DoggoLingo Playable-First Pattern (recorded 2026-06-30)
+## Playable-First Pattern (genericized 2026-07-23, `b00t lfmf mvp`)
 
-DoggoLingo is the active App4.Dog acceleration vector.
-Agents MUST prioritize a working local game loop over backend, cloud, or ML architecture.
-
-P0 is `tap-the-sheep`:
-- one skill: touch target acquisition
-- no backend dependency
-- no treat-dispenser dependency
-- no cloud dependency
-- static or hardcoded sheep asset is acceptable
-- reward is happy audio plus visual motion
+For any playable/interactive product, agents MUST prioritize one working
+end-to-end interaction loop over backend, cloud, or ML architecture:
+- one skill (e.g. touch target acquisition)
+- no backend, treat-dispenser, or cloud dependency
+- a static or hardcoded asset is acceptable for P0
+- reward is immediate audio/visual feedback
 - telemetry is local and JSON-shaped
 
-Before adding ML workflow code, agents MUST check:
-- `._b00t_/doggolingo.stack.tomllm`
-- `docs/DOGGOLINGO_CLEANUP_PLAN.md`
-- `SOUL.tomllm` `[doggolingo]`
-
-ComfyUI work is legacy exploration. Extract stage ideas into typed b00t business logic;
-do not make ComfyUI, workflow JSON, or a persistent ComfyUI server part of the game runtime.
+Infra-before-loop stalls momentum and hides scope creep behind unplayable
+plumbing. Project-specific stack files, cleanup plans, and legacy-exploration
+notes (e.g. workflow-tool experiments) live in that project's own datums —
+check the current repo's `_b00t_/` and `SOUL.tomllm` before adding ML/workflow
+code, not this file. `b00t lfmf mvp` holds the durable, repo-agnostic version
+of this lesson.

--- a/_b00t_/learn/docker.md
+++ b/_b00t_/learn/docker.md
@@ -1,2 +1,5 @@
 ---
 COPY vs ADD best practices: Use COPY for local files and ADD only for URLs or archives that need auto-extraction
+
+---
+build-arg version bump does not guarantee fresh download: Bumping an ARG (e.g. ARG TOOL_VERSION=x.y.z) in a Dockerfile/Containerfile does not guarantee buildx re-fetches the artifact — layer caching can silently keep the old binary even with a cache-bust comment. Verify by checking the running binary's actual reported version inside the built image, not the Dockerfile ARG value.

--- a/_b00t_/learn/docker.md
+++ b/_b00t_/learn/docker.md
@@ -3,3 +3,6 @@ COPY vs ADD best practices: Use COPY for local files and ADD only for URLs or ar
 
 ---
 build-arg version bump does not guarantee fresh download: Bumping an ARG (e.g. ARG TOOL_VERSION=x.y.z) in a Dockerfile/Containerfile does not guarantee buildx re-fetches the artifact — layer caching can silently keep the old binary even with a cache-bust comment. Verify by checking the running binary's actual reported version inside the built image, not the Dockerfile ARG value.
+
+---
+rootful socket is a security anti-pattern: The classic Docker daemon requires a rootful background socket (/var/run/docker.sock) that grants root-equivalent access to anyone who can reach it — this fails security/cyber review in hardened environments. Podman is a drop-in CLI-compatible replacement that runs rootless by default (no privileged daemon at all) and needs no docker binary present; prefer podman for all local container work, and treat any script hardcoding 'docker' as a signal to update it to call podman directly.

--- a/_b00t_/learn/gh.md
+++ b/_b00t_/learn/gh.md
@@ -1,2 +1,5 @@
 ---
 gh pr edit fails with GraphQL projectCards deprecation error on repos touched by classic Projects — patch title/body via REST instead: gh api -X PATCH repos/<owner>/<repo>/pulls/<n> --input body.json
+
+---
+file issues at confirmation time, not fix time: A regression confirmed-broken and fixed only in a commit message or a local handoff/status doc becomes unsearchable once the doc is deleted or the session ends. File (or update) a gh issue the moment a break is confirmed, even if you expect to close it same-session — gh issue search must stay the durable source of truth for 'what was broken and when'.

--- a/_b00t_/learn/git.md
+++ b/_b00t_/learn/git.md
@@ -47,3 +47,6 @@ submodule-moltis-b00t: origin/main references vendor/moltis-b00t commit 857aaed9
 
 ---
 NEVER delete corrupt git objects without first proving they are BOTH corrupt AND unreachable. The safe filter is: comm -12 <(sort corrupt.txt) <(sort unreachable.txt). `git log --find-object` only searches reachable commits — it MISSES dangling commits and will give a false "safe to delete" signal. Deleting a corrupt object that is still reachable from a live branch permanently corrupts that branch. Root cause here: OS crash created corrupt loose objects from in-flight commits; reset moved HEAD but ORIG_HEAD and reflogs may still reference those objects. Always run `git fsck --unreachable` not `git log --find-object` to classify reachability before any rm on .git/objects/.
+
+---
+build-artifact staleness: A locally-built artifact's embedded git-hash/build-hash file can lag HEAD by dozens of commits with no warning. Before treating a local build (APK, binary, bundle) as representative of current source, diff its recorded build hash against current HEAD — don't assume 'a file exists in build/' means 'built from current source'.

--- a/_b00t_/learn/minio.md
+++ b/_b00t_/learn/minio.md
@@ -1,0 +1,85 @@
+# MinIO — ARCHIVED, do not use for new work
+
+**MinIO is archived and no longer maintained as a consumable project.**
+
+Confirmed via GitHub API 2026-07-25: `minio/minio` repo has `archived: true`. The
+project has also moved to **source-only distribution** — no pre-built container
+images or binaries are published anymore; consumers must build from source
+themselves (see the minio/minio README's "Source-Only Distribution" section,
+and https://github.com/minio/minio/issues/21647 for the community reaction).
+
+## Do not
+
+- Do not add new MinIO usage to any project.
+- Do not treat an existing MinIO container/service as "just works" — pulling
+  `minio/minio:latest` (or any tag) may silently stop receiving updates, and
+  a fresh pull may eventually fail entirely once old tags are pruned.
+
+## Recommendation: RustFS as default replacement, behind a compat facade
+
+Based on an external writeup (not app4dog-specific — spot-checked, not fully
+verified; treat as a strong starting point, not settled) plus direct
+verification of the checkable claims:
+
+- **[RustFS](https://github.com/rustfs/rustfs)** — Rust, **Apache-2.0**
+  (verified via GitHub API — vs. MinIO's AGPL-3.0), not archived, actively
+  pushed. Its own S3 compatibility matrix (`docs/architecture/s3-compatibility-matrix.md`,
+  verified real, not the writeup's invention) reports **452 implemented**,
+  **17 unimplemented**, **273 intentionally-excluded** Ceph s3tests as of this
+  check. Same default ports (9000 API / 9001 console), same `server /data
+  --console-address :9001` invocation shape, many `MINIO_*` env var aliases,
+  MinIO-compatible `/minio/health/live`/`/minio/health/ready`/`/minio/admin`
+  paths. **Still beta** — distributed mode, lifecycle management, and KMS are
+  explicitly called out as under testing in their own docs.
+- **[Garage](https://garagehq.deuxfleurs.fr/)** — mature in its own niche
+  (geo-distributed small/edge clusters, production since 2020 at Deuxfleurs)
+  but NOT a broad MinIO equivalent — lacks/limits bucket policies, object
+  versioning, replication endpoints, object lock, bucket notifications,
+  tagging, several lifecycle ops. Use it specifically for geo/edge-replication
+  needs, not as a general default.
+- **SeaweedFS** (Go, not Rust) — the more mature fallback if RustFS's
+  distributed-mode beta status becomes a blocker. S3 + POSIX/FUSE + WebDAV,
+  more operational history, but a heavier multi-component architecture
+  (masters/volume servers/filers/S3 gateways) and not MinIO-operationally-compatible.
+- **Ceph RGW** — only sensible if Ceph is already deployed for other reasons;
+  deploying Ceph just to replace MinIO is a category error (control-plane/ops
+  overhead far exceeds the problem being solved).
+- **VersityGW** (Apache-2.0, Go) — S3-over-POSIX-filesystem gateway; good fit
+  for single-host dev or exposing an existing ZFS/Btrfs/XFS archive over S3,
+  not a distributed/erasure-coded replacement.
+- **[s3s](https://github.com/Nugine/s3s)** (Rust crate) — not a store itself;
+  useful for building a custom S3-protocol gateway/compat shim if none of the
+  above fit exactly.
+
+## Critical migration rule
+
+**Never swap the binary while keeping MinIO's on-disk data directory.** The
+migration boundary is S3 objects + config, not disk blocks — migrate via
+actual S3-level copy (`rclone`/`mc mirror`/AWS CLI) into fresh buckets on the
+new service, verify object count/bytes/checksums, then cut over. Versioning
+history, legal holds, and retention state are not guaranteed to survive a
+generic S3-to-S3 copy — treat those as separate migration concerns if in use.
+
+## Compatibility levels worth defining before committing to a replacement
+
+L1 (S3 client endpoint compat) through L5 (on-disk data format compat — never
+claim this one). RustFS is strong on L1/L2 (ports, env vars, health probes),
+partial on L3 (`mc`/admin ops — validate each command you actually use), and
+explicitly incomplete on L4 (IAM/notifications/lifecycle/replication/KMS
+semantics) per its own beta-status docs.
+
+## Known existing MinIO usage to migrate (found while writing this note)
+
+- `app4dog` workspace: `s3.dev.app4.dog` -> MinIO on `:9000`, referenced in
+  `nginxProxy/nginx.conf`, PM2 `ecosystem.config.js`, and
+  `middleware/artifacts/media-storage-config.json`'s `dev` region provider.
+  Not yet migrated — this note exists so the migration isn't done blind to
+  the fact that MinIO itself is going away, not just "currently down."
+
+## Not yet verified from the external writeup
+
+The Dockerfile/entrypoint-wrapper packaging pattern (`objectstore-minio-compat`
+image, `minio` compat executable shimming to RustFS's real entrypoint), the
+provider-independent `object_store:` config contract, and the four-layer test
+gate (protocol/application/failure/performance) are useful *patterns* but
+untested here — don't treat them as already-built or already-working.


### PR DESCRIPTION
## Summary
- `b00t learn minio` previously had zero content (`[learn:miss] no knowledge for 'minio'`).
- MinIO's GitHub repo is genuinely archived (`archived: true` via API) and moved to source-only distribution — no prebuilt images/binaries anymore.
- New `_b00t_/learn/minio.md` documents this plus a replacement comparison (RustFS default, Garage for geo/edge, SeaweedFS fallback, Ceph RGW only if Ceph exists, VersityGW for POSIX-local).

## Verification done, not just relayed
The replacement comparison originated from an external, not-project-specific writeup the user shared mid-session. Before incorporating it, spot-checked the most decision-relevant, checkable claims directly against GitHub:
- RustFS license: Apache-2.0 — confirmed via API.
- RustFS's "452 implemented / 17 unimplemented / 273 excluded" S3-compat test counts — confirmed real, pulled from their actual `docs/architecture/s3-compatibility-matrix.md`, not fabricated marketing copy.

The packaging/Dockerfile pattern and 4-layer test gate from the source writeup are called out explicitly in the note as **unverified patterns**, not confirmed facts — didn't want those bleeding into the doc with the same confidence as the checked items.

## Test plan
- [x] `b00t learn minio` now surfaces the new content (previously: miss)