### PR TITLE
chore: prevent stray root-level test/ dir (fixes #935)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -344,3 +344,9 @@ vendor/pi-mono/
 /target
 vscode.🆚/vscode-docs/
 .worktrees
+
+# Stray root-level test/ dir (#935): bats-core + bats-assert/bats-support
+# clones sometimes get checked out here by accident. The registered
+# submodules live under _b00t_/test/ — this anchored pattern only matches
+# the repo-root-level dir, not _b00t_/test/ or other nested test/ dirs.
+/test/

--- a/b00t-cli/src/commands/doctor_cmd.rs
+++ b/b00t-cli/src/commands/doctor_cmd.rs
@@ -84,6 +84,11 @@ fn all_deps() -> Vec<Value> {
         json!({"id": "gh-api", "check": "curl -sf --max-time 5 -o /dev/null -w '%{http_code}' https://api.github.com/zen 2>/dev/null"}),
         // Skill datum integrity: no loose .skill.* files in _b00t_/
         json!({"id": "skill-symlinks", "check": "cd $HOME/.dotfiles 2>/dev/null && find _b00t_/ -name '*.skill.*' ! -type l 2>/dev/null | wc -l | tr -d ' ' || echo 0"}),
+        // Stray root-level test/ dir (#935): bats-core/bats-assert/bats-support
+        // are registered as submodules under _b00t_/test/ only. A root-level
+        // test/ dir is an untracked, unregistered footgun — a duplicate
+        // checkout that could silently diverge from the real submodule.
+        json!({"id": "no-stray-root-test-dir", "check": "test -d $HOME/.b00t/test && echo FAIL || echo PASS"}),
     ].into_iter().map(|mut v| {
         let check = v.get("check").and_then(|c| c.as_str()).unwrap_or("");
         if !check.is_empty() {
@@ -97,6 +102,14 @@ fn all_deps() -> Vec<Value> {
                     json!("all .skill.* files are symlinks")
                 } else {
                     json!(format!("{} loose .skill.* files in _b00t_/ (must be symlinks to skills/*/SKILL.md)", count))
+                };
+            } else if v["id"] == "no-stray-root-test-dir" {
+                let pass = detail.trim() == "PASS";
+                v["pass"] = json!(pass);
+                v["detail"] = if pass {
+                    json!("no stray root-level test/ dir")
+                } else {
+                    json!("stray $HOME/.b00t/test/ dir present — use _b00t_/test/* submodules instead (#935)")
                 };
             } else {
                 v["pass"] = json!(ok);

--- a/build.sh
+++ b/build.sh
@@ -32,7 +32,9 @@ if [ -z "$(docker ps -q -s -f name=squid)" ] ; then
     sameersbn/squid:3.5.27-2
 fi
 
-./test/bats/bin/bats test/test.bats
+# 🦨 #935: was ./test/bats/bin/bats test/test.bats — that resolved against a
+# root-level test/ dir with no registered submodule; point at the real one.
+./_b00t_/test/bats/bin/bats _b00t_/test/test.bats
 
 @test "can run our script" {
     ./project.sh


### PR DESCRIPTION
## Summary

Issue #935 flagged a stray untracked root-level `test/` directory (pristine bats-core + bats-assert/bats-support clones duplicating the registered submodules at `_b00t_/test/*`) as a live footgun — a test harness resolving `test/bats` instead of `_b00t_/test/bats` would silently run a different bats version.

- The stray directory did **not** exist in this fresh checkout off `origin/main` — it was untracked and specific to a prior session's local working directory.
- Reference grep found one real, live bug: `build.sh` invoked `./test/bats/bin/bats test/test.bats`, a relative path resolving against a root-level `test/` when run from repo root (no submodule registered there). Fixed to point at `_b00t_/test/bats` and `_b00t_/test/test.bats` explicitly.
- Added an anchored `/test/` `.gitignore` entry (repo-root only, doesn't match `_b00t_/test/` or any other nested `test/` dirs) so a future accidental clone there doesn't silently reappear as untracked.
- `b00t doctor` already exists — added a `no-stray-root-test-dir` check to its existing dependency list, matching the issue's own `service_contract` handler.

Fixes #935

## Test plan
- [x] Local pre-push gate passes (1414/1414 non-ignored tests)
- [x] `test -d test && echo FAIL || echo PASS` → PASS

🤖 Generated with Claude Code