### PR TITLE
feat(whoami): local model server status — running/ready/feasible/unavailable

### DIFF
--- a/b00t-cli/src/main.rs
+++ b/b00t-cli/src/main.rs
@@ -2409,6 +2409,8 @@ async fn main() {
                 match B00tContext::current() {
                     Ok(ctx) => {
                         let health = b00t_cli::commands::doctor_cmd::health_json();
+                        // #962: local model server state — running/ready/feasible/unavailable
+                        let model_server_status = whoami::model_server_status();
                         let output = serde_json::json!({
                             "agent": ctx.agent,
                             "pid": ctx.pid,
@@ -2422,6 +2424,7 @@ async fn main() {
                             "timestamp": ctx.timestamp,
                             "role": role.clone().or_else(|| std::env::var("_B00T_ROLE").ok()),
                             "health": health,
+                            "model_server_status": model_server_status.as_str(),
                         });
                         println!("{}", serde_json::to_string_pretty(&output).unwrap());
                     }

--- a/b00t-cli/src/whoami.rs
+++ b/b00t-cli/src/whoami.rs
@@ -815,6 +815,7 @@ pub fn build_dashboard() -> Vec<DashboardLayer> {
     inf.push(check_binary("ollama", "ollama --version"));
     inf.push(check_binary("llama.cpp", "llama-cli --version"));
     inf.push(detect_models());
+    inf.push(detect_model_server());
     layers.push(DashboardLayer {
         z: 2,
         name: "Inference",
@@ -1045,6 +1046,180 @@ fn detect_models() -> DashboardItem {
             DashboardStatus::Unknown
         },
         detail: format!("{} GGUF files", count),
+    }
+}
+
+/// ─── Local model server status (issue #962) ─────────────────────────────────
+///
+/// Classifies whether a local OpenAI-compatible inference endpoint — the
+/// mistralrs-proxy gateway on `:1234` (`_b00t_/mistralrs-proxy.hive.toml`) or
+/// the ch0nky llama.cpp container on `:8001`
+/// (`_b00t_/inference-qwen36-35b-a3b-llamacpp.hive.toml`) — is actually
+/// usable right now, vs merely possible on this node. Kept as a pure
+/// function over `ModelServerProbe` so the classification logic is
+/// unit-testable without a real GPU or a real listening port;
+/// `probe_model_server()` does the (untestable-in-CI) real-world probing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ModelServerStatus {
+    /// A known local inference endpoint responds on its configured port right now.
+    Running,
+    /// Built/configured and startable (binary/image present, GPU free) but not running.
+    Ready,
+    /// GPU/hardware present and idle, but no local server built/configured yet.
+    Feasible,
+    /// No compatible GPU/hardware on this node, or explicitly disabled.
+    Unavailable,
+}
+
+impl ModelServerStatus {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            ModelServerStatus::Running => "running",
+            ModelServerStatus::Ready => "ready",
+            ModelServerStatus::Feasible => "feasible",
+            ModelServerStatus::Unavailable => "unavailable",
+        }
+    }
+}
+
+/// Independently-probed facts feeding classification. `probe_model_server()`
+/// fills these from real commands (nvidia-smi / curl / which); tests supply
+/// fabricated combinations directly, without touching real hardware or ports.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ModelServerProbe {
+    /// GPU/hardware present on this node (regardless of current utilization).
+    pub gpu_present: bool,
+    /// mistralrs-proxy gateway (`:1234`) answers a `/v1/models` request right now.
+    pub gateway_responding: bool,
+    /// ch0nky llama.cpp inference container (`:8001`) answers right now.
+    pub inference_responding: bool,
+    /// A local server is built/configured and startable (binary or image present).
+    pub server_built: bool,
+}
+
+/// Pure classification — see `ModelServerStatus` variants for precedence:
+/// responding now beats merely built, beats merely feasible.
+pub fn classify_model_server(probe: &ModelServerProbe) -> ModelServerStatus {
+    if probe.gateway_responding || probe.inference_responding {
+        ModelServerStatus::Running
+    } else if probe.server_built {
+        ModelServerStatus::Ready
+    } else if probe.gpu_present {
+        ModelServerStatus::Feasible
+    } else {
+        ModelServerStatus::Unavailable
+    }
+}
+
+/// Configured ports for the two known local inference endpoints — see
+/// `_b00t_/mistralrs-proxy.hive.toml` and
+/// `_b00t_/inference-qwen36-35b-a3b-llamacpp.hive.toml`.
+const MODEL_GATEWAY_PORT: u16 = 1234; // mistralrs-proxy
+const MODEL_INFERENCE_PORT: u16 = 8001; // ch0nky llama.cpp container
+
+/// Probe an OpenAI-compatible `/v1/models` endpoint via curl — mirrors
+/// `doctor_cmd::check_model_endpoint`'s pattern (curl over reqwest, to avoid
+/// pulling an async runtime into this sync CLI path).
+fn probe_http_models_ok(port: u16) -> bool {
+    command_output_with_timeout(
+        "curl",
+        &[
+            "-s",
+            "--max-time",
+            "2",
+            "-o",
+            "/dev/null",
+            "-w",
+            "%{http_code}",
+            &format!("http://127.0.0.1:{}/v1/models", port),
+        ],
+        dashboard_probe_timeout(),
+    )
+    .map(|o| String::from_utf8_lossy(&o.stdout).trim() == "200")
+    .unwrap_or(false)
+}
+
+/// True if a compatible local GPU (NVIDIA, via nvidia-smi) is present on
+/// this node. Mirrors `detect_gpu()`'s probe.
+fn probe_gpu_present() -> bool {
+    command_output_with_timeout(
+        "nvidia-smi",
+        &["--query-gpu=name", "--format=csv,noheader"],
+        dashboard_probe_timeout(),
+    )
+    .map(|o| o.status.success() && !String::from_utf8_lossy(&o.stdout).trim().is_empty())
+    .unwrap_or(false)
+}
+
+/// True if a local model server is built/startable: the mistralrs gateway
+/// binary or a llama.cpp server binary is on PATH, or the stock llama.cpp
+/// container image has been pulled (see
+/// `_b00t_/llama-cpp-server.container.toml`).
+fn probe_model_server_built() -> bool {
+    let present = |cmd: &str| {
+        command_output_with_timeout(cmd, &["--version"], dashboard_probe_timeout()).is_some()
+    };
+    if present("mistralrs") || present("llama-server") || present("llama-cli") {
+        return true;
+    }
+    command_output_with_timeout(
+        "podman",
+        &["image", "exists", "ghcr.io/ggml-org/llama.cpp:server"],
+        dashboard_probe_timeout(),
+    )
+    .map(|o| o.status.success())
+    .unwrap_or(false)
+}
+
+/// Real-world probe feeding `classify_model_server`. Not unit-tested
+/// directly (requires real GPU/curl/podman state on the host); the
+/// classification logic it feeds is tested exhaustively via fabricated
+/// `ModelServerProbe` fixtures instead.
+fn probe_model_server() -> ModelServerProbe {
+    ModelServerProbe {
+        gpu_present: probe_gpu_present(),
+        gateway_responding: probe_http_models_ok(MODEL_GATEWAY_PORT),
+        inference_responding: probe_http_models_ok(MODEL_INFERENCE_PORT),
+        server_built: probe_model_server_built(),
+    }
+}
+
+/// Public entry point for callers outside this module (e.g. `whoami --json`)
+/// that just need the classification, not the dashboard rendering.
+pub fn model_server_status() -> ModelServerStatus {
+    classify_model_server(&probe_model_server())
+}
+
+fn detect_model_server() -> DashboardItem {
+    let probe = probe_model_server();
+    let status = classify_model_server(&probe);
+    let detail = match status {
+        ModelServerStatus::Running => {
+            let mut which = Vec::new();
+            if probe.gateway_responding {
+                which.push(format!("gateway :{}", MODEL_GATEWAY_PORT));
+            }
+            if probe.inference_responding {
+                which.push(format!("inference :{}", MODEL_INFERENCE_PORT));
+            }
+            format!("running — {}", which.join(", "))
+        }
+        ModelServerStatus::Ready => format!(
+            "ready — built, not running (start via mistralrs-proxy :{} or ch0nky :{})",
+            MODEL_GATEWAY_PORT, MODEL_INFERENCE_PORT
+        ),
+        ModelServerStatus::Feasible => "feasible — GPU idle, no local server built yet".into(),
+        ModelServerStatus::Unavailable => "unavailable — no compatible GPU detected".into(),
+    };
+    DashboardItem {
+        label: "Local Model Server".into(),
+        status: match status {
+            ModelServerStatus::Running => DashboardStatus::Ready,
+            ModelServerStatus::Ready => DashboardStatus::Warning,
+            ModelServerStatus::Feasible => DashboardStatus::Unknown,
+            ModelServerStatus::Unavailable => DashboardStatus::Critical,
+        },
+        detail,
     }
 }
 
