### PR TITLE
fix(ci): repair 3 workflows failing on every push to main (fixes #920)

### DIFF
--- a/.github/workflows/b00t-cli-container.yml
+++ b/.github/workflows/b00t-cli-container.yml
@@ -29,7 +29,7 @@ jobs:
           ref: ${{ github.event_name == 'release' && github.event.release.tag_name || github.ref }}
 
       - name: Initialize required submodules
-        run: git submodule update --init --depth 1 vendor/ledgrrr
+        run: git submodule update --init --depth 1 vendor/ledgrrr vendor/runpod-sdk vendor/embed-anything-b00t
 
       - name: Set up Just command runner
         uses: extractions/setup-just@v1

--- a/.github/workflows/b00t-mcp-npm-release.yml
+++ b/.github/workflows/b00t-mcp-npm-release.yml
@@ -49,7 +49,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: 🔧 Initialize required submodules
-        run: git submodule update --init --depth 1 vendor/ledgrrr
+        run: git submodule update --init --depth 1 vendor/ledgrrr vendor/runpod-sdk vendor/embed-anything-b00t
 
       - name: 🦀 Setup Rust
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/b00t-mcp-npm-release.yml
+++ b/.github/workflows/b00t-mcp-npm-release.yml
@@ -48,6 +48,9 @@ jobs:
       - name: 📥 Checkout code
         uses: actions/checkout@v4
 
+      - name: 🔧 Initialize required submodules
+        run: git submodule update --init --depth 1 vendor/ledgrrr
+
       - name: 🦀 Setup Rust
         uses: dtolnay/rust-toolchain@stable
         with:

--- a/.github/workflows/copilot-review.yml
+++ b/.github/workflows/copilot-review.yml
@@ -1,10 +1,16 @@
 name: copilot-pr-review
 
+# Disabled (dispatch-only) — see #920.
+# `pull_request_review_request:` is not a real GitHub Actions event (the real
+# mechanism is `pull_request: types: [..., review_requested]`), so GitHub
+# rejected this entire workflow file with a 0s "workflow file issue" failure
+# on every push to main. Even fixed, the job body below shells out to
+# `gh copilot explain`, which needs a Copilot-entitled token — no such PAT is
+# configured in this repo's secrets (only CARGO_REGISTRY_TOKEN is), and
+# GitHub's native App-based "Copilot code review" workflow already covers PR
+# review. Re-enable only if a Copilot-entitled PAT is deliberately added.
 on:
-  pull_request:
-    types: [opened, synchronize, reopened]
-  pull_request_review_request:
-    types: [requested]
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/Dockerfile.b00t-cli
+++ b/Dockerfile.b00t-cli
@@ -55,8 +55,11 @@ COPY b00t-zellij/ ./b00t-zellij/
 COPY blessed/ ./blessed/
 COPY k0mmand3r/ ./k0mmand3r/
 COPY pm2-tasker/ ./pm2-tasker/
+COPY vendor/embed-anything-b00t/rust/ ./vendor/embed-anything-b00t/rust/
+COPY vendor/embed-anything-b00t/processors/ ./vendor/embed-anything-b00t/processors/
 COPY vendor/irontology-mcp/ ./vendor/irontology-mcp/
 COPY vendor/ledgrrr/crates/b00t-reflect-types/ ./vendor/ledgrrr/crates/b00t-reflect-types/
+COPY vendor/runpod-sdk/ ./vendor/runpod-sdk/
 COPY vendor/tomllm/ ./vendor/tomllm/
 
 # Build only the shipping binaries. `just install` is interactive, bumps versions,

--- a/Dockerfile.b00t-cli
+++ b/Dockerfile.b00t-cli
@@ -8,7 +8,7 @@ FROM ghcr.io/elasticdotventures/just:latest AS just-binary
 # ================================
 # Stage 1: Rust Build Environment
 # ================================
-FROM rust:1.91-slim AS rust-builder
+FROM rust:1.96-slim AS rust-builder
 
 # Copy just from forked container
 COPY --from=just-binary /usr/local/bin/just /usr/local/bin/just

--- a/Dockerfile.b00t-cli
+++ b/Dockerfile.b00t-cli
@@ -14,10 +14,13 @@ FROM rust:1.91-slim AS rust-builder
 COPY --from=just-binary /usr/local/bin/just /usr/local/bin/just
 
 # Install build dependencies
-# `perl` (not just the slim image's preinstalled perl-base) and `make` are
-# required because openssl-sys vendors and builds OpenSSL from source here:
-# Configure needs FindBin.pm (perl-base doesn't ship it), and the subsequent
-# `make depend` step needs make, which rust:slim doesn't include.
+# `perl` (not just the slim image's preinstalled perl-base) is required
+# because openssl-sys vendors and builds OpenSSL from source here, and its
+# Configure script needs FindBin.pm, which perl-base doesn't ship.
+# `build-essential` (make, gcc, g++, libc headers) is required because
+# rust:slim ships no native toolchain at all, and b00t-cli depends on
+# b00t-embed -> embed_anything, whose transitive deps (e.g. esaxx-rs) build
+# native C/C++ code.
 RUN apt-get update && apt-get install -y \
     pkg-config \
     libssl-dev \
@@ -25,7 +28,7 @@ RUN apt-get update && apt-get install -y \
     python3 \
     python3-dev \
     perl \
-    make \
+    build-essential \
     && rm -rf /var/lib/apt/lists/*
 
 # Set working directory for the Rust project

--- a/Dockerfile.b00t-cli
+++ b/Dockerfile.b00t-cli
@@ -28,24 +28,35 @@ WORKDIR /build
 # Copy workspace root and required workspace members/vendor crates
 COPY Cargo.toml Cargo.lock ./
 COPY _b00t_/ ./_b00t_/
+COPY b00t-admin/ ./b00t-admin/
 COPY b00t-ast/ ./b00t-ast/
 COPY b00t-azure-cp/ ./b00t-azure-cp/
 COPY b00t-bouncer/ ./b00t-bouncer/
+COPY b00t-cad/ ./b00t-cad/
 COPY b00t-cli/ ./b00t-cli/
+COPY b00t-crate/ ./b00t-crate/
 COPY b00t-c0re-a2a/ ./b00t-c0re-a2a/
 COPY b00t-c0re-gov/ ./b00t-c0re-gov/
 COPY b00t-c0re-hierarchy/ ./b00t-c0re-hierarchy/
 COPY b00t-c0re-lib/ ./b00t-c0re-lib/
+COPY b00t-datum-core/ ./b00t-datum-core/
+COPY b00t-embed/ ./b00t-embed/
 COPY b00t-grok/ ./b00t-grok/
 COPY b00t-ipc/ ./b00t-ipc/
 COPY b00t-l3dg3rr-viz/ ./b00t-l3dg3rr-viz/
 COPY b00t-lib-chat/ ./b00t-lib-chat/
+COPY b00t-lsp/ ./b00t-lsp/
 COPY b00t-mcp/ ./b00t-mcp/
 COPY b00t-mcp-npm/ ./b00t-mcp-npm/
+COPY b00t-mermaid-wasm/ ./b00t-mermaid-wasm/
 COPY b00t-pyverse/ ./b00t-pyverse/
+COPY b00t-ui-wasm/ ./b00t-ui-wasm/
+COPY b00t-zellij/ ./b00t-zellij/
+COPY blessed/ ./blessed/
 COPY k0mmand3r/ ./k0mmand3r/
 COPY pm2-tasker/ ./pm2-tasker/
 COPY vendor/irontology-mcp/ ./vendor/irontology-mcp/
+COPY vendor/ledgrrr/crates/b00t-reflect-types/ ./vendor/ledgrrr/crates/b00t-reflect-types/
 COPY vendor/tomllm/ ./vendor/tomllm/
 
 # Build only the shipping binaries. `just install` is interactive, bumps versions,

--- a/Dockerfile.b00t-cli
+++ b/Dockerfile.b00t-cli
@@ -14,9 +14,10 @@ FROM rust:1.91-slim AS rust-builder
 COPY --from=just-binary /usr/local/bin/just /usr/local/bin/just
 
 # Install build dependencies
-# `perl` (not just the slim image's preinstalled perl-base) is required because
-# openssl-sys vendors and builds OpenSSL from source here, and its Configure
-# script needs FindBin.pm, which perl-base does not ship.
+# `perl` (not just the slim image's preinstalled perl-base) and `make` are
+# required because openssl-sys vendors and builds OpenSSL from source here:
+# Configure needs FindBin.pm (perl-base doesn't ship it), and the subsequent
+# `make depend` step needs make, which rust:slim doesn't include.
 RUN apt-get update && apt-get install -y \
     pkg-config \
     libssl-dev \
@@ -24,6 +25,7 @@ RUN apt-get update && apt-get install -y \
     python3 \
     python3-dev \
     perl \
+    make \
     && rm -rf /var/lib/apt/lists/*
 
 # Set working directory for the Rust project

--- a/Dockerfile.b00t-cli
+++ b/Dockerfile.b00t-cli
@@ -14,12 +14,16 @@ FROM rust:1.91-slim AS rust-builder
 COPY --from=just-binary /usr/local/bin/just /usr/local/bin/just
 
 # Install build dependencies
+# `perl` (not just the slim image's preinstalled perl-base) is required because
+# openssl-sys vendors and builds OpenSSL from source here, and its Configure
+# script needs FindBin.pm, which perl-base does not ship.
 RUN apt-get update && apt-get install -y \
     pkg-config \
     libssl-dev \
     ca-certificates \
     python3 \
     python3-dev \
+    perl \
     && rm -rf /var/lib/apt/lists/*
 
 # Set working directory for the Rust project


### PR DESCRIPTION
## Summary

Three workflows were failing on every push to main: `copilot-review.yml` (0s, invalid trigger config), `b00t-mcp NPM Release` (missing vendor submodule init), and `Build and Publish b00t-cli Container` (stale COPY list + outdated rustc).

## Fixes

1. **`copilot-review.yml` → `workflow_dispatch`-only.** The `on:` block had an invalid trigger key (`pull_request_review_request` isn't a real GitHub Actions event — the real form is `pull_request: types: [review_requested]`), causing an instant "workflow file issue" failure on every push before any job started. Even fixed, the job runs `gh copilot explain`, which needs a Copilot-entitled credential this repo doesn't have (only `CARGO_REGISTRY_TOKEN` is configured), and GitHub's native "Copilot code review" App already covers PR review here. Disabled with a comment explaining why; re-enable only if a Copilot PAT is deliberately added.

2. **`b00t-mcp-npm-release.yml`**: missing submodule init. Root `Cargo.toml`'s workspace dependencies eagerly resolve `vendor/ledgrrr`, `vendor/runpod-sdk`, and `vendor/embed-anything-b00t` regardless of which package is being built — none were initialized on this runner. Added the init step.

3. **`Dockerfile.b00t-cli`**: two compounding issues.
   - Stale `COPY` list: ~11 newer workspace member directories (`b00t-admin`, `b00t-crate`, `b00t-embed`, etc.) plus the 3 vendor path deps above were never added as the workspace grew, so the manifest couldn't resolve inside the build context. Added the missing `COPY` lines.
   - `perl`/`build-essential`/`make` missing from the builder's apt install (needed for `openssl-sys` and `esaxx-rs` native builds).
   - `rust:1.91-slim` base image too old: `kstring@2.0.4` requires rustc 1.96.0. Bumped to `rust:1.96-slim`.

## Validation

- `copilot-review.yml`: confirmed still `state: active` via `gh api`, no longer fires on push.
- `Dockerfile.b00t-cli`: full local `podman build` — all 24 steps complete, image tagged, `b00t-cli --version`/`status --help` and `b00t-mcp --version` confirmed working, bundled `_b00t_` datums/scripts/learn content verified present.
- `b00t-mcp-npm-release.yml`: submodule init step verified against the same 3-submodule requirement confirmed for `ci.yml` (#948) and the container build here.

## Follow-up filed

#944 — `strip-nsfw-from-upstream.yml` also fails (weekly cron, missing `PAT_TOKEN` secret) but isn't one of the 3 named in this issue and isn't push-triggered; tracked separately per the issue's "no workflow left failing without a tracking issue" rule.

Fixes #920

🤖 Generated with Claude Code