### PR TITLE
ci: add real workspace CI gate (--locked); replace fake blank.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,86 @@
+# 🤓 The workflow that previously reported as "CI" was .github/workflows/blank.yml —
+#    the GitHub starter template, with every real step commented out. It installed uv
+#    and QEMU and never invoked cargo, which is why it "passed" in ~18s for a 30-crate
+#    Rust workspace. See #919. The check name is deliberately kept as "CI" so any
+#    branch-protection rule matching that name keeps working.
+
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+# A superseded run teaches nothing; cancel it rather than pay for it.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  workspace:
+    name: cargo check + test (workspace)
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout 🥾
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          # 🤓 NOT `submodules: recursive`. This repo has 34 submodules, and a
+          #    recursive checkout aborts on orphan//gutted gitlinks (see #924).
+          #    Init only what the workspace actually needs, explicitly.
+          submodules: false
+
+      - name: Init workspace-required vendor submodules
+        run: |
+          set -euo pipefail
+          # 🤓 Exactly the three carrying *active* path deps in the workspace
+          #    manifests. tomllm and irontology-mcp are commented out in
+          #    Cargo.toml and are NOT required — do not re-add them by reflex.
+          #      vendor/embed-anything-b00t -> embed_anything (b00t-embed)
+          #      vendor/runpod-sdk          -> runpod-sdk     (b00t-cli)
+          #      vendor/ledgrrr             -> b00t-reflect-types
+          git submodule update --init --depth 1 \
+            vendor/embed-anything-b00t \
+            vendor/runpod-sdk \
+            vendor/ledgrrr
+
+      - name: Verify the init produced usable, in-sync checkouts
+        run: |
+          set -euo pipefail
+          # 🤓 This does NOT guard developer-machine drift — the step above just
+          #    forced these to their recorded commits, so drift is impossible
+          #    here by construction. Local drift is #923's `b00t doctor` job.
+          #    What this catches is the init silently under-delivering: a
+          #    submodule left uninitialized ('-') or landing off-commit ('+'),
+          #    which otherwise surfaces later as a confusing cargo path error.
+          bad="$(git submodule status vendor/embed-anything-b00t vendor/runpod-sdk vendor/ledgrrr | grep -E '^[-+]' || true)"
+          if [ -n "$bad" ]; then
+            echo "FAIL: submodule(s) uninitialized or off-commit:"
+            echo "$bad"
+            exit 1
+          fi
+          # The path deps must actually resolve to crates.
+          for p in vendor/embed-anything-b00t/rust vendor/runpod-sdk vendor/ledgrrr/crates/b00t-reflect-types; do
+            test -f "$p/Cargo.toml" || { echo "FAIL: $p/Cargo.toml missing"; exit 1; }
+          done
+          echo "PASS: 3 submodules initialized, in-sync, path deps resolve"
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+
+      # --locked is the point: it makes lockfile/manifest disagreement a hard
+      # failure instead of a silent re-resolve that differs from local builds.
+      - name: cargo check --workspace --locked
+        run: cargo check --workspace --locked
+
+      - name: cargo test --workspace --locked
+        run: cargo test --workspace --locked


### PR DESCRIPTION
## Summary
Replace `.github/workflows/blank.yml` (GitHub's starter template with every step commented out) with a proper CI workflow that runs `cargo check --workspace --locked` and `cargo test --workspace --locked`.

The `--locked` flag makes lockfile/manifest disagreement a hard failure instead of a silent re-resolve, which was the goal of #922.

## Changes
- Delete `blank.yml` (107 lines of no-op template)
- Add `ci.yml` (86 lines) with real Rust workspace checks
- Init only the three workspace path deps (`vendor/embed-anything-b00t`, `vendor/runpod-sdk`, `vendor/ledgrrr`) instead of recursive submodule checkout, which aborts on orphan/gutted gitlinks (#924)

## Test plan
- [x] Commit passes gate (14/14 rules)
- [ ] CI runs on PR and passes
- [ ] Verify `--locked` enforces lockfile sync

🤖 Generated with Claude Code