### PR TITLE
docs: fix CLAUDE.md DatumType variant count drift (fixes #933)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,7 +135,7 @@ b00t types are Rust structs/enums in `b00t-cli/src/lib.rs`. Agents navigate via:
 - `b00t-cli ontology sparql --subject <X> --predicate type` — just type triples
 - `b00t-cli learn <topic>` — DWIW fanout: `DatumSearchSource(w=3)` + `GraphAdjacencySource(w=2)`
 - `b00t-cli blessing --manifest --role <R>` — walk `depends_on` graph for role
-- Key types: `BootDatum` (open struct) · `DatumType` (22-variant enum: Cli/Skill/Role/Mcp/Agent…)
+- Key types: `BootDatum` (open struct) · `DatumType` (open enum — see `b00t-cli/src/datum_types.rs` for the current variant list, do not hardcode a count here)
 - Chalk Interner pattern: `DatumStore` trait would abstract TOML/SQLite/Qdrant storage behind same API
 - `b00t learn chalk-interner` — load Chalk Interner → b00t DatumStore mapping
 - `b00t learn datum-macro` — load Rust macro → dynamic datum feasibility analysis


### PR DESCRIPTION
## Summary
- CLAUDE.md/AGENTS.md line 138 stated `DatumType` is a "22-variant enum" — re-running the issue's own verification handler (`awk '/pub enum DatumType/,/^}/' b00t-cli/src/datum_types.rs | grep -cE '^\s{4}[A-Z][A-Za-z0-9]*,?$'`) against current `main` confirms the real count is **36**, matching the issue's evidence exactly (still drifted, not yet worse).
- Per the issue's own stated preference, rather than update the hardcoded number to 36 (which will just drift again), the line now points at `b00t-cli/src/datum_types.rs` as the source of truth instead of hand-maintaining a count or abbreviated variant list.

## Audit (per issue's ask)
Scanned CLAUDE.md for other hand-maintained counts/lists referencing code elsewhere in the repo (`(N-variant enum...)`-style phrases, hardcoded crate/subcommand/tool counts, etc.). Found no other instances of this drift pattern. One adjacent claim in the same section ("b00t types are Rust structs/enums in `b00t-cli/src/lib.rs`") was checked too — `lib.rs` does declare `datum_types`/`boot_datum` as submodules of its module tree, so that statement still holds and wasn't changed.

Fixes #933

## Test plan
- [x] Re-ran the issue's exact awk/grep evidence command against current `b00t-cli/src/datum_types.rs` on `origin/main` — confirmed 36 variants (docs-only change, no code/test surface affected)
- [x] `cargo metadata` resolves cleanly; pre-push hook correctly identified no Rust packages affected by this AGENTS.md-only change and skipped the test gate