### PR TITLE
chore: remove unused rmcp-rust-sdk vendor; add just-lsp on-demand datum

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -38,10 +38,6 @@
 	path = python.🐍/DALLE2-pytorch
 	url = https://github.com/lucidrains/DALLE2-pytorch.git
 
-[submodule "rmcp-rust-sdk"]
-	path = rmcp-rust-sdk
-	url = https://github.com/modelcontextprotocol/rust-sdk.git
-
 [submodule "vendor/agent-framework"]
 	path = vendor/agent-framework
 	url = https://github.com/microsoft/agent-framework

--- a/_b00t_/just-lsp.cli.toml
+++ b/_b00t_/just-lsp.cli.toml
@@ -1,0 +1,18 @@
+# just-lsp.cli — cli datum
+# Assimilated from: github:terror/just-lsp
+
+[b00t]
+name        = "just-lsp"
+type        = "cli"
+hint        = "just-lsp — terror/just-lsp — language server for the `just` command runner (tree-sitter-backed, CC0-1.0)"
+
+install = "cargo install just-lsp"
+version = "just-lsp --version"
+version_regex = '(\d+\.\d+\.\d+)'
+
+# b00t:map v1
+# summary: datum for github:terror/just-lsp — language server for the `just` command runner
+# tags: just-lsp, terror, lsp, justfile
+# tier: sm0l
+# cmds: b00t install just-lsp
+# complexity: 1


### PR DESCRIPTION
## Summary
- Removes the `rmcp-rust-sdk` vendor submodule — the workspace already depends on `rmcp 1.6.0` from crates.io directly (root `Cargo.toml`, `b00t-mcp/Cargo.toml` via `workspace.dependencies`); nothing in the workspace referenced the vendored path.
- Adds `_b00t_/just-lsp.cli.toml` so `just-lsp` (terror/just-lsp, LSP for the `just` command runner) is installable on demand via `cargo install just-lsp` from crates.io — same pattern as `pyinfra.cli.toml` (installs from PyPI) and `serena.mcp.toml` (uvx zero-install), rather than requiring the vendored `b00t-vscode/just-lsp` submodule checkout.

## Process
The datum was produced through a plan → build/test → QA/test agent pipeline:
- **Plan**: confirmed `just-lsp` is published on crates.io (v0.6.1, owner `terror`, matches upstream) and chose `cargo install just-lsp` over a git-based fallback.
- **Build/Test**: wrote the datum file and actually ran `cargo install just-lsp` + `just-lsp --version` to confirm it works end-to-end.
- **QA/Test**: independently re-verified the file and commands, and caught a real bug — `version_regex = '(\\d+\\.\\d+\\.\\d+)'` was double-escaped inside a TOML single-quoted literal, so the regex the code would actually receive could never match. Fixed to `'(\d+\.\d+\.\d+)'` and verified the corrected pattern extracts `0.6.1` from the real version output.

## Test plan
- [x] `cargo install just-lsp` succeeds, installs v0.6.1
- [x] `just-lsp --version` runs, prints `just-lsp 0.6.1`
- [x] Fixed `version_regex` verified to match that output
- [x] `cargo run -p b00t-cli -- --path _b00t_ datum validate --graph` → `datum graph: valid (505 datums)`
- [x] Repo's commit gate passed (14/14 rules + datum graph gate)

## Note
Along the way, hit and fixed unrelated local build corruption (truncated `.rlib` archives in `target/debug/deps` from an interrupted build earlier this session) that was blocking the commit-hook's build-based validation gate — not a code defect, just stale local build artifacts.