### PR TITLE
fix(datums): register verifier DatumType token + b00t-lsp cargo-install datum

### DIFF
--- a/_b00t_/b00t-lsp.cli.toml
+++ b/_b00t_/b00t-lsp.cli.toml
@@ -1,0 +1,33 @@
+[b00t]
+name = "b00t-lsp"
+type = "cli"
+hint = "Language server + --check CI mode for b00t datum dialects (.toml/.tomllm/.tomllmd)"
+auto_install = true
+
+install = '''
+# b00t-lsp is a workspace crate — install from the b00t repo (parent of _b00t_)
+cargo install --path "${B00T_DIR:-$HOME/.b00t}/b00t-lsp" --locked --force
+'''
+
+update = '''
+cargo install --path "${B00T_DIR:-$HOME/.b00t}/b00t-lsp" --locked --force
+'''
+
+version = "b00t-lsp --version"
+version_regex = 'b00t-lsp (\d+\.\d+\.\d+)'
+desires = "latest"
+
+[[b00t.usage]]
+description = "Check a single datum file for errors and warnings"
+command = "b00t-lsp --check _b00t_/z3-verify.cli.toml"
+
+[[b00t.usage]]
+description = "Check the whole _b00t_ tree"
+command = "b00t-lsp --check _b00t_"
+
+# b00t:map v1
+# summary: b00t-lsp — LSP server + --check CI mode for b00t datum dialect validation
+# tags: lsp, datum, validation, ci, check
+# tier: sm0l
+# cmds: b00t-lsp --check _b00t_, b00t-lsp --check _b00t_/z3-verify.cli.toml
+# complexity: 2

--- a/_b00t_/vqa.polyseme.tomllmd
+++ b/_b00t_/vqa.polyseme.tomllmd
@@ -1,6 +1,6 @@
 [b00t]
 name = "vqa"
-type = "unknown"
+type = "polyseme"
 hint = "Polyseme datum — 'vqa' resolves to multiple artifacts"
 requires_sudo = false
 

--- a/b00t-cli/src/boot_datum.rs
+++ b/b00t-cli/src/boot_datum.rs
@@ -32,6 +32,8 @@ fn is_known_content_tag(s: &str) -> bool {
             | "ai_provider"
             | "pyinfra"
             | "wow"
+            | "lfmf"
+            | "capability"
     )
 }
 

--- a/b00t-cli/src/datum_types.rs
+++ b/b00t-cli/src/datum_types.rs
@@ -317,7 +317,7 @@ impl DatumType {
         Apt         => ["apt"]                       => ".apt",
         Nix         => ["nix"]                       => ".nix",
         Mcp         => ["mcp"]                       => ".mcp",
-        Cli         => ["cli"]                       => ".cli",
+        Cli         => ["cli", "verifier"]           => ".cli",
         Api         => ["api"]                       => ".api",
         Job         => ["job"]                       => ".job",
         // Ai is the umbrella; model/ai_model tokens map here (reverse dot: name.model.ai.tomllmd)

--- a/b00t-lsp/src/analysis.rs
+++ b/b00t-lsp/src/analysis.rs
@@ -54,6 +54,7 @@ pub const VALID_TYPE_TOKENS: &[&str] = &[
     "schema",
     "training",
     "vendor",
+    "verifier",
     "ooda",
 ];
 
@@ -76,6 +77,8 @@ pub const KNOWN_CONTENT_TAGS: &[&str] = &[
     "ai_provider",
     "pyinfra",
     "wow",
+    "lfmf",
+    "capability",
 ];
 
 /// Filenames that live in datum directories but are not datums.


### PR DESCRIPTION
Fixes #116.

Registers the `verifier` datum type token (aliased to the existing `Cli` DatumType), adds `lfmf`/`capability` as known content tags, corrects `vqa.polyseme.tomllmd` from type=\"unknown\" to \"polyseme\", and adds the `_b00t_/b00t-lsp.cli.toml` cargo-install datum.

**Before (pre-fix build):**
```
_b00t_/z3-verify.cli.toml:3:8: warning: unknown datum type 'verifier' (known: 41 type tokens + 16 content tags)
_b00t_/lmcache.capability.toml:3:8: warning: unknown datum type 'capability'
_b00t_/windows-wsl-x11.lfmf.toml:3:8: warning: unknown datum type 'lfmf'
_b00t_/vqa.polyseme.tomllmd:3:8: warning: unknown datum type 'unknown'
```
b00t-cli:
```
⚠️  b00t: unknown datum type token 'verifier' — not a typed datum or known content-tag; silence: B00T_DATUM_WARN=0
⚠️  b00t: unknown datum type token 'capability' — not a typed datum or known content-tag; silence: B00T_DATUM_WARN=0
⚠️  b00t: unknown datum type token 'lfmf' — not a typed datum or known content-tag; silence: B00T_DATUM_WARN=0
⚠️  b00t: unknown datum type token 'unknown' — not a typed datum or known content-tag; silence: B00T_DATUM_WARN=0
```

**After (post-fix build):** no `verifier`/`capability`/`lfmf`/`unknown` warnings in either tool.
b00t-cli: `datum graph: valid (508 datums)`, exit 0, zero `unknown datum type token` lines.
b00t-lsp full-tree check: token set now reported as \"42 type tokens + 18 content tags\"; the four targeted warnings are gone (unrelated pre-existing warnings for `pipeline`/`training-pipeline`/`governance` remain, untouched).