### PR TITLE
feat(credential): gate influence attribution on credential subject + expiry

### DIFF
--- a/b00t-c0re-lib/src/datum_credential.rs
+++ b/b00t-c0re-lib/src/datum_credential.rs
@@ -47,6 +47,14 @@ pub struct CredentialFields {
     /// Environment variable name for the secret
     #[serde(default)]
     pub secret_env: Option<String>,
+    /// Subject this credential is scoped to (e.g. agent/service identity).
+    /// Used by `validate_subject_not_expired` to check attribution callers
+    /// against the credential that authorized them.
+    #[serde(default)]
+    pub subject: Option<String>,
+    /// RFC3339 expiry timestamp. Past this time, the credential is considered expired.
+    #[serde(default)]
+    pub expires_at: Option<String>,
 }
 
 // ── Encryption helpers ────────────────────────────────────────────────────
@@ -117,6 +125,74 @@ mod tests {
         let encrypted = xor_crypt(secret.as_bytes(), &test_key);
         let decrypted = xor_crypt(&encrypted, &test_key);
         assert_eq!(String::from_utf8(decrypted).unwrap(), secret);
+    }
+
+    /// Shared fixture dir for `validate_subject_not_expired` tests. The
+    /// underlying `DATA_DIR_OVERRIDE` is a `OnceLock` (only the first
+    /// `_set_data_dir_for_test` call wins), so every test resolves to the
+    /// same directory and disambiguates via a unique provider name instead.
+    fn test_credential_data_dir() -> std::path::PathBuf {
+        let dir = std::env::temp_dir().join("b00t-credential-datum-test");
+        std::fs::create_dir_all(&dir).unwrap();
+        _set_data_dir_for_test(dir.clone());
+        dir
+    }
+
+    fn write_test_credential(
+        dir: &std::path::Path,
+        provider: &str,
+        subject: Option<&str>,
+        expires_at: Option<&str>,
+    ) {
+        let subject_line = subject
+            .map(|s| format!("subject = \"{s}\"\n"))
+            .unwrap_or_default();
+        let expires_line = expires_at
+            .map(|s| format!("expires_at = \"{s}\"\n"))
+            .unwrap_or_default();
+        let content = format!(
+            "[b00t]\nname = \"{provider}\"\ntype = \"credential\"\n\n[b00t.credential]\nprovider = \"{provider}\"\n{subject_line}{expires_line}"
+        );
+        std::fs::write(dir.join(format!("{provider}.credential.toml")), content).unwrap();
+    }
+
+    #[test]
+    fn test_validate_subject_not_expired_ok() {
+        let dir = test_credential_data_dir();
+        write_test_credential(
+            &dir,
+            "test-provider-ok",
+            Some("agent-123"),
+            Some("2999-01-01T00:00:00Z"),
+        );
+        let result = validate_subject_not_expired("test-provider-ok", "agent-123");
+        assert!(result.is_ok(), "expected Ok, got {result:?}");
+    }
+
+    #[test]
+    fn test_validate_subject_not_expired_subject_mismatch() {
+        let dir = test_credential_data_dir();
+        write_test_credential(
+            &dir,
+            "test-provider-mismatch",
+            Some("agent-123"),
+            Some("2999-01-01T00:00:00Z"),
+        );
+        let result = validate_subject_not_expired("test-provider-mismatch", "agent-999");
+        assert!(result.is_err(), "expected Err on subject mismatch");
+    }
+
+    #[test]
+    fn test_validate_subject_not_expired_expired() {
+        let dir = test_credential_data_dir();
+        write_test_credential(
+            &dir,
+            "test-provider-expired",
+            Some("agent-123"),
+            Some("2000-01-01T00:00:00Z"),
+        );
+        let result = validate_subject_not_expired("test-provider-expired", "agent-123");
+        assert!(result.is_err(), "expected Err on expired credential");
     }
 }
 
@@ -203,11 +279,78 @@ fn credential_path(provider: &str) -> std::path::PathBuf {
     b00t_data_dir().join(format!("{}.credential.toml", provider))
 }
 
