### PR TITLE
chore: remove vendor/agentfm-core submodule (broken pin)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -46,10 +46,6 @@
 	path = vendor/agent-framework
 	url = https://github.com/microsoft/agent-framework
 
-[submodule "vendor/agentfm-core"]
-	path = vendor/agentfm-core
-	url = https://github.com/microsoft/agent-framework
-
 [submodule "vendor/codebase-memory-mcp-b00t-ir0n-ledg3rr"]
 	path = vendor/codebase-memory-mcp-b00t-ir0n-ledg3rr
 	url = https://github.com/PromptExecution/codebase-memory-mcp-b00t-ir0n-ledg3rr.git


### PR DESCRIPTION
## Summary
Removes the `vendor/agentfm-core` submodule. Its recorded pin on `main` (`82e8653f`) no longer exists on the `Agent-FM/agentfm-core` remote (force-pushed away upstream — `git fetch` fails with "not our ref"), so the pin is permanently unresolvable as recorded. Nothing else in the workspace references this vendored path.

Also noted: `.gitmodules` had a stale/mismatched URL for this entry (`microsoft/agent-framework`) versus what was actually checked out on disk (`Agent-FM/agentfm-core`) — moot now that the submodule is gone.

## Context
Flagged during an earlier submodule pin-sync pass (#959) as a pre-existing broken pin needing separate investigation; per operator direction, removing it outright rather than trying to reconstruct a valid pin.

## Test plan
- [x] `grep -rn "agentfm-core"` outside the submodule itself returns no workspace references
- [x] Repo's commit gate passed (14/14 rules)