### PR TITLE
refactor(b00t-cli): route validation through Satisfies<C>, preserve Unknown end-to-end (fixes #927)

### DIFF
--- a/b00t-cli/src/commands/datum.rs
+++ b/b00t-cli/src/commands/datum.rs
@@ -4,6 +4,7 @@ use crate::datum_utils::{self, DatumFilter};
 use anyhow::{Context, Result};
 use clap::Parser;
 use std::collections::HashMap;
+use ufo_types::{Disposition, IsoAuditable, Satisfies, SatisfiesResult, Stereotyped, UfoStereotype};
 
 #[derive(Parser, Debug)]
 pub enum DatumCommands {
@@ -1040,21 +1041,78 @@ fn handle_validate(datum_path: &str, target: &str, strict: bool) -> Result<()> {
     let content = std::fs::read_to_string(&file_path).context("cannot read file")?;
     let raw: toml::Value = toml::from_str(&content).context("invalid TOML")?;
 
-    let mut errors = Vec::new();
-    let mut warnings = Vec::new();
-
     // Check [b00t] section exists
     let b00t_table = match raw.get("b00t") {
-        Some(toml::Value::Table(t)) => t,
+        Some(toml::Value::Table(t)) => t.clone(),
         Some(_) => {
-            errors.push("[b00t] must be a TOML table".into());
-            return print_validation_result(&errors, &warnings);
+            let errors = vec!["[b00t] must be a TOML table".to_string()];
+            return print_validation_result(&errors, &[]);
         }
         None => {
-            errors.push("missing [b00t] section".into());
-            return print_validation_result(&errors, &warnings);
+            let errors = vec!["missing [b00t] section".to_string()];
+            return print_validation_result(&errors, &[]);
         }
     };
+
+    let outcome = compute_datum_validation(&b00t_table, filename, strict);
+    print_validation_result(&outcome.errors, &outcome.warnings)?;
+
+    // Route through the real Satisfies<C> / evidence-sink path (#927) —
+    // additive to the print-based UX above, which is unchanged.
+    let subject = DatumTomlSubject {
+        raw: &b00t_table,
+        filename,
+    };
+    let constraint = BootDatumSchemaConstraint { strict };
+    let result = subject.satisfies(&constraint);
+
+    let _ = crate::commands::evidence::record_is_a(target, &subject.ufo_stereotype().to_string());
+    for iso_id in constraint.iso_standard_ids() {
+        let _ = crate::commands::evidence::record_audited_by(target, &iso_id);
+    }
+
+    if matches!(result.disposition, Disposition::Unknown) {
+        println!("  UNKNOWN: cannot verify type/extension consistency (unrecognized extension)");
+        if strict {
+            anyhow::bail!(
+                "--strict: type/extension consistency is undecidable for '{}' (unrecognized extension)",
+                filename
+            );
+        }
+    }
+
+    Ok(())
+}
+
+/// Pure outcome of validating a `[b00t]` TOML table against the `BootDatum`
+/// schema — same checks `handle_validate` has always run, extracted so both
+/// the print-based UX and the `Satisfies<BootDatumSchemaConstraint>` impl
+/// below can share one implementation.
+struct DatumValidationOutcome {
+    errors: Vec<String>,
+    warnings: Vec<String>,
+    /// True exactly when the strict extension↔type consistency check could
+    /// not be decided because the filename's extension is not a recognized
+    /// datum type (`DatumType::from_filename` returned `Unknown`). Prior to
+    /// #927 this case was silently skipped — neither an error nor a
+    /// warning — which is the bug this issue fixes: it's now surfaced as a
+    /// distinguishable `Disposition::Unknown`, not silently folded into
+    /// "valid".
+    extension_check_undecidable: bool,
+}
+
+/// Same required-field / unknown-key / extension-consistency / version_regex
+/// checks `handle_validate` has always run — extracted to a pure function so
+/// it can feed both the existing print-based UX and the new
+/// `Satisfies<BootDatumSchemaConstraint>` impl.
+fn compute_datum_validation(
+    b00t_table: &toml::value::Table,
+    filename: &str,
+    strict: bool,
+) -> DatumValidationOutcome {
+    let mut errors = Vec::new();
+    let mut warnings = Vec::new();
+    let mut extension_check_undecidable = false;
 
     // Required fields
     if b00t_table.get("name").is_none() {
@@ -1079,7 +1137,12 @@ fn handle_validate(datum_path: &str, target: &str, strict: bool) -> Result<()> {
         if let Some(toml::Value::String(type_str)) = b00t_table.get("type") {
             let declared = DatumType::from_type_token(type_str);
             let from_ext = DatumType::from_filename(filename);
-            if declared != Some(from_ext) && from_ext != DatumType::Unknown {
+            if from_ext == DatumType::Unknown {
+                // #927 fix: previously silently skipped — no error, no
+                // warning. Unrecognized extension means we genuinely cannot
+                // decide whether type and extension are consistent.
+                extension_check_undecidable = true;
+            } else if declared != Some(from_ext) {
                 warnings.push(format!(
                     "type={} but filename suggests {:?} (extension .{})",
                     type_str,
@@ -1097,7 +1160,61 @@ fn handle_validate(datum_path: &str, target: &str, strict: bool) -> Result<()> {
         }
     }
 
-    print_validation_result(&errors, &warnings)
+    DatumValidationOutcome {
+        errors,
+        warnings,
+        extension_check_undecidable,
+    }
+}
+
+/// `[b00t]` TOML table + originating filename — the subject evaluated
+/// against `BootDatumSchemaConstraint`.
+pub struct DatumTomlSubject<'a> {
+    pub raw: &'a toml::value::Table,
+    pub filename: &'a str,
+}
+
+/// Constraint: a `[b00t]` TOML table must conform to the `BootDatum` schema
+/// (required fields present, extension↔type consistent when `strict`,
+/// `version_regex` compiles).
+pub struct BootDatumSchemaConstraint {
+    pub strict: bool,
+}
+
+impl IsoAuditable for BootDatumSchemaConstraint {
+    fn iso_standard_ids(&self) -> Vec<String> {
+        vec!["b00t:BootDatumSchema".into()]
+    }
+}
+
+impl Stereotyped for DatumTomlSubject<'_> {
+    /// Resolves the declared `type` field through `DatumType`'s lattice
+    /// (#925/#926 single source of truth) — same pattern as
+    /// `ontology.rs`'s sparql "type" arm and `BootDatum`'s own
+    /// `Stereotyped` impl. Missing/unrecognized type degrades to
+    /// `Kind("Unknown")`, never panics.
+    fn ufo_stereotype(&self) -> UfoStereotype {
+        let type_str = match self.raw.get("type") {
+            Some(toml::Value::String(s)) => s.as_str(),
+            _ => "",
+        };
+        DatumType::from_type_token(type_str)
+            .unwrap_or(DatumType::Unknown)
+            .ufo_stereotype()
+    }
+}
+
+impl Satisfies<BootDatumSchemaConstraint> for DatumTomlSubject<'_> {
+    fn satisfies(&self, c: &BootDatumSchemaConstraint) -> SatisfiesResult {
+        let outcome = compute_datum_validation(self.raw, self.filename, c.strict);
+        if !outcome.errors.is_empty() {
+            return SatisfiesResult::violated(outcome.errors.join("; "), 1.0);
+        }
+        if outcome.extension_check_undecidable {
+            return SatisfiesResult::unknown(0.5);
+        }
+        SatisfiesResult::satisfied(1.0)
+    }
 }
 
 fn handle_validate_graph(datum_path: &str) -> Result<()> {
@@ -2185,5 +2302,204 @@ mod govern_tests {
             !reports.iter().any(|r| r.datum == "disabled-cli"),
             "disabled datum should be skipped from --all governance"
         );
+    }
+}
+
+#[cfg(test)]
+mod datum_toml_subject_satisfies_tests {
+    use super::*;
+
+    fn table_from_toml(toml_str: &str) -> toml::value::Table {
+        let value: toml::Value = toml::from_str(toml_str).unwrap();
+        match value {
+            toml::Value::Table(t) => t,
+            _ => panic!("expected a TOML table"),
+        }
+    }
+
+    #[test]
+    fn clean_datum_is_satisfied() {
+        let table = table_from_toml(
+            r#"
+name = "clean-cli"
+type = "cli"
+hint = "a clean datum"
+"#,
+        );
+        let subject = DatumTomlSubject {
+            raw: &table,
+            filename: "clean-cli.cli.toml",
+        };
+        let result = subject.satisfies(&BootDatumSchemaConstraint { strict: true });
+        assert!(result.is_satisfied(), "expected Satisfied, got {:?}", result.disposition);
+    }
+
+    #[test]
+    fn missing_required_field_is_violated() {
+        // No `hint` field — a required field per KNOWN_B00T_KEYS / handle_validate.
+        let table = table_from_toml(
+            r#"
+name = "incomplete-cli"
+type = "cli"
+"#,
+        );
+        let subject = DatumTomlSubject {
+            raw: &table,
+            filename: "incomplete-cli.cli.toml",
+        };
+        let result = subject.satisfies(&BootDatumSchemaConstraint { strict: false });
+        match result.disposition {
+            Disposition::Violated { reason } => {
+                assert!(reason.contains("hint"), "reason: {reason}");
+            }
+            other => panic!("expected Violated, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn recognized_type_unrecognized_extension_strict_is_unknown() {
+        // type="cli" is a recognized type, but the fixture filename's
+        // extension is not a recognized datum-type suffix — #927's fix:
+        // this must surface as Unknown, not be silently skipped as before.
+        let table = table_from_toml(
+            r#"
+name = "weird-ext-cli"
+type = "cli"
+hint = "a datum with an unrecognized filename extension"
+"#,
+        );
+        let subject = DatumTomlSubject {
+            raw: &table,
+            filename: "weird-ext-cli.some-made-up-extension-xyz",
+        };
+        let result = subject.satisfies(&BootDatumSchemaConstraint { strict: true });
+        assert!(
+            matches!(result.disposition, Disposition::Unknown),
+            "expected Unknown, got {:?}",
+            result.disposition
+        );
+    }
+
+    #[test]
+    fn non_strict_mode_never_produces_unknown_for_extension_mismatch() {
+        // Same fixture as above, but strict=false: the extension check is
+        // skipped entirely (not even attempted), so it's Satisfied.
+        let table = table_from_toml(
+            r#"
+name = "weird-ext-cli"
+type = "cli"
+hint = "a datum with an unrecognized filename extension"
+"#,
+        );
+        let subject = DatumTomlSubject {
+            raw: &table,
+            filename: "weird-ext-cli.some-made-up-extension-xyz",
+        };
+        let result = subject.satisfies(&BootDatumSchemaConstraint { strict: false });
+        assert!(result.is_satisfied());
+    }
+
+    #[test]
+    fn ufo_stereotype_delegates_to_datum_type_lattice() {
+        let table = table_from_toml(
+            r#"
+name = "docker-thing"
+type = "docker"
+hint = "t"
+"#,
+        );
+        let subject = DatumTomlSubject {
+            raw: &table,
+            filename: "docker-thing.docker.toml",
+        };
+        assert_eq!(
+            subject.ufo_stereotype(),
+            DatumType::Docker.ufo_stereotype()
+        );
+    }
+
+    #[test]
+    fn ufo_stereotype_degrades_to_unknown_for_missing_type() {
+        let table = table_from_toml(
+            r#"
+name = "typeless"
+hint = "t"
+"#,
+        );
+        let subject = DatumTomlSubject {
+            raw: &table,
+            filename: "typeless.toml",
+        };
+        assert_eq!(
+            subject.ufo_stereotype(),
+            UfoStereotype::Kind("Unknown".into())
+        );
+    }
+}
+
+#[cfg(test)]
+mod validate_evidence_integration_tests {
+    use super::*;
+    use crate::commands::evidence::{read_evidence, with_test_evidence_log_path};
+    use tempfile::TempDir;
+
+    /// Proves the #927 wiring is real, not just computed and discarded:
+    /// evaluating a `DatumTomlSubject` against `BootDatumSchemaConstraint`
+    /// and recording NS-9/NS-10 evidence really appends rows to
+    /// `satisfies.jsonl` (via the same `record_is_a`/`record_audited_by`
+    /// sink `handle_validate` itself calls), with `object` strings prefixed
+    /// `"isA:"` and `"audited_by:"` respectively.
+    #[test]
+    fn satisfies_evaluation_records_isa_and_audited_by_evidence() {
+        let dir = TempDir::new().unwrap();
+        let log_path = dir.path().join("satisfies.jsonl");
+
+        with_test_evidence_log_path(log_path, || {
+            let table = toml::from_str::<toml::Value>(
+                r#"
+name = "evidence-cli"
+type = "cli"
+hint = "exercises the evidence sink"
+"#,
+            )
+            .unwrap();
+            let table = match table {
+                toml::Value::Table(t) => t,
+                _ => unreachable!(),
+            };
+
+            let subject = DatumTomlSubject {
+                raw: &table,
+                filename: "evidence-cli.cli.toml",
+            };
+            let constraint = BootDatumSchemaConstraint { strict: true };
+            let target = "evidence-cli.cli";
+
+            let _result = subject.satisfies(&constraint);
+            crate::commands::evidence::record_is_a(target, &subject.ufo_stereotype().to_string())
+                .unwrap();
+            for iso_id in constraint.iso_standard_ids() {
+                crate::commands::evidence::record_audited_by(target, &iso_id).unwrap();
+            }
+
+            let records = read_evidence().unwrap();
+            assert!(
+                records
+                    .iter()
+                    .any(|r| r.subject == target
+                        && r.object.as_str().map_or(false, |o| o.starts_with("isA:"))),
+                "expected an isA: evidence record, got: {:?}",
+                records
+            );
+            assert!(
+                records.iter().any(|r| r.subject == target
+                    && r
+                        .object
+                        .as_str()
+                        .map_or(false, |o| o.starts_with("audited_by:"))),
+                "expected an audited_by: evidence record, got: {:?}",
+                records
+            );
+        });
     }
 }

--- a/b00t-cli/src/commands/ontology.rs
+++ b/b00t-cli/src/commands/ontology.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::Path;
 use std::process::Command;
-use ufo_types::Stereotyped;
+use ufo_types::{IsoAuditable, Satisfies, SatisfiesResult, Stereotyped, UfoStereotype};
 
 use crate::DatumType;
 
@@ -72,6 +72,36 @@ impl OntologyCommands {
                     }
                     _ => println!("{}", serde_json::to_string_pretty(&triples)?),
                 }
+
+                // NS-9/NS-10 evidence wiring (#927): `sparql_query` itself
+                // stays pure/side-effect-free for testability — evidence
+                // recording happens here, at the command layer, once per
+                // matched datum, only for the "validate"/"all" predicates
+                // (the ones that actually evaluate `DatumValidateConstraint`).
+                if predicate == "validate" || predicate == "b00t:validate" || predicate == "all" {
+                    let datums = scan_datums(&datum_dir).unwrap_or_default();
+                    for datum in &datums {
+                        if let Some(subj) = subject.as_deref() {
+                            if !datum.b00t.name.contains(subj) {
+                                continue;
+                            }
+                        }
+                        if datum.validate.command.is_empty() {
+                            continue;
+                        }
+                        let constraint = DatumValidateConstraint;
+                        let _ = datum.satisfies(&constraint);
+                        let _ = crate::commands::evidence::record_is_a(
+                            &datum.b00t.name,
+                            &datum.ufo_stereotype().to_string(),
+                        );
+                        for iso_id in constraint.iso_standard_ids() {
+                            let _ =
+                                crate::commands::evidence::record_audited_by(&datum.b00t.name, &iso_id);
+                        }
+                    }
+                }
+
                 Ok(())
             }
             OntologyCommands::FindAgent {
@@ -189,37 +219,92 @@ pub fn scan_datums(datum_dir: &str) -> Result<Vec<DatumMeta>> {
     Ok(datums)
 }
 
-pub fn is_validated(datum: &DatumMeta) -> bool {
-    if datum.validate.command.is_empty() {
-        return false;
+/// Constraint: a datum's `[validate]` command exits successfully (and, if
+/// `regex` is set, its combined stdout+stderr matches). Deliberately unit
+/// (no fields) — the datum itself carries the command/regex to evaluate.
+pub struct DatumValidateConstraint;
+
+impl IsoAuditable for DatumValidateConstraint {
+    fn iso_standard_ids(&self) -> Vec<String> {
+        vec!["b00t:DatumValidateCommand".into()]
     }
-    // Expand ~ to the actual home directory so validate commands like
-    // `git -C ~/.b00t cat-file -e <hash>` work without shell expansion.
-    let home = dirs::home_dir()
-        .map(|p| p.to_string_lossy().into_owned())
-        .unwrap_or_default();
-    let expanded = datum.validate.command.replace('~', &home);
-    let parts: Vec<&str> = expanded.split_whitespace().collect();
-    if parts.is_empty() {
-        return false;
+}
+
+impl Stereotyped for DatumMeta {
+    /// Delegates to `DatumType`'s lattice (#925/#926 single source of
+    /// truth) — same pattern as `sparql_query`'s "type" arm and
+    /// `BootDatum`'s own `Stereotyped` impl. Missing/unrecognized type
+    /// degrades to `Kind("Unknown")`, never panics.
+    fn ufo_stereotype(&self) -> UfoStereotype {
+        DatumType::from_type_token(&self.b00t.datum_type)
+            .unwrap_or(DatumType::Unknown)
+            .ufo_stereotype()
     }
-    match Command::new(parts[0]).args(&parts[1..]).output() {
-        Ok(output) => {
-            let combined = format!(
-                "{}{}",
-                String::from_utf8_lossy(&output.stdout),
-                String::from_utf8_lossy(&output.stderr)
-            );
-            if datum.validate.regex.is_empty() {
-                output.status.success()
-            } else {
-                regex::Regex::new(&datum.validate.regex)
-                    .map(|re| re.is_match(&combined))
-                    .unwrap_or(false)
-            }
+}
+
+impl Satisfies<DatumValidateConstraint> for DatumMeta {
+    /// Same command-splitting/expansion and output-combination logic
+    /// `is_validated()` has always run, but distinguishing three cases the
+    /// old bool return silently collapsed into `false`:
+    ///  1. no `[validate]` command at all → `Unknown` (nothing to check)
+    ///  2. command genuinely ran and failed / output didn't match →
+    ///     `Violated`
+    ///  3. command couldn't even be spawned (ENOENT etc.), or the regex
+    ///     itself doesn't compile → `Unknown` (we couldn't determine
+    ///     pass/fail, we did not determine it to be false)
+    fn satisfies(&self, _c: &DatumValidateConstraint) -> SatisfiesResult {
+        if self.validate.command.is_empty() {
+            return SatisfiesResult::unknown(0.0);
         }
-        Err(_) => false,
+        // Expand ~ to the actual home directory so validate commands like
+        // `git -C ~/.b00t cat-file -e <hash>` work without shell expansion.
+        let home = dirs::home_dir()
+            .map(|p| p.to_string_lossy().into_owned())
+            .unwrap_or_default();
+        let expanded = self.validate.command.replace('~', &home);
+        let parts: Vec<&str> = expanded.split_whitespace().collect();
+        if parts.is_empty() {
+            return SatisfiesResult::unknown(0.0);
+        }
+        match Command::new(parts[0]).args(&parts[1..]).output() {
+            Ok(output) => {
+                let combined = format!(
+                    "{}{}",
+                    String::from_utf8_lossy(&output.stdout),
+                    String::from_utf8_lossy(&output.stderr)
+                );
+                if self.validate.regex.is_empty() {
+                    if output.status.success() {
+                        SatisfiesResult::satisfied(1.0)
+                    } else {
+                        SatisfiesResult::violated(
+                            format!("command exited {:?}", output.status.code()),
+                            1.0,
+                        )
+                    }
+                } else {
+                    match regex::Regex::new(&self.validate.regex) {
+                        Ok(re) if re.is_match(&combined) => SatisfiesResult::satisfied(1.0),
+                        Ok(_) => SatisfiesResult::violated(
+                            format!("output did not match /{}/", self.validate.regex),
+                            1.0,
+                        ),
+                        Err(_) => SatisfiesResult::unknown(0.0),
+                    }
+                }
+            }
+            Err(_) => SatisfiesResult::unknown(0.0),
+        }
     }
+}
+
+/// Legacy bool entry point — delegates to `Satisfies<DatumValidateConstraint>`.
+/// `is_satisfied()` is `false` for BOTH `Violated` and `Unknown`, so this
+/// preserves the exact same bool result `is_validated()` has always
+/// returned for every input (see `is_validated_returns_false_for_all_three_unknown_cases`
+/// regression-lock test).
+pub fn is_validated(datum: &DatumMeta) -> bool {
+    datum.satisfies(&DatumValidateConstraint).is_satisfied()
 }
 
 pub fn detect_blessings() -> Vec<String> {
@@ -295,6 +380,9 @@ pub fn sparql_query(
             "validate" | "b00t:validate" => {
                 if !datum.validate.command.is_empty() {
                     triples.push(emit("b00t:validateCmd", &datum.validate.command));
+                    let result = datum.satisfies(&DatumValidateConstraint);
+                    triples.push(emit("b00t:validateDisposition", &result.disposition.to_string()));
+                    triples.push(emit("b00t:validateConfidence", &result.confidence.to_string()));
                 }
             }
             _ => {
@@ -427,6 +515,7 @@ fn print_agent_results(task: &str, results: &[AgentMatch]) {
 mod tests {
     use super::*;
     use std::io::Write;
+    use ufo_types::Disposition;
 
     fn make_datum(
         name: &str,
@@ -679,5 +768,121 @@ optional_for = []
 
         let results = find_agents_for_task("a b c d", 5, dir.path().to_str().unwrap()).unwrap();
         assert!(results.is_empty());
+    }
+
+    // ── is_validated / Satisfies<DatumValidateConstraint> (#927) ──
+
+    fn make_datum_with_regex(name: &str, validate_cmd: &str, regex: &str) -> DatumMeta {
+        DatumMeta {
+            b00t: B00tSection {
+                name: name.to_string(),
+                datum_type: "cli".to_string(),
+            },
+            validate: ValidateSection {
+                command: validate_cmd.to_string(),
+                regex: regex.to_string(),
+            },
+            roles: RolesSection::default(),
+        }
+    }
+
+    /// Regression lock: `is_validated()`'s legacy bool must remain
+    /// byte-identical (`false`) for all three cases that used to silently
+    /// collapse "couldn't determine" into "false" — proving the #927
+    /// refactor changed the underlying disposition tracking without
+    /// changing this function's observable output.
+    #[test]
+    fn is_validated_returns_false_for_all_three_unknown_cases() {
+        // Case 1: empty validate command.
+        let no_cmd = make_datum("no-validate-cmd", &[], &[], "");
+        assert!(!is_validated(&no_cmd));
+
+        // Case 2: invalid regex.
+        let bad_regex = make_datum_with_regex("bad-regex", "echo hi", "(unclosed[");
+        assert!(!is_validated(&bad_regex));
+
+        // Case 3: command exec failure (ENOENT).
+        let bad_cmd = make_datum(
+            "nonexistent-binary",
+            &[],
+            &[],
+            "definitely-not-a-real-command-927-xyz",
+        );
+        assert!(!is_validated(&bad_cmd));
+    }
+
+    #[test]
+    fn satisfies_empty_validate_command_is_unknown() {
+        let datum = make_datum("no-validate-cmd", &[], &[], "");
+        let result = datum.satisfies(&DatumValidateConstraint);
+        assert!(
+            matches!(result.disposition, Disposition::Unknown),
+            "expected Unknown, got {:?}",
+            result.disposition
+        );
+    }
+
+    #[test]
+    fn satisfies_invalid_regex_is_unknown() {
+        let datum = make_datum_with_regex("bad-regex", "echo hi", "(unclosed[");
+        let result = datum.satisfies(&DatumValidateConstraint);
+        assert!(
+            matches!(result.disposition, Disposition::Unknown),
+            "expected Unknown, got {:?}",
+            result.disposition
+        );
+    }
+
+    #[test]
+    fn satisfies_command_exec_failure_is_unknown() {
+        let datum = make_datum(
+            "nonexistent-binary",
+            &[],
+            &[],
+            "definitely-not-a-real-command-927-xyz",
+        );
+        let result = datum.satisfies(&DatumValidateConstraint);
+        assert!(
+            matches!(result.disposition, Disposition::Unknown),
+            "expected Unknown, got {:?}",
+            result.disposition
+        );
+    }
+
+    /// Proves the 3-way split is real: a command that genuinely runs and
+    /// exits non-zero is a real `Violated`, distinct from all three
+    /// `Unknown` cases above.
+    #[test]
+    fn satisfies_command_exits_nonzero_is_violated() {
+        let datum = make_datum("failing-cmd", &[], &[], "false");
+        let result = datum.satisfies(&DatumValidateConstraint);
+        match result.disposition {
+            Disposition::Violated { reason } => {
+                assert!(reason.contains("exited"), "reason: {reason}");
+            }
+            other => panic!("expected Violated, got {:?}", other),
+        }
+    }
+
+    /// Proves genuine regex-mismatch (command runs fine, output doesn't
+    /// match) is `Violated`, distinct from the invalid-regex `Unknown` case.
+    #[test]
+    fn satisfies_regex_mismatch_is_violated() {
+        let datum =
+            make_datum_with_regex("echo-cli", "echo hello-world", "definitely-wont-match-xyz");
+        let result = datum.satisfies(&DatumValidateConstraint);
+        match result.disposition {
+            Disposition::Violated { reason } => {
+                assert!(reason.contains("did not match"), "reason: {reason}");
+            }
+            other => panic!("expected Violated, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn satisfies_passing_command_is_satisfied() {
+        let datum = make_datum("passing-cmd", &[], &[], "true");
+        let result = datum.satisfies(&DatumValidateConstraint);
+        assert!(result.is_satisfied());
     }
 }

--- a/b00t-cli/src/gates.rs
+++ b/b00t-cli/src/gates.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
+use ufo_types::{Disposition, IsoAuditable, Satisfies, SatisfiesResult};
 
 /// A single gate precondition — late-binding condition evaluated at install time.
 /// All fields are optional; any present field must pass for the gate to open.
@@ -107,24 +108,41 @@ pub fn eval_gate_status(kind: &str, spec: &str) -> &'static str {
     }
 }
 
-/// Evaluate all gates for a datum. Returns a Vec of GateResults, one per gate.
-/// If any gate fails, the datum should be skipped.
-pub fn evaluate_gates(gates: &[GateSpec], path: &str) -> Vec<GateResult> {
-    let mut results = Vec::new();
-    for gate in gates {
-        let mut passed = true;
-        let mut reasons = Vec::new();
+/// Per-field outcome of a single gate's checks, in field-declaration order
+/// (command, file, env, rhai, knowledge_backend). Only non-passing fields
+/// produce an outcome. `Violated` is a genuine failed check; `UnknownReason`
+/// is reserved for checks that could not be evaluated at all (currently:
+/// a rhai expression that failed to *compile/evaluate*, as opposed to one
+/// that evaluated cleanly to `false`) — carries its own reason text so the
+/// legacy bool-returning `evaluate_gates()` can reproduce today's exact
+/// message, even though `ufo_types::Disposition::Unknown` itself carries no
+/// payload.
+enum FieldOutcome {
+    Violated(String),
+    UnknownReason(String),
+}
+
+impl GateSpec {
+    /// Runs the same command/file/env/rhai/knowledge_backend checks
+    /// `evaluate_gates()` has always run, in the same order, producing the
+    /// same reason text for each failing field — but tagging each failure
+    /// as a genuine `Violated` or an `UnknownReason` (rhai eval error)
+    /// instead of collapsing both into "not passed".
+    fn eval_fields(&self, path: &str) -> Vec<FieldOutcome> {
+        let mut outcomes = Vec::new();
 
         // Command gate: check if command exists on PATH
-        if let Some(ref cmd) = gate.command {
+        if let Some(ref cmd) = self.command {
             if !check_command_available(cmd) {
-                passed = false;
-                reasons.push(format!("command '{}' not found on PATH", cmd));
+                outcomes.push(FieldOutcome::Violated(format!(
+                    "command '{}' not found on PATH",
+                    cmd
+                )));
             }
         }
 
         // File gate: check if file exists (supports ~ expansion and relative paths)
-        if let Some(ref file) = gate.file {
+        if let Some(ref file) = self.file {
             let expanded = shellexpand::tilde(file).to_string();
             let exists = if std::path::Path::new(&expanded).is_absolute() {
                 std::path::Path::new(&expanded).exists()
@@ -144,13 +162,15 @@ pub fn evaluate_gates(gates: &[GateSpec], path: &str) -> Vec<GateResult> {
                 base.join(&expanded).exists() || std::path::Path::new(&expanded).exists()
             };
             if !exists {
-                passed = false;
-                reasons.push(format!("file '{}' does not exist", file));
+                outcomes.push(FieldOutcome::Violated(format!(
+                    "file '{}' does not exist",
+                    file
+                )));
             }
         }
 
         // Env gate: check if env var or .env entry is set
-        if let Some(ref env_var) = gate.env {
+        if let Some(ref env_var) = self.env {
             let direct = std::env::var(env_var);
             let env_ok = direct.is_ok() && !direct.unwrap_or_default().is_empty();
             if !env_ok {
@@ -175,54 +195,125 @@ pub fn evaluate_gates(gates: &[GateSpec], path: &str) -> Vec<GateResult> {
                     false
                 };
                 if !env_file_ok {
-                    passed = false;
-                    reasons.push(format!("env var '{}' not set", env_var));
+                    outcomes.push(FieldOutcome::Violated(format!(
+                        "env var '{}' not set",
+                        env_var
+                    )));
                 }
             }
         }
 
-        // Rhai gate: evaluate rhai expression
-        if let Some(ref rhai_expr) = gate.rhai {
-            let (rhai_ok, rhai_err) = evaluate_rhai_gate(rhai_expr);
-            if !rhai_ok {
-                passed = false;
-                let reason = if let Some(err) = rhai_err {
-                    format!("rhai gate '{rhai_expr}' failed: {err}")
-                } else {
-                    format!("rhai gate '{rhai_expr}' returned false")
-                };
-                reasons.push(reason);
+        // Rhai gate: evaluate rhai expression via the Disposition-native
+        // classifier (#927 fix — an eval ERROR is `Unknown`, not a
+        // violation; only `Ok(false)` is a genuine violation).
+        if let Some(ref rhai_expr) = self.rhai {
+            match rhai_gate_disposition(rhai_expr) {
+                Disposition::Satisfied => {}
+                Disposition::Violated { reason } => outcomes.push(FieldOutcome::Violated(reason)),
+                Disposition::Unknown => {
+                    // `Disposition::Unknown` carries no payload, so recover
+                    // the original rhai error text (for the legacy
+                    // bool-returning `evaluate_gates()`'s reason string) by
+                    // re-running the eval. Only reached on eval error, which
+                    // is rare, so the extra eval is not a hot-path cost.
+                    let (_, err) = evaluate_rhai_gate(rhai_expr);
+                    let text = err
+                        .map(|e| format!("rhai gate '{rhai_expr}' failed: {e}"))
+                        .unwrap_or_else(|| format!("rhai gate '{rhai_expr}' failed"));
+                    outcomes.push(FieldOutcome::UnknownReason(text));
+                }
             }
         }
 
-        if let Some(ref backend) = gate.knowledge_backend {
+        if let Some(ref backend) = self.knowledge_backend {
             if b00t_c0re_lib::compiled_knowledge_backend() != backend {
-                passed = false;
-                reasons.push(format!(
+                outcomes.push(FieldOutcome::Violated(format!(
                     "knowledge backend '{}' does not match compiled backend '{}'",
                     backend,
                     b00t_c0re_lib::compiled_knowledge_backend()
-                ));
+                )));
             }
         }
 
-        let reason = if reasons.is_empty() {
-            gate.hint
-                .clone()
-                .unwrap_or_else(|| "gate passed".to_string())
-        } else {
-            gate.hint
-                .clone()
-                .map(|h| format!("{}: {}", h, reasons.join("; ")))
-                .unwrap_or_else(|| reasons.join("; "))
-        };
-
-        results.push(GateResult { passed, reason });
+        outcomes
     }
-    results
+
+    /// Disposition-returning evaluation of this gate's preconditions.
+    /// A genuine violation always wins over an undetermined (`Unknown`)
+    /// field; only when every field either passed or was undetermined (and
+    /// none were genuinely violated) does an undetermined field yield
+    /// `Unknown` overall.
+    pub fn eval_disposition(&self, path: &str) -> Disposition {
+        let outcomes = self.eval_fields(path);
+
+        let violated: Vec<String> = outcomes
+            .iter()
+            .filter_map(|o| match o {
+                FieldOutcome::Violated(reason) => Some(reason.clone()),
+                FieldOutcome::UnknownReason(_) => None,
+            })
+            .collect();
+        if !violated.is_empty() {
+            let reason = self
+                .hint
+                .clone()
+                .map(|h| format!("{}: {}", h, violated.join("; ")))
+                .unwrap_or_else(|| violated.join("; "));
+            return Disposition::Violated { reason };
+        }
+
+        if outcomes
+            .iter()
+            .any(|o| matches!(o, FieldOutcome::UnknownReason(_)))
+        {
+            return Disposition::Unknown;
+        }
+
+        Disposition::Satisfied
+    }
 }
 
-/// Evaluate a simple rhai boolean expression.
+/// Evaluate all gates for a datum. Returns a Vec of GateResults, one per gate.
+/// If any gate fails, the datum should be skipped.
+///
+/// Thin fold over `GateSpec::eval_fields()` — preserves the exact
+/// `passed`/`reason` behavior this function has always had (including for
+/// the rhai-eval-error case, which today is folded into `passed: false`
+/// with the same reason text; #927 exposes that same case as
+/// `Disposition::Unknown` via `eval_disposition()` without changing this
+/// function's observable output).
+pub fn evaluate_gates(gates: &[GateSpec], path: &str) -> Vec<GateResult> {
+    gates
+        .iter()
+        .map(|gate| {
+            let outcomes = gate.eval_fields(path);
+            let reasons: Vec<String> = outcomes
+                .iter()
+                .map(|o| match o {
+                    FieldOutcome::Violated(reason) => reason.clone(),
+                    FieldOutcome::UnknownReason(reason) => reason.clone(),
+                })
+                .collect();
+            let passed = reasons.is_empty();
+            let reason = if reasons.is_empty() {
+                gate.hint
+                    .clone()
+                    .unwrap_or_else(|| "gate passed".to_string())
+            } else {
+                gate.hint
+                    .clone()
+                    .map(|h| format!("{}: {}", h, reasons.join("; ")))
+                    .unwrap_or_else(|| reasons.join("; "))
+            };
+            GateResult { passed, reason }
+        })
+        .collect()
+}
+
+/// Evaluate a simple rhai boolean expression, returning (passed, error_text).
+/// `error_text` is `Some` only when the expression failed to evaluate at all
+/// (syntax error, unknown symbol, …) — used by `eval_fields()` to reproduce
+/// today's exact legacy reason text.
 fn evaluate_rhai_gate(expr: &str) -> (bool, Option<String>) {
     use rhai::Engine;
     let engine = Engine::new();
@@ -230,6 +321,72 @@ fn evaluate_rhai_gate(expr: &str) -> (bool, Option<String>) {
         Ok(true) => (true, None),
         Ok(false) => (false, None),
         Err(e) => (false, Some(e.to_string())),
+    }
+}
+
+/// Disposition-returning evaluation of a rhai boolean expression. An eval
+/// ERROR (bad syntax, unknown symbol, …) means the expression could not be
+/// determined true or false — that is `Unknown`, not a violation. Fixes the
+/// #927 bug where `evaluate_rhai_gate`'s bool-collapsing treated a rhai eval
+/// error as an outright `false` (i.e. a violation).
+fn rhai_gate_disposition(expr: &str) -> Disposition {
+    use rhai::Engine;
+    let engine = Engine::new();
+    match engine.eval::<bool>(expr) {
+        Ok(true) => Disposition::Satisfied,
+        Ok(false) => Disposition::Violated {
+            reason: format!("rhai gate '{expr}' returned false"),
+        },
+        Err(_) => Disposition::Unknown,
+    }
+}
+
+/// Constraint: `path`'s datum must satisfy every gate in `gates`.
+/// Bundles the gate list with the evaluation path since `Satisfies<C>`
+/// takes the constraint by reference alone — `GateSpec::eval_disposition`
+/// needs both.
+pub struct GatePreconditions<'a> {
+    pub gates: &'a [GateSpec],
+    pub path: &'a str,
+}
+
+impl IsoAuditable for GatePreconditions<'_> {
+    fn iso_standard_ids(&self) -> Vec<String> {
+        vec!["b00t:GatePrecondition".into()]
+    }
+}
+
+impl Satisfies<GatePreconditions<'_>> for crate::BootDatum {
+    fn satisfies(&self, c: &GatePreconditions<'_>) -> SatisfiesResult {
+        if c.gates.is_empty() {
+            return SatisfiesResult::satisfied(1.0);
+        }
+
+        let dispositions: Vec<Disposition> = c
+            .gates
+            .iter()
+            .map(|g| g.eval_disposition(c.path))
+            .collect();
+
+        let violated: Vec<String> = dispositions
+            .iter()
+            .filter_map(|d| match d {
+                Disposition::Violated { reason } => Some(reason.clone()),
+                _ => None,
+            })
+            .collect();
+        if !violated.is_empty() {
+            return SatisfiesResult::violated(violated.join("; "), 1.0);
+        }
+
+        if dispositions
+            .iter()
+            .any(|d| matches!(d, Disposition::Unknown))
+        {
+            return SatisfiesResult::unknown(0.5);
+        }
+
+        SatisfiesResult::satisfied(1.0)
     }
 }
 
@@ -350,4 +507,182 @@ pub fn list_gates(path: &str, search: Option<&str>) -> Result<Vec<GateReport>> {
     }
 
     Ok(gates)
+}
+
+#[cfg(test)]
+mod satisfies_tests {
+    use super::*;
+    use ufo_types::satisfies::Disposition as UfoDisposition;
+
+    #[test]
+    fn eval_disposition_bad_rhai_syntax_is_unknown_not_violated() {
+        // Regression lock for the #927 bug: a rhai eval ERROR (bad syntax)
+        // must be Unknown, never Violated — we could not determine
+        // pass/fail, we did not determine it to be false.
+        let gate = GateSpec {
+            rhai: Some("this is not valid rhai (((".to_string()),
+            ..Default::default()
+        };
+        let disposition = gate.eval_disposition("/tmp");
+        assert!(
+            matches!(disposition, UfoDisposition::Unknown),
+            "expected Unknown for a rhai syntax error, got {:?}",
+            disposition
+        );
+    }
+
+    #[test]
+    fn eval_disposition_rhai_false_is_violated() {
+        // A rhai expression that evaluates cleanly to `false` IS a genuine
+        // violation — distinct from the syntax-error/Unknown case above,
+        // proving the 3-way split (Satisfied/Violated/Unknown) is real.
+        let gate = GateSpec {
+            rhai: Some("false".to_string()),
+            ..Default::default()
+        };
+        let disposition = gate.eval_disposition("/tmp");
+        match disposition {
+            UfoDisposition::Violated { reason } => {
+                assert!(reason.contains("returned false"), "reason: {reason}");
+            }
+            other => panic!("expected Violated, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn eval_disposition_rhai_true_is_satisfied() {
+        let gate = GateSpec {
+            rhai: Some("true".to_string()),
+            ..Default::default()
+        };
+        assert!(matches!(
+            gate.eval_disposition("/tmp"),
+            UfoDisposition::Satisfied
+        ));
+    }
+
+    #[test]
+    fn evaluate_gates_regression_lock_bad_rhai_syntax_matches_legacy_output() {
+        // Regression-lock: legacy bool-returning evaluate_gates() must
+        // produce byte-identical passed/reason output for a rhai syntax
+        // error after the #927 refactor — this test would have caught a
+        // behavior change in that path.
+        let gates = vec![GateSpec {
+            rhai: Some("this is not valid rhai (((".to_string()),
+            ..Default::default()
+        }];
+        let results = evaluate_gates(&gates, "/tmp");
+        assert_eq!(results.len(), 1);
+        assert!(!results[0].passed, "rhai syntax error should fail the gate");
+        assert!(
+            results[0].reason.contains("rhai gate")
+                && results[0].reason.contains("failed:"),
+            "reason should preserve the legacy 'rhai gate ... failed: <err>' text, got: {}",
+            results[0].reason
+        );
+    }
+
+    #[test]
+    fn evaluate_gates_regression_lock_rhai_false_matches_legacy_output() {
+        let gates = vec![GateSpec {
+            rhai: Some("false".to_string()),
+            ..Default::default()
+        }];
+        let results = evaluate_gates(&gates, "/tmp");
+        assert_eq!(results.len(), 1);
+        assert!(!results[0].passed);
+        assert!(results[0].reason.contains("returned false"));
+    }
+
+    #[test]
+    fn evaluate_gates_regression_lock_rhai_true_passes() {
+        let gates = vec![GateSpec {
+            rhai: Some("true".to_string()),
+            ..Default::default()
+        }];
+        let results = evaluate_gates(&gates, "/tmp");
+        assert_eq!(results.len(), 1);
+        assert!(results[0].passed);
+    }
+
+    #[test]
+    fn gate_preconditions_empty_gates_is_satisfied() {
+        let datum = crate::BootDatum {
+            name: "empty-gates".into(),
+            ..Default::default()
+        };
+        let gates: Vec<GateSpec> = vec![];
+        let constraint = GatePreconditions {
+            gates: &gates,
+            path: "/tmp",
+        };
+        let result = datum.satisfies(&constraint);
+        assert!(result.is_satisfied());
+    }
+
+    #[test]
+    fn gate_preconditions_violated_gate_wins() {
+        let datum = crate::BootDatum {
+            name: "violated-gate".into(),
+            ..Default::default()
+        };
+        let gates = vec![GateSpec {
+            command: Some("definitely-not-a-real-command-927".to_string()),
+            ..Default::default()
+        }];
+        let constraint = GatePreconditions {
+            gates: &gates,
+            path: "/tmp",
+        };
+        let result = datum.satisfies(&constraint);
+        assert!(result.is_violated());
+    }
+
+    #[test]
+    fn gate_preconditions_unknown_gate_yields_unknown_disposition() {
+        let datum = crate::BootDatum {
+            name: "unknown-gate".into(),
+            ..Default::default()
+        };
+        let gates = vec![GateSpec {
+            rhai: Some("this is not valid rhai (((".to_string()),
+            ..Default::default()
+        }];
+        let constraint = GatePreconditions {
+            gates: &gates,
+            path: "/tmp",
+        };
+        let result = datum.satisfies(&constraint);
+        assert!(
+            matches!(result.disposition, UfoDisposition::Unknown),
+            "expected Unknown, got {:?}",
+            result.disposition
+        );
+    }
+
+    #[test]
+    fn gate_preconditions_violated_wins_over_unknown() {
+        // One violated gate + one undecidable (rhai syntax error) gate:
+        // Violated must win per the documented precedence.
+        let datum = crate::BootDatum {
+            name: "mixed-gates".into(),
+            ..Default::default()
+        };
+        let gates = vec![
+            GateSpec {
+                command: Some("definitely-not-a-real-command-927".to_string()),
+                ..Default::default()
+            },
+            GateSpec {
+                rhai: Some("this is not valid rhai (((".to_string()),
+                ..Default::default()
+            },
+        ];
+        let constraint = GatePreconditions {
+            gates: &gates,
+            path: "/tmp",
+        };
+        let result = datum.satisfies(&constraint);
+        assert!(result.is_violated());
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #927. Three ad-hoc bool/String validation paths silently collapsed "couldn't determine" into `false`/violated, losing the distinction between a genuine violation and an undecidable check. Each now routes through a real `Satisfies<C>` impl returning `SatisfiesResult` (`Disposition::Satisfied` / `Violated{reason}` / `Unknown`), wired to the real evidence sink (`b00t-cli/src/commands/evidence.rs`'s `record_is_a`/`record_audited_by`, which append to `~/.b00t/evidence/satisfies.jsonl`).

### The three Unknown-collapse bugs fixed

1. **`b00t-cli/src/gates.rs`** — a rhai gate eval **error** (bad syntax) was folded into `(false, Some(error))`, i.e. treated as a **violation**. It's now `Disposition::Unknown` (we couldn't evaluate it, we didn't evaluate it to false). Added `GateSpec::eval_disposition()`, a `GatePreconditions` constraint, and `impl Satisfies<GatePreconditions> for BootDatum`.

2. **`b00t-cli/src/commands/datum.rs`** (`datum validate --strict`) — the extension↔type consistency check was **silently skipped** (no error, no warning) whenever the filename extension was unrecognized. Extracted `compute_datum_validation()` as a pure function; added `DatumTomlSubject` + `BootDatumSchemaConstraint` + `Satisfies` impl. `Unknown` is now surfaced (printed, non-fatal by default; fatal under `--strict`, since `--strict` already means "be pedantic").

3. **`b00t-cli/src/commands/ontology.rs`** (`ontology sparql --predicate validate` / `is_validated`) — three distinct "couldn't determine" cases (empty validate command, invalid regex, command exec failure/ENOENT) all collapsed into `false`. Added `DatumValidateConstraint` + `impl Satisfies<DatumValidateConstraint> for DatumMeta`. `is_validated()` now delegates to `.satisfies(...).is_satisfied()`.

### Backward compatibility

- `evaluate_gates()` is a byte-identical thin fold over the new per-field evaluator — same `passed`/`reason` output for all 3 existing callers (`install.rs`, `commands/datum.rs`'s `govern_one`/`health_check_one` via `GateResultSummary`).
- `is_validated()` is byte-identical for every input (regression-lock test: `is_validated_returns_false_for_all_three_unknown_cases`).
- `handle_validate`'s existing print-based UX and `anyhow::bail!` error path are unchanged; the errors-still-fail behavior is preserved exactly.
- Full `b00t-cli --lib` test suite: **1449 tests pass, 0 failed** (pre-push gate also ran b00t-mcp: 58 tests, all green).

### Evidence-sink wiring proof

`validate_evidence_integration_tests::satisfies_evaluation_records_isa_and_audited_by_evidence` (in `commands/datum.rs`) uses the existing `with_test_evidence_log_path()` test harness to prove the NS-9/NS-10 wiring actually appends `isA:`/`audited_by:`-prefixed rows to `satisfies.jsonl`, not just computed and discarded.

### Acceptance measurement

`grep -rc 'impl.*Satisfies<' --include=*.rs . --exclude-dir=vendor --exclude-dir=target` now reads **4** (was 1): `gates.rs`, `commands/datum.rs`, `commands/ontology.rs`, and the pre-existing `b00t-c0re-lib/src/ai_artifact.rs` impl.

### Non-goals (explicitly untouched)

- Issue #906 (ScopeStore)
- `b00t-c0re-lib::gate_result::GateResult` (Zellij routing) — different type, same name
- `b00t_c0re_gov::types::GateResult` — different type, same name
- `guards/mod.rs`'s `HiveGuard`/`GuardResult` (separate "hive guard" subsystem)
- `govern_one`'s `prove_by_type()`/`PhaseResult`
- `list_gates()`/`GateReport.status`
- Adding a `--json` flag to `datum validate`

## Test plan

- [x] `cargo build -p b00t-cli` compiles clean
- [x] `cargo test -p b00t-cli --lib` — 1449 passed, 0 failed
- [x] New regression-lock tests confirm legacy bool/`GateResult` output is byte-identical pre/post refactor
- [x] New tests confirm each of the 3 Unknown-collapse bugs now surfaces `Disposition::Unknown` distinctly from `Violated`
- [x] Evidence-sink integration test confirms NS-9/NS-10 rows actually land in `satisfies.jsonl`
- [x] Pre-push gate (real `cargo test` across b00t-cli + reverse-dependant closure) passed on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)