### PR TITLE
feat(mcp): register store init/status/validate in TOOL_CATALOG

### DIFF
--- a/b00t-mcp/src/mcp_tools.rs
+++ b/b00t-mcp/src/mcp_tools.rs
@@ -1892,6 +1892,21 @@ pub static TOOL_CATALOG: &[ToolCatalogEntry] = &[
         description: "Run a registered just recipe through a typed recipe-and-args contract",
         subcommand: "just",
     },
+    ToolCatalogEntry {
+        name: "b00t_store_init",
+        description: "Initialise the knowledge store",
+        subcommand: "store init",
+    },
+    ToolCatalogEntry {
+        name: "b00t_store_status",
+        description: "Show store status (backend, objects, bytes)",
+        subcommand: "store status",
+    },
+    ToolCatalogEntry {
+        name: "b00t_store_validate",
+        description: "Cross-engine consistency check",
+        subcommand: "store validate",
+    },
 ];
 
 /// Search TOOL_CATALOG by keyword (case-insensitive substring match on name + description)
@@ -2645,6 +2660,26 @@ mod tests {
             shlex::split(argv).is_none(),
             "unterminated quote must fail tokenization, not panic"
         );
+    }
+
+    #[test]
+    fn test_store_subcommands_discoverable() {
+        // #708: store subcommands (init/status/validate) must be discoverable
+        // via b00t_discover("store") — the CLI commands already exist and are
+        // reachable through b00t_exec, but were missing from TOOL_CATALOG.
+        let matches = discover_tools("store");
+        assert!(
+            matches.len() >= 3,
+            "expected at least 3 store entries in discover_tools(\"store\"), got {}",
+            matches.len()
+        );
+        for expected in ["b00t_store_init", "b00t_store_status", "b00t_store_validate"] {
+            assert!(
+                matches.iter().any(|e| e.name == expected),
+                "discover_tools(\"store\") missing entry {}",
+                expected
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- The `b00t-cli` `store init`, `store status`, and `store validate` subcommands existed and were reachable via `b00t_exec`, but were missing from `b00t-mcp`'s `TOOL_CATALOG`, so `b00t_discover("store")` couldn't surface them.
- Adds the three catalog entries in `b00t-mcp/src/mcp_tools.rs`, plus a regression test (`test_store_subcommands_discoverable`) asserting `discover_tools("store")` returns all three.

Recovered from an interrupted agent worktree (`task/708-store-mcp-discovery`); this session verified the change against current `origin/main` before pushing — rebased (fast-forward) onto `origin/main` and manually resolved a trivial merge conflict in `TOOL_CATALOG`/tests caused by an unrelated upstream reformat + the new `b00t_just` entry (#917).

Note: `Cargo.lock` and `vendor/embed-anything-b00t` showed as dirty in the worktree but were confirmed to be unrelated submodule-pointer drift noise (embed-anything-b00t 0.7.0 → 0.7.2), not excluded from this PR intentionally.

## Test plan
- [x] `cargo check -p b00t-mcp` — clean (after resyncing stale `vendor/runpod-sdk` submodule pointer, an unrelated worktree-staleness false alarm)
- [x] `cargo test -p b00t-mcp test_store_subcommands_discoverable` — passes
- [x] pre-push hook: 58/58 `b00t-mcp` reverse-dependency tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)