### PR TITLE
fix(test): unblock b00t-cli full test suite (grok e2e env! + entangled_cli assertion)

### DIFF
--- a/b00t-cli/src/integration_tests.rs
+++ b/b00t-cli/src/integration_tests.rs
@@ -325,7 +325,7 @@ baz = "learn/baz.md"
         let gemini = get_mcp_config("gemini-mcp-tool", b00t_path_str).expect("load gemini datum");
         assert_eq!(
             gemini.entangled_cli,
-            Some(vec!["geminicli".to_string()]),
+            Some(vec!["geminicli.cli".to_string()]),
             "gemini datum should keep top-level entangled CLI metadata"
         );
 

--- a/b00t-cli/tests/grok_semantic_e2e_test.rs
+++ b/b00t-cli/tests/grok_semantic_e2e_test.rs
@@ -38,7 +38,7 @@ fn load_fixtures() -> GrokTestCases {
 
 /// Resolve path to the b00t-cli binary as built by Cargo for this test target.
 fn b00t_bin() -> PathBuf {
-    PathBuf::from(env!("CARGO_BIN_EXE_b00t-cli"))
+    assert_cmd::cargo::cargo_bin("b00t-cli")
 }
 /// Returns a Command pointing at the b00t-cli binary built by Cargo.
 /// Uses `assert_cmd::prelude::CommandCargoExt` so the binary is always available.


### PR DESCRIPTION
Fixes #167.

## Problem
`cargo test -p b00t-cli` failed to compile:
- tests/grok_semantic_e2e_test.rs used `env!("CARGO_BIN_EXE_b00t-cli")` at compile time — that variable is only available to a crate's own bin-target tests, not integration tests. This blocked the entire integration suite.
- After fixing that, a second pre-existing failure surfaced: integration_tests.rs asserted `entangled_cli == ["geminicli"]` but datums canonically use the qualified form `"geminicli.cli"` (datum changed in repo #849). `parse_entanglement_ref` resolves the qualified form correctly, so the test assertion was stale.

## Changes
- `b00t_bin()` now uses `assert_cmd::cargo::cargo_bin("b00t-cli")` (runtime resolution, same approach as the other 8 test files already using `Command::cargo_bin`).
- entangled_cli assertion updated to `["geminicli.cli"]`.

## Verification
- `cargo test -p b00t-cli --test grok_semantic_e2e_test`: 7 passed, 2 ignored (TEST_RAGLIGHT-gated)
- `cargo test -p b00t-cli --lib`: 1397 passed, 0 failed, 4 ignored
- `cargo test -p b00t-cli --bin b00t-cli`: 45 passed, 0 failed
- All integration test binaries pass individually (docker, integration, cli_*, learn_*, hive, install, orchestrator, pipeline, ai, gh_runner, k0mmand3r, crew, checkpoint, constraint, session, worker, lfmf)