### PR TITLE
feat(b00t-cli): ground DatumType/BootDatum in ufo-types (closes #925, closes #926)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1680,6 +1680,7 @@ dependencies = [
  "tokio",
  "toml 1.1.2+spec-1.1.0",
  "tracing",
+ "ufo-types",
  "url",
  "uuid",
  "walkdir",

--- a/b00t-cli/Cargo.toml
+++ b/b00t-cli/Cargo.toml
@@ -48,6 +48,7 @@ b00t-bouncer = { path = "../b00t-bouncer" }
 blessed = { path = "../blessed" }
 b00t-grok = { workspace = true }
 k0mmand3r = { workspace = true }
+ufo-types = { workspace = true }
 openssl-sys = { workspace = true }
 duct = "1.0"
 shellexpand = "3.1"

--- a/b00t-cli/src/boot_datum.rs
+++ b/b00t-cli/src/boot_datum.rs
@@ -2,6 +2,7 @@ use std::collections::HashSet;
 use std::sync::OnceLock;
 
 use serde::{Deserialize, Deserializer, Serialize};
+use ufo_types::{Stereotyped, UfoStereotype};
 
 use crate::{
     ComposeConfig, DatumType, GateSpec, InstallSpec, JustfileConfig, K0mmand3rDatumConfig,
@@ -311,6 +312,19 @@ impl BootDatum {
     }
 }
 
+impl Stereotyped for BootDatum {
+    /// Delegates to `DatumType`'s lattice (#925) — this impl declares no
+    /// mapping of its own. Missing/unrecognized type degrades to
+    /// `Kind("Unknown")` — never panics, per Postel's Law (CLAUDE.md:
+    /// "be liberal in what you accept"). BootDatum is an open struct; the
+    /// stereotype is derived from the *declared* type, never field presence.
+    fn ufo_stereotype(&self) -> UfoStereotype {
+        self.datum_type
+            .map(|dt| dt.ufo_stereotype())
+            .unwrap_or_else(|| UfoStereotype::Kind("Unknown".into()))
+    }
+}
+
 /// Scans `dir` (non-recursive) for datum files and loads them into a
 /// `{name}.{type_prefix}` -> `BootDatum` map. The single shared
 /// implementation of the scan itself for `install`/`uninstall`/`stack`/
@@ -479,5 +493,36 @@ mod load_all_datums_tests {
         let path = temp_dir.path().to_str().unwrap();
         let datums = load_all_datums(path).unwrap();
         assert_eq!(datums.len(), 0);
+    }
+}
+
+#[cfg(test)]
+mod stereotype_tests {
+    use super::*;
+
+    #[test]
+    fn stereotype_degrades_to_unknown_for_untyped_datum() {
+        let d = BootDatum {
+            name: "synthetic".into(),
+            datum_type: None,
+            ..Default::default()
+        };
+        assert_eq!(d.ufo_stereotype(), UfoStereotype::Kind("Unknown".into()));
+    }
+
+    #[test]
+    fn stereotype_delegates_to_datum_type() {
+        let d = BootDatum {
+            name: "x".into(),
+            datum_type: Some(DatumType::Docker),
+            ..Default::default()
+        };
+        assert_eq!(
+            d.ufo_stereotype(),
+            UfoStereotype::SubKind {
+                name: "Docker".into(),
+                parent: "ContainerRuntime".into()
+            }
+        );
     }
 }

--- a/b00t-cli/src/commands/ontology.rs
+++ b/b00t-cli/src/commands/ontology.rs
@@ -5,6 +5,9 @@ use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::Path;
 use std::process::Command;
