### PR TITLE
chore(release): bump workspace version to v0.10.3 + two lfmf entries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1375,7 +1375,7 @@ version = "0.1.0"
 
 [[package]]
 name = "b00t-admin"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "axum 0.8.9",
  "b00t-c0re-lib",
@@ -1397,7 +1397,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-ast"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -1413,7 +1413,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-azure-cp"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -1437,7 +1437,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-bouncer"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1451,7 +1451,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-c0re-a2a"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "chrono",
  "serde",
@@ -1464,7 +1464,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-c0re-gov"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "async-trait",
  "b00t-c0re-lib",
@@ -1479,7 +1479,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-c0re-hierarchy"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "b00t-c0re-gov",
  "chrono",
@@ -1491,7 +1491,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-c0re-lib"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -1553,7 +1553,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-chat"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "anyhow",
  "arrow",
@@ -1596,7 +1596,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-cli"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "anyhow",
  "apalis",
@@ -1691,7 +1691,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-datum-core"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1703,7 +1703,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-embed"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1724,7 +1724,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-grok"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "anyhow",
  "async-openai",
@@ -1743,7 +1743,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-ipc"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -1763,7 +1763,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-l3dg3rr-viz"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "blake3",
  "kasuari",
@@ -1774,7 +1774,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-lsp"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "anyhow",
  "b00t-datum-core",
@@ -1788,7 +1788,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-mcp"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -1832,7 +1832,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-mermaid-wasm"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "mermaid-rs-renderer",
  "wasm-bindgen",
@@ -1840,7 +1840,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-pyverse"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "anyhow",
  "b00t-c0re-lib",
@@ -1855,14 +1855,14 @@ dependencies = [
 
 [[package]]
 name = "b00t-reflect-types"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "b00t-ui-wasm"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "dioxus",
  "dioxus-web",
@@ -1879,7 +1879,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-zellij"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "b00t-c0re-lib",
  "chrono",
@@ -7143,7 +7143,7 @@ dependencies = [
 
 [[package]]
 name = "k0mmand3r"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "decimal-rs",
  "indexmap 2.14.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ resolver = "2"
 [workspace.package]
 # 🤓 Version management centralized in b00t-c0re-lib
 # All workspace crates inherit from the single source of truth
-version = "0.10.2"
+version = "0.10.3"
 edition = "2024"
 authors = ["Brian Horakh <brian@promptexecution.com>"]
 license = "MIT"

--- a/_b00t_/learn/cargo-workspace-install.md
+++ b/_b00t_/learn/cargo-workspace-install.md
@@ -1,0 +1,2 @@
+---
+Use-cargo-install---locked-for-workspace-path-binaries-to-preserve-the-repository-lockfile-and-MSRS-compatible-resolution: Use-cargo-install---locked-for-workspace-path-binaries-to-preserve-the-repository-lockfile-and-MSRS-compatible-resolution <!-- salvaged:no_colon -->

--- a/_b00t_/learn/guard-session-fixtures.md
+++ b/_b00t_/learn/guard-session-fixtures.md
@@ -1,0 +1,2 @@
+---
+Session guards a/b/c from June 27 b00t tests persisted in ~/.b00t/session-guards.json and blocked: Session guards a/b/c from June 27 b00t tests persisted in ~/.b00t/session-guards.json and blocked unrelated audited commands; tests MUST isolate or remove session guards on teardown. Operator checkpoint docs also use invalid rustc --edition without a value. <!-- salvaged:no_colon -->


### PR DESCRIPTION
## Change

Bumps the centralized workspace version `0.10.2` → `0.10.3`, and adds two `b00t lfmf` entries.

### Lockfile

The lockfile update is deliberately **minimal — 23 version lines, nothing else**. It covers the 22 `b00t-*` crates plus `k0mmand3r`, which is also a workspace path member and inherits the workspace version.

⚠️ Worth knowing: `main`'s `Cargo.lock` is currently **out of sync with its own manifests**, independent of this PR. On a pristine `main` with no version change at all, `cargo update --workspace --offline --dry-run` reports 33 changes — chiefly wanting to downgrade `candle 0.11.0 → 0.9.2`. Letting cargo regenerate the lock here would have dragged all of that in and buried the version bump in ~250 lines of unrelated churn, so I bumped only the workspace members. **This PR neither causes nor fixes that drift** — it likely wants a dedicated lockfile-resync PR.

### Docs

Two lfmf entries:
- **cargo-workspace-install** — use `cargo install --locked` for workspace path binaries so the repo lockfile and its MSRV-compatible resolution hold.
- **guard-session-fixtures** — session guards `a`/`b`/`c` from June 27 b00t tests persisted in `~/.b00t/session-guards.json` and blocked unrelated audited commands; tests MUST isolate or tear down session guards.

Both were written by the lfmf salvage path and carry its `salvaged:no_colon` marker with a duplicated key. Content is correct, formatting is not — left as-emitted rather than hand-cleaned, since the mangling is a writer bug worth fixing at the source.

## Verification

```
$ just test-b00t-mcp
test result: ok. 57 passed; 0 failed; 0 ignored
test result: ok. 3 passed; 0 failed; 0 ignored
test result: ok. 5 passed; 0 failed; 0 ignored
EXIT=0
```

Independent of #916 and #917.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CxBnYUur8h2Awz34fxnLhW