### PR TITLE
refactor(b00t-cli): extract shared FilterLogic/TryFrom defaults for Docker/K8s/Podman (fixes #865)

### DIFF
--- a/b00t-cli/src/datum_docker.rs
+++ b/b00t-cli/src/datum_docker.rs
@@ -125,14 +125,6 @@ impl DockerDatum {
     }
 }
 
-impl TryFrom<(&str, &str)> for DockerDatum {
-    type Error = anyhow::Error;
-
-    fn try_from((name, path): (&str, &str)) -> Result<Self, Self::Error> {
-        Self::from_config(name, path)
-    }
-}
-
 impl DatumChecker for DockerDatum {
     fn is_installed(&self) -> bool {
         // Docker containers are "installed" if:
@@ -197,7 +189,7 @@ impl StatusProvider for DockerDatum {
 
 impl FilterLogic for DockerDatum {
     fn is_available(&self) -> bool {
-        !DatumChecker::is_installed(self) && self.prerequisites_satisfied()
+        self.is_available_default()
     }
 
     fn prerequisites_satisfied(&self) -> bool {
@@ -215,14 +207,4 @@ impl FilterLogic for DockerDatum {
     }
 }
 
-impl ConstraintEvaluator for DockerDatum {
-    fn datum(&self) -> &BootDatum {
-        &self.datum
-    }
-}
-
-impl DatumProvider for DockerDatum {
-    fn datum(&self) -> &BootDatum {
-        &self.datum
-    }
-}
+crate::impl_boot_datum_accessors!(DockerDatum);

--- a/b00t-cli/src/datum_k8s.rs
+++ b/b00t-cli/src/datum_k8s.rs
@@ -71,14 +71,6 @@ impl K8sDatum {
     }
 }
 
-impl TryFrom<(&str, &str)> for K8sDatum {
-    type Error = anyhow::Error;
-
-    fn try_from((name, path): (&str, &str)) -> Result<Self, Self::Error> {
-        Self::from_config(name, path)
-    }
-}
-
 impl DatumChecker for K8sDatum {
     fn is_installed(&self) -> bool {
         // K8s charts are "installed" if:
@@ -156,7 +148,7 @@ impl StatusProvider for K8sDatum {
 
 impl FilterLogic for K8sDatum {
     fn is_available(&self) -> bool {
-        !DatumChecker::is_installed(self) && self.prerequisites_satisfied()
+        self.is_available_default()
     }
 
     fn prerequisites_satisfied(&self) -> bool {
@@ -174,17 +166,7 @@ impl FilterLogic for K8sDatum {
     }
 }
 
-impl ConstraintEvaluator for K8sDatum {
-    fn datum(&self) -> &BootDatum {
-        &self.datum
-    }
-}
-
-impl DatumProvider for K8sDatum {
-    fn datum(&self) -> &BootDatum {
-        &self.datum
-    }
-}
+crate::impl_boot_datum_accessors!(K8sDatum);
 
 /// Sync all datum files to k8s ConfigMaps in the given namespace.
 ///

--- a/b00t-cli/src/datum_podman.rs
+++ b/b00t-cli/src/datum_podman.rs
@@ -62,14 +62,6 @@ impl PodmanDatum {
     }
 }
 
-impl TryFrom<(&str, &str)> for PodmanDatum {
-    type Error = anyhow::Error;
-
-    fn try_from((name, path): (&str, &str)) -> Result<Self, Self::Error> {
-        Self::from_config(name, path)
-    }
-}
-
 impl DatumChecker for PodmanDatum {
     fn is_installed(&self) -> bool {
         check_command_available("podman") && (self.is_deployed() || self.is_manifest_available())
@@ -127,7 +119,7 @@ impl StatusProvider for PodmanDatum {
 
 impl FilterLogic for PodmanDatum {
     fn is_available(&self) -> bool {
-        !DatumChecker::is_installed(self) && self.prerequisites_satisfied()
+        self.is_available_default()
     }
 
     fn prerequisites_satisfied(&self) -> bool {
@@ -143,17 +135,7 @@ impl FilterLogic for PodmanDatum {
     }
 }
 
-impl ConstraintEvaluator for PodmanDatum {
-    fn datum(&self) -> &BootDatum {
-        &self.datum
-    }
-}
-
-impl DatumProvider for PodmanDatum {
-    fn datum(&self) -> &BootDatum {
-        &self.datum
-    }
-}
+crate::impl_boot_datum_accessors!(PodmanDatum);
 
 #[cfg(test)]
 mod tests {

--- a/b00t-cli/src/traits.rs
+++ b/b00t-cli/src/traits.rs
@@ -111,6 +111,19 @@ pub trait FilterLogic {
     fn evaluate_constraints(&self, require: &[String]) -> bool;
 }
 
+/// Shared default for `FilterLogic::is_available`: "not installed AND
+/// prerequisites satisfied." Mirrors `ConstraintEvaluator::evaluate_constraints_default`
+/// — implement the type-specific pieces (`DatumChecker::is_installed`,
+/// `FilterLogic::prerequisites_satisfied`), delegate `is_available` to this.
+/// NOT every `FilterLogic` impl wants this semantics (some diverge deliberately)
+/// — opt in per type, don't force it via a supertrait bound.
+pub trait AvailabilityEvaluator: DatumChecker + FilterLogic {
+    fn is_available_default(&self) -> bool {
+        !DatumChecker::is_installed(self) && FilterLogic::prerequisites_satisfied(self)
+    }
+}
+impl<T: DatumChecker + FilterLogic> AvailabilityEvaluator for T {}
+
 pub trait DatumProvider: DatumChecker + StatusProvider + FilterLogic + Send + Sync {
     /// Used by ConstraintEvaluator trait methods (compiler doesn't detect indirect usage)
     #[allow(dead_code)]
@@ -226,6 +239,36 @@ pub trait ConstraintEvaluator {
                 .unwrap_or(false) // Unknown constraints → fail-closed
         })
     }
+}
+
+/// Generates `TryFrom<(&str, &str)>` (delegating to `Self::from_config`) plus the
+/// `ConstraintEvaluator`/`DatumProvider` `datum()` accessors, for datum types whose
+/// state is a single `datum: BootDatum` field. Does NOT touch `from_config` itself
+/// (type-specific per datum type) or `StatusProvider`/`DatumChecker` (genuinely
+/// type-specific) — those stay hand-written per file.
+#[macro_export]
+macro_rules! impl_boot_datum_accessors {
+    ($ty:ty) => {
+        impl TryFrom<(&str, &str)> for $ty {
+            type Error = anyhow::Error;
+
+            fn try_from((name, path): (&str, &str)) -> Result<Self, Self::Error> {
+                Self::from_config(name, path)
+            }
+        }
+
+        impl $crate::traits::ConstraintEvaluator for $ty {
+            fn datum(&self) -> &$crate::BootDatum {
+                &self.datum
+            }
+        }
+
+        impl $crate::traits::DatumProvider for $ty {
+            fn datum(&self) -> &$crate::BootDatum {
+                &self.datum
+            }
+        }
+    };
 }
 
 // ── Sandbox type hierarchy ────────────────────────────────────────────────────

--- a/b00t-cli/tests/filter_logic_defaults_test.rs
+++ b/b00t-cli/tests/filter_logic_defaults_test.rs
@@ -1,0 +1,64 @@
+//! Tests for the shared `AvailabilityEvaluator`/`impl_boot_datum_accessors!`
+//! extraction (#865) — proves the Docker/K8s/Podman datum types still behave
+//! identically after deduplicating their `FilterLogic::is_available` bodies
+//! and `TryFrom`/`ConstraintEvaluator`/`DatumProvider` boilerplate into
+//! shared trait defaults + a macro. Pure refactor: no behavior change.
+
+use b00t_cli::datum_docker::DockerDatum;
+use b00t_cli::datum_k8s::K8sDatum;
+use b00t_cli::datum_podman::PodmanDatum;
+use b00t_cli::traits::{AvailabilityEvaluator, DatumChecker, FilterLogic};
+use b00t_cli::BootDatum;
+
+/// Compile-time proof: all three container datum types implement
+/// `AvailabilityEvaluator` via the blanket impl (`DatumChecker + FilterLogic`).
+#[test]
+fn all_three_types_implement_availability_evaluator() {
+    fn assert_impl<T: AvailabilityEvaluator>() {}
+    assert_impl::<DockerDatum>();
+    assert_impl::<K8sDatum>();
+    assert_impl::<PodmanDatum>();
+}
+
+fn fixture_datum(name: &str) -> BootDatum {
+    BootDatum {
+        name: name.into(),
+        hint: "test".into(),
+        ..Default::default()
+    }
+}
+
+/// Behavioral proof: `FilterLogic::is_available()` for each type still equals
+/// the independently-computed `!is_installed() && prerequisites_satisfied()`
+/// — i.e. delegating to `AvailabilityEvaluator::is_available_default()`
+/// changed nothing observable. Builds datum structs directly (no
+/// `from_config`/CLI shell-out), so no real docker/kubectl/helm/podman
+/// binaries are required and no `#[ignore]` is needed — mirrors the direct
+/// struct-construction pattern already used by
+/// `datum_podman.rs`'s `manifest_path_none_without_resource_path` test.
+#[test]
+fn is_available_matches_independent_computation_docker() {
+    let datum = DockerDatum {
+        datum: fixture_datum("docker-fixture"),
+    };
+    let expected = !DatumChecker::is_installed(&datum) && datum.prerequisites_satisfied();
+    assert_eq!(FilterLogic::is_available(&datum), expected);
+}
+
+#[test]
+fn is_available_matches_independent_computation_k8s() {
+    let datum = K8sDatum {
+        datum: fixture_datum("k8s-fixture"),
+    };
+    let expected = !DatumChecker::is_installed(&datum) && datum.prerequisites_satisfied();
+    assert_eq!(FilterLogic::is_available(&datum), expected);
+}
+
+#[test]
+fn is_available_matches_independent_computation_podman() {
+    let datum = PodmanDatum {
+        datum: fixture_datum("podman-fixture"),
+    };
+    let expected = !DatumChecker::is_installed(&datum) && datum.prerequisites_satisfied();
+    assert_eq!(FilterLogic::is_available(&datum), expected);
+}


### PR DESCRIPTION
## Summary

`DockerDatum`, `K8sDatum`, and `PodmanDatum` (`b00t-cli/src/datum_docker.rs`, `datum_k8s.rs`, `datum_podman.rs`) shared five byte-identical impl blocks:
- `TryFrom<(&str, &str)>` (delegates to `Self::from_config`)
- `StatusProvider::name()` / `hint()`
- `FilterLogic::is_available()` — `!is_installed() && prerequisites_satisfied()`
- `FilterLogic::evaluate_constraints()` — already delegated to `evaluate_constraints_default` (no change needed)
- `ConstraintEvaluator::datum()` / `DatumProvider::datum()` accessors

This PR extracts the duplicated pieces into `b00t-cli/src/traits.rs`:
- A new `AvailabilityEvaluator` mixin trait with a blanket impl over `DatumChecker + FilterLogic`, providing `is_available_default()`. Each type's `FilterLogic::is_available()` now delegates to it instead of repeating the inline predicate. This is opt-in per type (not a supertrait bound) since not every `FilterLogic` impl wants this semantics.
- A new `impl_boot_datum_accessors!` macro (following the existing `datum_type_table!` macro idiom in `datum_types.rs`) that generates the `TryFrom` wrapper plus the `ConstraintEvaluator`/`DatumProvider` `datum()` accessors for datum types with a single `datum: BootDatum` field.

**Left untouched** (genuinely type-specific, confirmed by direct inspection):
- `subsystem()` string, `is_disabled()` predicate, `prerequisites_satisfied()` body
- `from_config()` body — `DockerDatum::from_config` does extra env-merging (`config.env` → `datum.env`) that `K8sDatum`/`PodmanDatum` don't do, so only the `TryFrom` *wrapper* was safe to deduplicate
- `StatusProvider::name()`/`hint()` stay hand-written in each file — they're two identical lines inside an impl block whose other methods (`subsystem()`, `is_disabled()`) are type-specific, so macro'ing them wasn't worth fragmenting the block

This is a pure, behavior-preserving refactor. No `FilterLogic`/`TryFrom`/accessor logic changed — only where the code lives.

## Follow-up opportunities (not in this PR)

- The `is_available`/`evaluate_constraints` pattern is also identical across 8 other datum types (`AiDatum`, `AptDatum`, `BashDatum`, `DatabaseDatum`, `McpDatum`, `RepoDatum`, `VscodeDatum`, `ModelDatumEntry`). `AvailabilityEvaluator`/`impl_boot_datum_accessors!` were designed so those types could opt in later without redesign, but that's out of scope here — matching #865's own stated scope (Docker/K8s/Podman only).
- Related issue #864 (wiring `K8sDatum` into runtime dispatch) will follow as a **separate PR** built on top of this one.

## Test plan

- [x] `cargo build -p b00t-cli` — clean
- [x] `cargo test -p b00t-cli --lib datum_docker:: / datum_k8s:: / datum_podman::` — all pass, no assertion changes
- [x] New `b00t-cli/tests/filter_logic_defaults_test.rs`:
  - Compile-time proof all three types implement `AvailabilityEvaluator`
  - Behavioral test per type: `is_available()` matches an independently-computed `!is_installed() && prerequisites_satisfied()`, built via direct struct construction (no `from_config`/CLI shell-out needed, so no `#[ignore]` required)
- [x] Existing `tests/docker_test.rs` and `tests/constraint_test.rs` — unaffected, same pass/ignore status as before
- [x] Full pre-push gate (`cargo test --lib` across `b00t-cli`/`b00t-mcp`/`b00t-pyverse`): 1425 passed, 0 failed, 4 ignored (b00t-cli) + 58 passed (b00t-mcp) — all green

Fixes #865

🤖 Generated with [Claude Code](https://claude.com/claude-code)