@@ -1865,5 +2040,116 @@ hint = "ralph mcp"
         let output = "no tasks found\n";
         let tasks = parse_task_list_output(output);
         assert!(tasks.is_empty());
+    }
+
+    // ─── Model server status tests (#962) ──────────────────────────────
+
+    #[test]
+    fn test_model_server_running_when_gateway_responds() {
+        let probe = ModelServerProbe {
+            gpu_present: true,
+            gateway_responding: true,
+            inference_responding: false,
+            server_built: true,
+        };
+        assert_eq!(classify_model_server(&probe), ModelServerStatus::Running);
+    }
+
+    #[test]
+    fn test_model_server_running_when_inference_responds() {
+        // Gateway down but the ch0nky llama.cpp container answers — still "running".
+        let probe = ModelServerProbe {
+            gpu_present: true,
+            gateway_responding: false,
+            inference_responding: true,
+            server_built: true,
+        };
+        assert_eq!(classify_model_server(&probe), ModelServerStatus::Running);
+    }
+
+    #[test]
+    fn test_model_server_running_takes_precedence_over_built_and_gpu() {
+        // Even if server_built/gpu_present were somehow false, a live port answer wins.
+        let probe = ModelServerProbe {
+            gpu_present: false,
+            gateway_responding: true,
+            inference_responding: false,
+            server_built: false,
+        };
+        assert_eq!(classify_model_server(&probe), ModelServerStatus::Running);
+    }
+
+    #[test]
+    fn test_model_server_ready_when_built_but_not_responding() {
+        let probe = ModelServerProbe {
+            gpu_present: true,
+            gateway_responding: false,
+            inference_responding: false,
+            server_built: true,
+        };
+        assert_eq!(classify_model_server(&probe), ModelServerStatus::Ready);
+    }
+
+    #[test]
+    fn test_model_server_feasible_when_gpu_present_but_nothing_built() {
+        let probe = ModelServerProbe {
+            gpu_present: true,
+            gateway_responding: false,
+            inference_responding: false,
+            server_built: false,
+        };
+        assert_eq!(classify_model_server(&probe), ModelServerStatus::Feasible);
+    }
+
+    #[test]
+    fn test_model_server_unavailable_when_no_gpu_and_nothing_built() {
+        let probe = ModelServerProbe::default();
+        assert_eq!(
+            classify_model_server(&probe),
+            ModelServerStatus::Unavailable
+        );
+    }
+
+    #[test]
+    fn test_model_server_unavailable_takes_precedence_when_not_responding_or_built() {
+        // No GPU, nothing built, nothing responding — unavailable regardless
+        // of any other combination not already covered above.
+        let probe = ModelServerProbe {
+            gpu_present: false,
+            gateway_responding: false,
+            inference_responding: false,
+            server_built: false,
+        };
+        assert_eq!(
+            classify_model_server(&probe),
+            ModelServerStatus::Unavailable
+        );
+    }
+
+    #[test]
+    fn test_model_server_status_as_str_matches_issue_962_vocabulary() {
+        assert_eq!(ModelServerStatus::Running.as_str(), "running");
+        assert_eq!(ModelServerStatus::Ready.as_str(), "ready");
+        assert_eq!(ModelServerStatus::Feasible.as_str(), "feasible");
+        assert_eq!(ModelServerStatus::Unavailable.as_str(), "unavailable");
+    }
+
+    #[test]
+    fn test_detect_model_server_is_present_in_inference_layer() {
+        // Real-world smoke test: this node may or may not have a GPU/server,
+        // but the dashboard item must always be produced without panicking
+        // and must carry a non-empty label/detail (see
+        // test_dashboard_status_display_consistency for the general check).
+        let layers = build_dashboard();
+        let inference = layers
+            .iter()
+            .find(|l| l.name == "Inference")
+            .expect("Inference layer missing");
+        let item = inference
+            .items
+            .iter()
+            .find(|i| i.label == "Local Model Server")
+            .expect("Local Model Server item missing from Inference layer");
+        assert!(!item.detail.is_empty());
     }
 }