+static DATA_DIR_OVERRIDE: std::sync::OnceLock<std::path::PathBuf> = std::sync::OnceLock::new();
+
+/// Override the credential data directory for tests. Mirrors
+/// `store::_set_store_root_for_test`. Only the first call takes effect
+/// (OnceLock); tests should share one directory and use distinct provider
+/// names to avoid collisions.
+#[doc(hidden)]
+pub fn _set_data_dir_for_test(path: std::path::PathBuf) {
+    let _ = DATA_DIR_OVERRIDE.set(path);
+}
+
 fn b00t_data_dir() -> std::path::PathBuf {
+    if let Some(dir) = DATA_DIR_OVERRIDE.get() {
+        return dir.clone();
+    }
     dirs::home_dir()
         .unwrap_or_else(|| std::path::PathBuf::from("."))
         .join(".b00t")
         .join("_b00t_")
+}
+
+/// Validate that the credential datum for `provider` is scoped to
+/// `expected_subject` and has not expired.
+///
+/// Used by `store::put_influence` to gate attribution: if a caller passes a
+/// `credential_subject_check` provider, the influence receipt is only
+/// generated when the named credential's `subject` matches the attribution
+/// subject and its `expires_at` (if set) is still in the future.
+///
+/// Errors when: no credential datum exists for `provider`, the credential's
+/// `subject` is set and does not match `expected_subject`, or `expires_at`
+/// is set and is in the past (or fails to parse as RFC3339).
+pub fn validate_subject_not_expired(provider: &str, expected_subject: &str) -> Result<()> {
+    let cred = list_credential_files()?
+        .into_iter()
+        .find(|datum| {
+            datum.b00t.name == provider
+                || datum.b00t.credential.as_ref().map(|c| c.provider.as_str()) == Some(provider)
+        })
+        .and_then(|datum| datum.b00t.credential)
+        .ok_or_else(|| anyhow::anyhow!("no credential datum found for provider '{}'", provider))?;
+
+    if let Some(ref subject) = cred.subject {
+        if subject != expected_subject {
+            anyhow::bail!(
+                "credential subject mismatch for provider '{}': expected '{}', found '{}'",
+                provider,
+                expected_subject,
+                subject
+            );
+        }
+    }
+
+    if let Some(ref expires_at) = cred.expires_at {
+        let expiry = chrono::DateTime::parse_from_rfc3339(expires_at)
+            .with_context(|| {
+                format!(
+                    "credential expires_at for provider '{}' is not valid RFC3339: '{}'",
+                    provider, expires_at
+                )
+            })?
+            .with_timezone(&chrono::Utc);
+        if expiry < chrono::Utc::now() {
+            anyhow::bail!(
+                "credential for provider '{}' expired at {}",
+                provider,
+                expires_at
+            );
+        }
+    }
+
+    Ok(())
 }
 
 fn list_credential_files() -> Result<Vec<CredentialDatum>> {

--- a/b00t-c0re-lib/src/store.rs
+++ b/b00t-c0re-lib/src/store.rs
@@ -191,11 +191,29 @@ pub struct InfluenceSource {
 pub struct InfluenceReceipt {
     pub subject: String,
     pub sources: Vec<InfluenceSource>,
+    /// 🤓 Provider name checked via `datum_credential::validate_subject_not_expired`,
+    ///    when the caller opted into credential-scoped attribution. `None` when no
+    ///    check was requested (backward-compatible default).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub credential_subject_check: Option<String>,
 }
 
 /// 🤓 Minimal AL-1.0 attribution: normalises raw scores into ratios summing to 1.0.
 ///    Does not persist — callers (e.g. evidence records) attach the receipt directly.
-pub fn put_influence(subject: &str, scored_sources: &[(String, f64)]) -> Result<InfluenceReceipt> {
+///
+///    `credential_subject_check`: optional credential provider name. When set, the
+///    credential datum for that provider must have `subject == subject` and not be
+///    expired (see `datum_credential::validate_subject_not_expired`), or this errors.
+///    `None` skips the check entirely (default, backward-compatible).
+pub fn put_influence(
+    subject: &str,
+    scored_sources: &[(String, f64)],
+    credential_subject_check: Option<&str>,
+) -> Result<InfluenceReceipt> {
+    if let Some(provider) = credential_subject_check {
+        crate::datum_credential::validate_subject_not_expired(provider, subject)?;
+    }
+
     let total: f64 = scored_sources.iter().map(|(_, score)| score).sum();
     let sources = scored_sources
         .iter()
@@ -208,6 +226,7 @@ pub fn put_influence(subject: &str, scored_sources: &[(String, f64)]) -> Result<
     Ok(InfluenceReceipt {
         subject: subject.to_string(),
         sources,
+        credential_subject_check: credential_subject_check.map(|s| s.to_string()),
     })
 }
 
@@ -468,6 +487,33 @@ mod tests {
 
         let query = query(&tags).expect("query");
         assert!(!query.is_empty());
+    }
+
+    #[test]
+    fn test_put_influence_credential_check_missing_provider_errors() {
+        // No credential datum exists for "nonexistent-provider" — the check
+        // must fail closed rather than silently skipping attribution.
+        let scored = vec![("source-a".to_string(), 1.0)];
+        let result = put_influence("subject-x", &scored, Some("nonexistent-provider"));
+        assert!(
+            result.is_err(),
+            "expected Err when credential_subject_check provider has no credential datum"
+        );
+    }
+
+    #[test]
+    fn test_put_influence_no_credential_check_is_unchanged() {
+        // Regression guard: passing None must preserve prior (pre-#715) behavior.
+        let scored = vec![
+            ("source-a".to_string(), 3.0),
+            ("source-b".to_string(), 1.0),
+        ];
+        let receipt = put_influence("subject-y", &scored, None).expect("put_influence");
+        assert_eq!(receipt.subject, "subject-y");
+        assert_eq!(receipt.sources.len(), 2);
+        assert!(receipt.credential_subject_check.is_none());
+        let source_a = receipt.sources.iter().find(|s| s.source_key == "source-a").unwrap();
+        assert!((source_a.ratio - 0.75).abs() < 1e-9);
     }
 }
 

--- a/b00t-cli/src/commands/evidence.rs
+++ b/b00t-cli/src/commands/evidence.rs
@@ -148,15 +148,23 @@ pub fn prove_skill(skill: &str) -> Result<Vec<EvidenceRecord>> {
 
 /// Record that `skill` satisfies `constraint` with AL-1.0 influence attribution.
 /// Generates influence receipt in store, attaches receipt key to evidence record.
+///
 /// `agent_id` (if given) is stamped onto the record for `b00t influence log --agent`
 /// and `b00t influence stats` top-agent aggregation (#691).
+///
+/// `credential_subject_check`: optional credential provider name (see
+/// `b00t_c0re_lib::store::put_influence`). Pass `None` for the prior,
+/// unchecked behavior; pass `Some(provider)` to require that provider's
+/// credential datum be scoped to `skill` and not expired.
 pub fn record_satisfies_with_influence(
     skill: &str,
     constraint: &str,
     scored_sources: &[(String, f64)],
     agent_id: Option<&str>,
+    credential_subject_check: Option<&str>,
 ) -> Result<()> {
-    let receipt = b00t_c0re_lib::store::put_influence(skill, scored_sources)?;
+    let receipt =
+        b00t_c0re_lib::store::put_influence(skill, scored_sources, credential_subject_check)?;
     let weights: Vec<InfluenceWeight> = receipt
         .sources
         .iter()
@@ -351,7 +359,7 @@ pub fn handle_evidence(args: &EvidenceArgs) -> Result<()> {
         } => {
             if let Some(spec) = influence {
                 let scored_sources = parse_influence_arg(spec)?;
-                record_satisfies_with_influence(skill, constraint, &scored_sources, agent_id.as_deref())?;
+                record_satisfies_with_influence(skill, constraint, &scored_sources, agent_id.as_deref(), None)?;
             } else {
                 let mut rec = EvidenceRecord::satisfies(skill, constraint);
                 rec.agent_id = agent_id.clone();
@@ -540,6 +548,7 @@ mod tests {
                 "requires:role:backend",
                 &[("source-a".to_string(), 3.0), ("source-b".to_string(), 1.0)],
                 Some("agent-1"),
+                None,
             )
             .unwrap();
 

--- a/b00t-cli/tests/influence_audit_test.rs
+++ b/b00t-cli/tests/influence_audit_test.rs
@@ -68,6 +68,7 @@ fn producer_path_writes_influence_and_log_surfaces_it() {
             "requires:role:backend",
             &[("grok-doc-1".to_string(), 4.0), ("lfmf-lesson-9".to_string(), 1.0)],
             Some("agent-alpha"),
+            None,
         )
         .unwrap();
 


### PR DESCRIPTION
## Summary
- Adds `CredentialFields.subject` / `.expires_at` and `datum_credential::validate_subject_not_expired(provider, expected_subject)`, erroring if a credential datum's subject doesn't match the caller or its `expires_at` (RFC3339) is in the past.
- `store::put_influence` gains an optional `credential_subject_check: Option<&str>` parameter; when set, runs the check before generating the influence receipt (fail closed), and records which provider was checked. `None` preserves prior behavior exactly.
- `evidence::record_satisfies_with_influence` threads the new parameter through to callers, resolved against the concurrently-landed `agent_id` parameter from #691.

Recovered from an interrupted agent worktree (task/715) — rebased onto current `main`, resolved a real conflict against #691's `agent_id` parameter (both are now threaded through), and stripped incidental submodule-pointer drift picked up by the stale worktree.

## Test plan
- [x] Rebased onto `origin/main`, conflict in `evidence.rs` resolved by combining both new parameters
- [x] New unit tests: `test_put_influence_credential_check_missing_provider_errors`, `test_put_influence_no_credential_check_is_unchanged`
- [x] Pre-push gate: full workspace test suite passes (1452 passed, 0 failed)