### PR TITLE
feat(b00t-mcp): silent chat — omit <🥾> envelope when inbox is empty

### DIFF
--- a/b00t-mcp/src/chat.rs
+++ b/b00t-mcp/src/chat.rs
@@ -36,6 +36,10 @@ impl ChatRuntime {
     pub async fn drain_indicator(&self) -> String {
         let messages = self.inbox.drain().await;
         let count = messages.len();
+        if messages.is_empty() {
+            return String::new();
+        }
+
         for msg in &messages {
             info!(
                 channel = %msg.channel,
@@ -44,10 +48,68 @@ impl ChatRuntime {
                 "chat message queued"
             );
         }
-        format!("<🥾>{{ \"chat\": {{ \"msgs\": {} }} }}</🥾>", count)
+
+        let displayed_messages: Vec<serde_json::Value> = messages
+            .iter()
+            .map(|msg| {
+                serde_json::json!({
+                    "channel": msg.channel,
+                    "sender": msg.sender,
+                    "body": msg.body,
+                })
+            })
+            .collect();
+        let payload = serde_json::json!({
+            "chat": {
+                "msgs": count,
+                "messages": displayed_messages,
+            }
+        });
+
+        format!("<🥾>{payload}</🥾>")
     }
 
     pub async fn unread_count(&self) -> usize {
         self.inbox.unread_count().await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use b00t_chat::ChatMessage;
+
+    #[tokio::test]
+    async fn empty_inbox_emits_no_indicator() {
+        let runtime = ChatRuntime {
+            inbox: ChatInbox::new(),
+        };
+
+        assert_eq!(runtime.drain_indicator().await, "");
+    }
+
+    #[tokio::test]
+    async fn nonempty_inbox_displays_message_content() {
+        let inbox = ChatInbox::new();
+        inbox
+            .push(ChatMessage::new(
+                "a2a.review",
+                "worker-1",
+                "ready for review",
+            ))
+            .await;
+        let runtime = ChatRuntime { inbox };
+
+        let output = runtime.drain_indicator().await;
+        let payload = output
+            .strip_prefix("<🥾>")
+            .and_then(|value| value.strip_suffix("</🥾>"))
+            .unwrap();
+        let value: serde_json::Value = serde_json::from_str(payload).unwrap();
+
+        assert_eq!(value["chat"]["msgs"], 1);
+        assert_eq!(value["chat"]["messages"][0]["channel"], "a2a.review");
+        assert_eq!(value["chat"]["messages"][0]["sender"], "worker-1");
+        assert_eq!(value["chat"]["messages"][0]["body"], "ready for review");
     }
 }

--- a/b00t-mcp/src/mcp_server_rusty.rs
+++ b/b00t-mcp/src/mcp_server_rusty.rs
@@ -425,13 +425,15 @@ impl B00tMcpServerRusty {
             success: bool,
             server_type: String,
             working_dir: String,
-            indicator: String,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            indicator: Option<String>,
         }
 
-        let decorated_output = if output.trim().is_empty() {
-            indicator.to_string()
-        } else {
-            format!("{}\n{}", output, indicator)
+        let decorated_output = match (output.trim().is_empty(), indicator.trim().is_empty()) {
+            (true, true) => String::new(),
+            (true, false) => indicator.to_string(),
+            (false, true) => output.to_string(),
+            (false, false) => format!("{}\n{}", output, indicator),
         };
 
         let result = B00tOutput {
@@ -439,7 +441,7 @@ impl B00tMcpServerRusty {
             success: true,
             server_type: "rusty".to_string(),
             working_dir: self.working_dir.display().to_string(),
-            indicator: indicator.to_string(),
+            indicator: (!indicator.trim().is_empty()).then(|| indicator.to_string()),
         };
 
         let content = serde_json::to_string_pretty(&result)
@@ -456,13 +458,15 @@ impl B00tMcpServerRusty {
             success: bool,
             server_type: String,
             working_dir: String,
-            indicator: String,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            indicator: Option<String>,
         }
 
-        let decorated_error = if error.trim().is_empty() {
-            indicator.to_string()
-        } else {
-            format!("{}\n{}", error, indicator)
+        let decorated_error = match (error.trim().is_empty(), indicator.trim().is_empty()) {
+            (true, true) => String::new(),
+            (true, false) => indicator.to_string(),
+            (false, true) => error.to_string(),
+            (false, false) => format!("{}\n{}", error, indicator),
         };
 
         let result = B00tError {
@@ -470,7 +474,7 @@ impl B00tMcpServerRusty {
             success: false,
             server_type: "rusty".to_string(),
             working_dir: self.working_dir.display().to_string(),
-            indicator: indicator.to_string(),
+            indicator: (!indicator.trim().is_empty()).then(|| indicator.to_string()),
         };
 
         let content = serde_json::to_string_pretty(&result)
@@ -565,18 +569,40 @@ mod tests {
             let temp_dir = TempDir::new().unwrap();
             let server = B00tMcpServerRusty::new_flat(temp_dir.path(), "").unwrap();
 
-            let indicator = "<🥾>{ \"chat\": { \"msgs\": 0 } }</🥾>";
-            let success_result = server.create_success_result("Test output", indicator);
+            let success_result = server.create_success_result("Test output", "");
             assert!(!success_result.content.is_empty());
+            let success_value = serde_json::to_value(&success_result).unwrap();
+            let success_text = success_value["content"][0]["text"].as_str().unwrap();
+            let success_payload: serde_json::Value = serde_json::from_str(success_text).unwrap();
+            assert_eq!(success_payload["output"], "Test output");
+            assert!(success_payload.get("indicator").is_none());
+            assert!(!success_text.contains("<🥾>"));
 
-            let error_result = server.create_error_result("Test error", indicator);
+            let error_result = server.create_error_result("Test error", "");
             assert!(!error_result.content.is_empty());
+            let error_value = serde_json::to_value(&error_result).unwrap();
+            let error_text = error_value["content"][0]["text"].as_str().unwrap();
+            let error_payload: serde_json::Value = serde_json::from_str(error_text).unwrap();
+            assert_eq!(error_payload["error"], "Test error");
+            assert!(error_payload.get("indicator").is_none());
+            assert!(!error_text.contains("<🥾>"));
+        });
+    }
 
-            // Verify the content can be parsed
-            if let Some(_content) = success_result.content.get(0) {
-                // Verify we have content
-                assert!(!success_result.content.is_empty());
-            }
+    #[test]
+    fn nonempty_indicator_is_preserved() {
+        with_tokio_runtime(|| {
+            let temp_dir = TempDir::new().unwrap();
+            let server = B00tMcpServerRusty::new_flat(temp_dir.path(), "").unwrap();
+            let indicator = "<🥾>{ \"chat\": { \"msgs\": 1 } }</🥾>";
+
+            let result = server.create_success_result("Test output", indicator);
+            let value = serde_json::to_value(&result).unwrap();
+            let text = value["content"][0]["text"].as_str().unwrap();
+            let payload: serde_json::Value = serde_json::from_str(text).unwrap();
+
+            assert_eq!(payload["indicator"], indicator);
+            assert!(payload["output"].as_str().unwrap().contains(indicator));
         });
     }
 }


### PR DESCRIPTION
## Problem

`drain_indicator` returned a `{"chat":{"msgs":0}}` envelope on **every** MCP tool call, so each response carried a noise line even when there was no chat traffic at all. When there *was* traffic, the payload was a bare count — you learned that N messages existed but not what any of them said, which isn't actionable on its own.

## Change

- Empty inbox → returns an empty string, no envelope.
- Non-empty inbox → emits the message bodies (`channel` / `sender` / `body`) alongside the count.
- `create_success_result` / `create_error_result` take `indicator` as `Option<String>` with `skip_serializing_if`, so the field disappears from the JSON entirely instead of serializing as `""`.
- Output decoration is now an explicit 2×2 match on `(output empty, indicator empty)`. The old two-arm form appended a stray newline when the output was non-empty and the indicator was empty.

## Tests

Four new assertions:
- empty inbox emits no indicator
- non-empty inbox surfaces channel/sender/body
- success and error payloads omit the `indicator` key when silent
- a non-empty indicator is preserved verbatim and still appended to `output`

## Verification

```
$ just test-b00t-mcp
test result: ok. 57 passed; 0 failed; 0 ignored
test result: ok. 3 passed; 0 failed; 0 ignored
test result: ok. 5 passed; 0 failed; 0 ignored
EXIT=0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CxBnYUur8h2Awz34fxnLhW