+use ufo_types::Stereotyped;
+
+use crate::DatumType;
 
 #[derive(Parser, Debug)]
 pub enum OntologyCommands {
@@ -277,6 +280,9 @@ pub fn sparql_query(
         match predicate {
             "type" | "b00t:type" => {
                 triples.push(emit("b00t:type", &datum.b00t.datum_type));
+                let dt = DatumType::from_type_token(&datum.b00t.datum_type)
+                    .unwrap_or(DatumType::Unknown);
+                triples.push(emit("ufo:stereotype", &dt.ufo_stereotype().to_string()));
             }
             "roles" | "b00t:roles" => {
                 for r in &datum.roles.required_for {
@@ -294,6 +300,9 @@ pub fn sparql_query(
             _ => {
                 // "all" or unknown — emit all predicates
                 triples.push(emit("b00t:type", &datum.b00t.datum_type));
+                let dt = DatumType::from_type_token(&datum.b00t.datum_type)
+                    .unwrap_or(DatumType::Unknown);
+                triples.push(emit("ufo:stereotype", &dt.ufo_stereotype().to_string()));
                 for r in &datum.roles.required_for {
                     triples.push(emit("b00t:requiredFor", r));
                 }
@@ -531,6 +540,15 @@ optional_for = []
         assert_eq!(triples[0][0], "rust");
         assert_eq!(triples[0][1], "b00t:type");
         assert_eq!(triples[0][2], "cli");
+
+        // ufo:stereotype triple (#926) — Cli is a SubKind of Executable.
+        // NOTE: the vendored ufo_types::UfoStereotype Display impl for SubKind
+        // has a real upstream bug (missing closing '>'), so the expected
+        // string is "SubKind:Cli<Executable" with no trailing '>'. This is
+        // NOT fixed here — see PR description.
+        assert_eq!(triples[1][0], "rust");
+        assert_eq!(triples[1][1], "ufo:stereotype");
+        assert_eq!(triples[1][2], "SubKind:Cli<Executable");
 
         let triples2 = sparql_query(Some("rust"), "roles", dir.path().to_str().unwrap()).unwrap();
         assert!(

--- a/b00t-cli/src/datum_types.rs
+++ b/b00t-cli/src/datum_types.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use ufo_types::{Stereotyped, UfoStereotype};
 
 // ── DatumType — b00t's typed datum registry ────────────────────────────────
 // 🤓 single source of truth: add new variants ONLY here. The macro below derives:
@@ -218,6 +219,14 @@ impl DatumType {
 
     /// Stereotype hierarchy: which types does this type imply?
     /// e.g. McpServer implies Mcp (server → protocol), Runtime implies Cli (can run → can check)
+    ///
+    /// 🤓 NOT the same relation as [`ufo_stereotype()`](Stereotyped::ufo_stereotype)'s
+    ///    Kind/SubKind lattice below. `implies()` is capability entailment
+    ///    ("having this type means you also have that capability"); the UFO
+    ///    lattice is structural subtyping (Guizzardi 2005 §4.2.1–4.2.2). The
+    ///    two may diverge — see `ufo_stereotype()`'s doc comment for the
+    ///    inverse cross-reference and the one point where they're pinned to
+    ///    agree (`McpServer`).
     pub const fn implies(&self) -> &'static [DatumType] {
         match self {
             Self::McpServer => &[Self::Mcp],
@@ -235,6 +244,74 @@ impl DatumType {
     }
 
     // 🎨 display() defined below with DatumDisplay struct
+}
+
+impl Stereotyped for DatumType {
+    /// UFO Kind/SubKind lattice for datum types (Guizzardi 2005 §4.2.1–4.2.2).
+    /// 🤓 SINGLE SOURCE OF TRUTH — this is the ONLY place the lattice is
+    ///    declared. Callers (ontology sparql, BootDatum) delegate here;
+    ///    do not re-derive parent/child relationships anywhere else.
+    ///
+    /// Most variants are their own rigid Kind. Only variants with a clear,
+    /// pre-existing structural relationship are modeled as SubKind. This is
+    /// a DIFFERENT, stricter relation than `implies()` above (capability
+    /// entailment) — they may diverge; see `implies()`'s doc comment.
+    fn ufo_stereotype(&self) -> UfoStereotype {
+        match self {
+            // ── container/orchestration engines — SubKind of abstract ContainerRuntime ──
+            Self::Docker => UfoStereotype::SubKind {
+                name: "Docker".into(),
+                parent: "ContainerRuntime".into(),
+            },
+            Self::Podman => UfoStereotype::SubKind {
+                name: "Podman".into(),
+                parent: "ContainerRuntime".into(),
+            },
+            Self::K8s => UfoStereotype::SubKind {
+                name: "K8s".into(),
+                parent: "ContainerRuntime".into(),
+            },
+
+            // ── executable surface — SubKind of abstract Executable ─────────────────────
+            Self::Cli => UfoStereotype::SubKind {
+                name: "Cli".into(),
+                parent: "Executable".into(),
+            },
+            Self::Bash => UfoStereotype::SubKind {
+                name: "Bash".into(),
+                parent: "Executable".into(),
+            },
+            Self::Justfile => UfoStereotype::SubKind {
+                name: "Justfile".into(),
+                parent: "Executable".into(),
+            },
+
+            // ── package managers — SubKind of abstract PackageManager ───────────────────
+            Self::Apt => UfoStereotype::SubKind {
+                name: "Apt".into(),
+                parent: "PackageManager".into(),
+            },
+            Self::Nix => UfoStereotype::SubKind {
+                name: "Nix".into(),
+                parent: "PackageManager".into(),
+            },
+
+            // ── MCP: McpServer is-a Mcp (matches implies(): McpServer => [Mcp]) ──────────
+            // Deliberately using Mcp itself as parent (not inventing an abstract "MCP"
+            // label) — Mcp is already a real, addressable Kind elsewhere in the codebase;
+            // a third parallel label would duplicate it (see #905's warning against
+            // parallel vocabularies).
+            Self::McpServer => UfoStereotype::SubKind {
+                name: "McpServer".into(),
+                parent: "Mcp".into(),
+            },
+
+            // ── everything else: rigid Kind, name = variant name (Debug format gives
+            //    exact variant name for fieldless enum variants — zero maintenance,
+            //    stays in sync automatically as variants are added) ────────────────────
+            other => UfoStereotype::Kind(format!("{other:?}")),
+        }
+    }
 }
 
 macro_rules! datum_type_table {
@@ -419,5 +496,69 @@ impl DatumDisplay {
             "icon": self.icon,
             "css_class": self.css_class,
         })
+    }
+}
+
+#[cfg(test)]
+mod ufo_stereotype_tests {
+    use super::*;
+
+    #[test]
+    fn every_variant_produces_a_stereotype_without_panicking() {
+        for v in DatumType::all_variants() {
+            let _ = v.ufo_stereotype();
+        }
+        let _ = DatumType::Unknown.ufo_stereotype();
+    }
+
+    #[test]
+    fn container_orchestration_cluster_shares_parent() {
+        for v in [DatumType::Docker, DatumType::Podman, DatumType::K8s] {
+            match v.ufo_stereotype() {
+                UfoStereotype::SubKind { parent, .. } => assert_eq!(parent, "ContainerRuntime"),
+                other => panic!("expected SubKind for {v:?}, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn executable_cluster_shares_parent() {
+        for v in [DatumType::Cli, DatumType::Bash, DatumType::Justfile] {
+            match v.ufo_stereotype() {
+                UfoStereotype::SubKind { parent, .. } => assert_eq!(parent, "Executable"),
+                other => panic!("expected SubKind for {v:?}, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn package_manager_cluster_shares_parent() {
+        for v in [DatumType::Apt, DatumType::Nix] {
+            match v.ufo_stereotype() {
+                UfoStereotype::SubKind { parent, .. } => assert_eq!(parent, "PackageManager"),
+                other => panic!("expected SubKind for {v:?}, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn mcp_server_is_subkind_of_mcp_matching_implies() {
+        // Pins the one point where implies() and the lattice coincide.
+        assert_eq!(DatumType::McpServer.implies(), &[DatumType::Mcp]);
+        assert_eq!(
+            DatumType::McpServer.ufo_stereotype(),
+            UfoStereotype::SubKind {
+                name: "McpServer".into(),
+                parent: "Mcp".into()
+            }
+        );
+    }
+
+    #[test]
+    fn unknown_is_plain_kind() {
+        assert_eq!(
+            DatumType::Unknown.ufo_stereotype(),
+            UfoStereotype::Kind("Unknown".into())
+        );
     }
 }


### PR DESCRIPTION
## Summary

Implements #925 and #926 together — they're tightly coupled and neither compiles independently (BootDatum's stereotype delegates to DatumType's lattice).

- **#925**: `DatumType` now implements `ufo_types::Stereotyped`, grounding its 36 variants in a UFO Kind/SubKind lattice (Guizzardi 2005 §4.2.1–4.2.2) instead of a flat enum. This is the single source of truth — no other code re-derives parent/child relationships.
  - Container/orchestration engines (`Docker`, `Podman`, `K8s`) → SubKind of `ContainerRuntime`
  - Executable surface (`Cli`, `Bash`, `Justfile`) → SubKind of `Executable`
  - Package managers (`Apt`, `Nix`) → SubKind of `PackageManager`
  - `McpServer` → SubKind of `Mcp` (mirrors `implies()`'s `McpServer => [Mcp]`)
  - Everything else → rigid `Kind(variant_name)`
- **#926**: Adds the `ufo-types` dependency to `b00t-cli` and implements `Stereotyped` for `BootDatum`, delegating to `DatumType`'s lattice. Untyped/unrecognized datums degrade to `Kind("Unknown")` rather than panicking (Postel's Law). Also wires `ontology sparql --predicate type` to emit a new `ufo:stereotype` triple alongside the existing `b00t:type` triple.

### Deviations from #925's literal sketch

- **Mcp-as-parent**: rather than inventing a new abstract "MCP" label for `McpServer`'s parent, this uses `Mcp` itself — it's already a real, addressable `Kind` elsewhere in the codebase, and a parallel label would duplicate it (per #905's warning against parallel vocabularies).
- **`implies()` vs the lattice**: these are kept as two distinct, cross-referenced relations rather than merged. `implies()` is capability entailment (pre-existing, used elsewhere); `ufo_stereotype()`'s SubKind is UFO structural subtyping. They may diverge in principle — a regression test (`mcp_server_is_subkind_of_mcp_matching_implies`) pins the one point where they currently agree.

### Known upstream quirk (not fixed here)

The vendored `ufo_types::UfoStereotype` `Display` impl for `SubKind` has a real bug — `write!(f, "SubKind:{name}<{parent}")` is missing the closing `>`, so `.to_string()` produces e.g. `"SubKind:Cli<Executable"` with no trailing `>`. This is confirmed in the external crate's own test suite (it asserts the same truncated string), so it's an intentional-looking bug upstream, not a typo introduced here. Not patched in this PR since `ufo-types` is pinned via git tag (`v0.10.2`) as an external dependency — tests in this PR assert the actual (buggy) output.

## Test plan

- [x] `cargo build -p b00t-cli` — clean build
- [x] `cargo test -p b00t-cli --lib` — 1425 passed, 0 failed (full suite, includes new tests)
- [x] New tests: `datum_types::ufo_stereotype_tests::*` (6 tests), `boot_datum::stereotype_tests::*` (2 tests), `commands::ontology::tests::test_sparql_query_with_datum` (extended) — all pass
- [x] Manual e2e: built the release binary and ran `ontology sparql --subject ansible --predicate type` against the real `_b00t_/` directory — confirmed both `b00t:type` and `ufo:stereotype` triples appear, e.g. `["ansible", "ufo:stereotype", "SubKind:Cli<Executable"]`
- [x] Pre-push gate: full 1425-test suite passed

Closes #925
Closes #926

🤖 Generated with [Claude Code](https://claude.com/claude-code)