### PR DESCRIPTION
## Summary
- `b00t whoami --dashboard` gains a **Local Model Server** item in the Inference layer, classified as one of `running` / `ready` / `feasible` / `unavailable`.
- `b00t whoami --json` gains a top-level `model_server_status` field with the same classification.
- Classification (`classify_model_server`) checks, in precedence order: does the mistralrs-proxy gateway (`:1234`, `_b00t_/mistralrs-proxy.hive.toml`) or the ch0nky llama.cpp container (`:8001`, `_b00t_/inference-qwen36-35b-a3b-llamacpp.hive.toml`) answer `/v1/models` right now (`running`) → is a server binary/image built (`mistralrs`/`llama-server`/`llama-cli` on PATH, or the stock `ghcr.io/ggml-org/llama.cpp:server` image pulled) but not running (`ready`) → is a compatible GPU present via `nvidia-smi` but nothing built (`feasible`) → otherwise `unavailable`.
- Pure classification logic (`classify_model_server`) takes a `ModelServerProbe` struct of booleans, so it's unit-tested exhaustively without touching real hardware, curl, or podman. The real-world probing (`probe_model_server()`) is a thin, untested-by-design wiring layer, exercised only as a dashboard smoke test.

## Why
Fixes #962 — agents were manually curling ports / grepping `podman ps` to figure out whether a local inference endpoint was up, and had no cheap way to distinguish "nothing running" from "wrong port" from "not feasible on this node at all."

## Files
- `b00t-cli/src/whoami.rs` — `ModelServerStatus`, `ModelServerProbe`, `classify_model_server`, `probe_model_server`, `detect_model_server`, wired into `build_dashboard()`'s Inference layer; 9 new unit tests.
- `b00t-cli/src/main.rs` — `model_server_status` field added to the `whoami --json` output.

## Test plan
- [x] `cargo test -p b00t-cli --lib` — 1461 passed, 0 failed, 4 ignored (pre-existing ignores, unrelated).
- [x] `cargo build -p b00t-cli --bin b00t-cli` — clean build.
- [x] Manual smoke test on this node (no NVIDIA GPU): `b00t whoami --dashboard` shows `✗ Local Model Server — unavailable — no compatible GPU detected`; `b00t whoami --json | jq .model_server_status` → `"unavailable"` — correct given no `nvidia-smi` here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)