### PR TITLE
feat(docker): adopt cargo-chef three-stage pattern for workspace Rust builds

### DIFF
--- a/Dockerfile.b00t-cli
+++ b/Dockerfile.b00t-cli
@@ -6,14 +6,8 @@
 FROM ghcr.io/elasticdotventures/just:latest AS just-binary
 
 # ================================
-# Stage 1: Rust Build Environment
+# Stage 1: cargo-chef base (dependency cache layer)
 # ================================
-FROM rust:1.96-slim AS rust-builder
-
-# Copy just from forked container
-COPY --from=just-binary /usr/local/bin/just /usr/local/bin/just
-
-# Install build dependencies
 # `perl` (not just the slim image's preinstalled perl-base) is required
 # because openssl-sys vendors and builds OpenSSL from source here, and its
 # Configure script needs FindBin.pm, which perl-base doesn't ship.
@@ -21,6 +15,7 @@ COPY --from=just-binary /usr/local/bin/just /usr/local/bin/just
 # rust:slim ships no native toolchain at all, and b00t-cli depends on
 # b00t-embed -> embed_anything, whose transitive deps (e.g. esaxx-rs) build
 # native C/C++ code.
+FROM rust:1.96-slim AS chef
 RUN apt-get update && apt-get install -y \
     pkg-config \
     libssl-dev \
@@ -30,11 +25,89 @@ RUN apt-get update && apt-get install -y \
     perl \
     build-essential \
     && rm -rf /var/lib/apt/lists/*
-
-# Set working directory for the Rust project
+RUN cargo install cargo-chef --locked
 WORKDIR /build
 
-# Copy workspace root and required workspace members/vendor crates
+# ================================
+# Stage 2: planner — compute the dependency recipe
+# ================================
+FROM chef AS planner
+
+# Copy workspace root and required workspace members/vendor crates.
+# cargo-chef only needs the manifests (Cargo.toml/Cargo.lock) to compute
+# recipe.json, but this workspace is a virtual workspace: `cargo` refuses to
+# resolve *any* member unless every listed member's Cargo.toml is present on
+# disk, and several members path-depend on crates living outside the
+# workspace `members` list (e.g. vendor/*). Copying full crate directories
+# (matching the exact set the real build needs) keeps this list a single
+# source of truth shared with the builder stage below.
+COPY Cargo.toml Cargo.lock ./
+COPY _b00t_/ ./_b00t_/
+COPY b00t-admin/ ./b00t-admin/
+COPY b00t-ast/ ./b00t-ast/
+COPY b00t-azure-cp/ ./b00t-azure-cp/
+COPY b00t-bouncer/ ./b00t-bouncer/
+COPY b00t-cad/ ./b00t-cad/
+COPY b00t-cli/ ./b00t-cli/
+COPY b00t-crate/ ./b00t-crate/
+COPY b00t-c0re-a2a/ ./b00t-c0re-a2a/
+COPY b00t-c0re-gov/ ./b00t-c0re-gov/
+COPY b00t-c0re-hierarchy/ ./b00t-c0re-hierarchy/
+COPY b00t-c0re-lib/ ./b00t-c0re-lib/
+COPY b00t-datum-core/ ./b00t-datum-core/
+COPY b00t-embed/ ./b00t-embed/
+COPY b00t-grok/ ./b00t-grok/
+COPY b00t-ipc/ ./b00t-ipc/
+COPY b00t-l3dg3rr-viz/ ./b00t-l3dg3rr-viz/
+COPY b00t-lib-chat/ ./b00t-lib-chat/
+COPY b00t-lsp/ ./b00t-lsp/
+COPY b00t-mcp/ ./b00t-mcp/
+COPY b00t-mcp-npm/ ./b00t-mcp-npm/
+COPY b00t-mermaid-wasm/ ./b00t-mermaid-wasm/
+COPY b00t-pyverse/ ./b00t-pyverse/
+COPY b00t-ui-wasm/ ./b00t-ui-wasm/
+COPY b00t-zellij/ ./b00t-zellij/
+COPY blessed/ ./blessed/
+COPY k0mmand3r/ ./k0mmand3r/
+COPY pm2-tasker/ ./pm2-tasker/
+COPY vendor/embed-anything-b00t/rust/ ./vendor/embed-anything-b00t/rust/
+COPY vendor/embed-anything-b00t/processors/ ./vendor/embed-anything-b00t/processors/
+COPY vendor/irontology-mcp/ ./vendor/irontology-mcp/
+COPY vendor/ledgrrr/crates/b00t-reflect-types/ ./vendor/ledgrrr/crates/b00t-reflect-types/
+COPY vendor/runpod-sdk/ ./vendor/runpod-sdk/
+COPY vendor/tomllm/ ./vendor/tomllm/
+
+RUN cargo chef prepare --recipe-path recipe.json
+
+# ================================
+# Stage 3: builder — cook deps (cacheable), then build real binaries
+# ================================
+FROM chef AS rust-builder
+
+# Copy just from forked container
+COPY --from=just-binary /usr/local/bin/just /usr/local/bin/just
+
+# Build only the dependency graph from the recipe. As long as recipe.json
+# is unchanged (i.e. no Cargo.toml/Cargo.lock edits), this RUN layer is
+# served from cache even when application source changes below.
+COPY --from=planner /build/recipe.json recipe.json
+
+# 🤓 cargo-chef's `cook` only reconstructs dummy sources for crates in
+# `[workspace] members`. vendor/embed-anything-b00t and vendor/runpod-sdk
+# are deliberately excluded from workspace membership (root Cargo.toml
+# `exclude`) yet are real path dependencies of workspace members
+# (b00t-embed, b00t-cli respectively) — chef silently drops them from the
+# reconstructed tree, so `cook` fails trying to read their Cargo.toml back
+# out. Copying their real source in before cook fixes this; it narrows the
+# dependency-cache benefit slightly for these two (rarely-changing) vendored
+# submodules, but every other workspace member still caches cleanly.
+COPY vendor/embed-anything-b00t/rust/ ./vendor/embed-anything-b00t/rust/
+COPY vendor/embed-anything-b00t/processors/ ./vendor/embed-anything-b00t/processors/
+COPY vendor/runpod-sdk/ ./vendor/runpod-sdk/
+
+RUN cargo chef cook --release --recipe-path recipe.json
+
+# Copy the real sources (same set as the planner stage above).
 COPY Cargo.toml Cargo.lock ./
 COPY _b00t_/ ./_b00t_/
 COPY b00t-admin/ ./b00t-admin/
@@ -82,7 +155,7 @@ RUN ls -la /usr/local/bin/b00t-* && \
     /usr/local/bin/b00t-mcp --version
 
 # ================================
-# Stage 2: b00t Resources Layer
+# Stage 4: b00t Resources Layer
 # ================================
 FROM scratch AS b00t-resources
 
@@ -91,7 +164,7 @@ FROM scratch AS b00t-resources
 COPY _b00t_/ /opt/b00t/config/
 
 # ================================
-# Stage 3: b00t-cli Distribution Layer
+# Stage 5: b00t-cli Distribution Layer
 # ================================
 FROM ubuntu:24.04 AS b00t-cli-layer
 

--- a/b00t-azure-cp/Dockerfile
+++ b/b00t-azure-cp/Dockerfile
@@ -1,12 +1,17 @@
 # syntax=docker/dockerfile:1
 # ---------------------------------------------------------------------------
-# b00t Azure Control Plane — multi-stage Dockerfile
+# b00t Azure Control Plane — multi-stage Dockerfile (cargo-chef pattern)
 #
-# Stage 1 (builder): Rust workspace build — compiles only b00t-azure-cp.
-# Stage 2 (runtime): Distroless, ~30MB final image.
+# Stage 1 (chef):    base image + cargo-chef install.
+# Stage 2 (planner): `cargo chef prepare` -> recipe.json (deps-only fingerprint).
+# Stage 3 (builder): `cargo chef cook` builds ONLY dependencies as a
+#                     cacheable layer, then the real source is copied in and
+#                     `cargo build` compiles just b00t-azure-cp against the
+#                     already-warm dependency cache.
+# Stage 4 (runtime): Distroless, ~30MB final image.
 #
 # Build:
-#   docker build -t ghcr.io/elasticdotventures/b00t-azure-cp:latest \
+#   podman build -t ghcr.io/elasticdotventures/b00t-azure-cp:latest \
 #     -f b00t-azure-cp/Dockerfile .
 #   (run from ~/.b00t/ workspace root)
 #
@@ -14,54 +19,136 @@
 #   B00T_NODE_ID, AZURE_STORAGE_ACCOUNT_NAME, AZURE_TABLE_NAME,
 #   AZURE_RESOURCE_GROUP, AZURE_SUBSCRIPTION_ID, AZURE_CLIENT_ID,
 #   LEASE_TTL_MINUTES, PORT
+#
+# 🤓 b00t-azure-cp itself only depends on workspace-external crates (azure_*,
+#    axum, tokio, ...) — no path deps on sibling b00t-* crates. But this repo
+#    is one big Cargo virtual workspace (see root Cargo.toml `[workspace]
+#    members`), and `cargo` refuses to resolve *any* member — even to build
+#    just one bin — unless every listed member's Cargo.toml is present on
+#    disk, and several of those members path-depend on crates living outside
+#    the workspace `members` list (vendor/*). So the manifest COPY list below
+#    must cover the *entire* workspace, matching Dockerfile.b00t-cli's list —
+#    this is not b00t-azure-cp-specific bloat, it's a workspace resolution
+#    requirement. The previous non-chef version of this Dockerfile only
+#    copied a 10-crate subset (and had a stale `tomllm/` path instead of
+#    `vendor/tomllm/`), which would have failed to resolve against the full
+#    25-member workspace.
 # ---------------------------------------------------------------------------
 
-FROM rust:1.82-slim-bookworm AS builder
-
-WORKDIR /workspace
-
-# Cache dependency compilation — copy workspace manifests first.
-COPY Cargo.toml Cargo.lock ./
-COPY b00t-azure-cp/Cargo.toml b00t-azure-cp/
-COPY b00t-c0re-lib/Cargo.toml b00t-c0re-lib/
-COPY b00t-cli/Cargo.toml b00t-cli/
-COPY b00t-mcp/Cargo.toml b00t-mcp/
-COPY b00t-lib-chat/Cargo.toml b00t-lib-chat/
-COPY b00t-grok/Cargo.toml b00t-grok/
-COPY k0mmand3r/Cargo.toml k0mmand3r/
-COPY b00t-pyverse/Cargo.toml b00t-pyverse/
-COPY b00t-ipc/Cargo.toml b00t-ipc/
-COPY tomllm/Cargo.toml tomllm/
-
-# Create stub lib/bin files so cargo can resolve the dep graph.
-RUN for dir in b00t-azure-cp b00t-c0re-lib b00t-cli b00t-mcp b00t-lib-chat \
-               b00t-grok k0mmand3r b00t-pyverse b00t-ipc tomllm; do \
-      mkdir -p "$dir/src" && \
-      echo 'fn main() {}' > "$dir/src/main.rs" && \
-      echo '' > "$dir/src/lib.rs"; \
-    done
-
+# 🤓 rust:1.82 predates edition2024 stabilization (Rust 1.85+); the root
+#    Cargo.toml sets `edition = "2024"` workspace-wide, so anything older
+#    fails to even parse the workspace manifest graph. Pinned to the same
+#    tag as Dockerfile.b00t-cli for consistency.
+FROM rust:1.96-slim AS chef
 RUN apt-get update && apt-get install -y --no-install-recommends \
     pkg-config libssl-dev ca-certificates && \
     rm -rf /var/lib/apt/lists/*
+RUN cargo install cargo-chef --locked
+WORKDIR /workspace
 
-# Pre-warm the dependency cache.
-RUN cargo build --release --bin b00t-azure-cp 2>/dev/null || true
+FROM chef AS planner
+COPY Cargo.toml Cargo.lock ./
+COPY _b00t_/ ./_b00t_/
+COPY b00t-admin/ ./b00t-admin/
+COPY b00t-ast/ ./b00t-ast/
+COPY b00t-azure-cp/ ./b00t-azure-cp/
+COPY b00t-bouncer/ ./b00t-bouncer/
+COPY b00t-cad/ ./b00t-cad/
+COPY b00t-cli/ ./b00t-cli/
+COPY b00t-crate/ ./b00t-crate/
+COPY b00t-c0re-a2a/ ./b00t-c0re-a2a/
+COPY b00t-c0re-gov/ ./b00t-c0re-gov/
+COPY b00t-c0re-hierarchy/ ./b00t-c0re-hierarchy/
+COPY b00t-c0re-lib/ ./b00t-c0re-lib/
+COPY b00t-datum-core/ ./b00t-datum-core/
+COPY b00t-embed/ ./b00t-embed/
+COPY b00t-grok/ ./b00t-grok/
+COPY b00t-ipc/ ./b00t-ipc/
+COPY b00t-l3dg3rr-viz/ ./b00t-l3dg3rr-viz/
+COPY b00t-lib-chat/ ./b00t-lib-chat/
+COPY b00t-lsp/ ./b00t-lsp/
+COPY b00t-mcp/ ./b00t-mcp/
+COPY b00t-mcp-npm/ ./b00t-mcp-npm/
+COPY b00t-mermaid-wasm/ ./b00t-mermaid-wasm/
+COPY b00t-pyverse/ ./b00t-pyverse/
+COPY b00t-ui-wasm/ ./b00t-ui-wasm/
+COPY b00t-zellij/ ./b00t-zellij/
+COPY blessed/ ./blessed/
+COPY k0mmand3r/ ./k0mmand3r/
+COPY pm2-tasker/ ./pm2-tasker/
+COPY vendor/embed-anything-b00t/rust/ ./vendor/embed-anything-b00t/rust/
+COPY vendor/embed-anything-b00t/processors/ ./vendor/embed-anything-b00t/processors/
+COPY vendor/irontology-mcp/ ./vendor/irontology-mcp/
+COPY vendor/ledgrrr/crates/b00t-reflect-types/ ./vendor/ledgrrr/crates/b00t-reflect-types/
+COPY vendor/runpod-sdk/ ./vendor/runpod-sdk/
+COPY vendor/tomllm/ ./vendor/tomllm/
 
-# Copy the real sources.
-COPY b00t-azure-cp/src b00t-azure-cp/src/
-COPY b00t-c0re-lib/src b00t-c0re-lib/src/
-COPY b00t-cli/src b00t-cli/src/
-COPY b00t-mcp/src b00t-mcp/src/
-COPY b00t-lib-chat/src b00t-lib-chat/src/
-COPY b00t-grok/src b00t-grok/src/
-COPY k0mmand3r/src k0mmand3r/src/
-COPY b00t-pyverse/src b00t-pyverse/src/
-COPY b00t-ipc/src b00t-ipc/src/
-COPY tomllm/src tomllm/src/
+# 🤓 No `--bin` scoping here: this is a virtual workspace where several
+#    members path-depend on crates *outside* the `[workspace] members` list
+#    (e.g. b00t-cli -> vendor/runpod-sdk, which is in root Cargo.toml's
+#    `exclude`). A `--bin`-scoped recipe only reconstructs the dependency
+#    subgraph reachable from that target, which silently drops manifests
+#    for out-of-workspace path deps pulled in by *other* members — cargo
+#    chef cook then fails trying to read them back out of the recipe.
+#    Preparing the full workspace (matching vendor/ledgrrr/Dockerfile's
+#    unscoped `cargo chef prepare`) keeps recipe.json self-contained.
+RUN cargo chef prepare --recipe-path recipe.json
 
-# Touch to bust the stub-vs-real cache difference.
-RUN touch b00t-azure-cp/src/main.rs
+FROM chef AS builder
+COPY --from=planner /workspace/recipe.json recipe.json
+
+# 🤓 cargo-chef's `cook` only reconstructs dummy sources for crates in
+#    `[workspace] members`. vendor/embed-anything-b00t and vendor/runpod-sdk
+#    are deliberately excluded from workspace membership (root Cargo.toml
+#    `exclude`) yet are real path dependencies of workspace members
+#    (b00t-embed, b00t-cli respectively) — chef silently drops them from the
+#    reconstructed tree, so `cook` fails trying to read their Cargo.toml back
+#    out. Copying their real source in before cook — instead of relying on
+#    chef's reconstruction — fixes this. It narrows the dependency-cache
+#    benefit slightly for these two (rarely-changing) vendored submodules,
+#    but every other workspace member still caches cleanly.
+COPY vendor/embed-anything-b00t/rust/ ./vendor/embed-anything-b00t/rust/
+COPY vendor/embed-anything-b00t/processors/ ./vendor/embed-anything-b00t/processors/
+COPY vendor/runpod-sdk/ ./vendor/runpod-sdk/
+
+RUN cargo chef cook --release --recipe-path recipe.json
+
+# Copy the real sources (same set as the planner stage above).
+COPY Cargo.toml Cargo.lock ./
+COPY _b00t_/ ./_b00t_/
+COPY b00t-admin/ ./b00t-admin/
+COPY b00t-ast/ ./b00t-ast/
+COPY b00t-azure-cp/ ./b00t-azure-cp/
+COPY b00t-bouncer/ ./b00t-bouncer/
+COPY b00t-cad/ ./b00t-cad/
+COPY b00t-cli/ ./b00t-cli/
+COPY b00t-crate/ ./b00t-crate/
+COPY b00t-c0re-a2a/ ./b00t-c0re-a2a/
+COPY b00t-c0re-gov/ ./b00t-c0re-gov/
+COPY b00t-c0re-hierarchy/ ./b00t-c0re-hierarchy/
+COPY b00t-c0re-lib/ ./b00t-c0re-lib/
+COPY b00t-datum-core/ ./b00t-datum-core/
+COPY b00t-embed/ ./b00t-embed/
+COPY b00t-grok/ ./b00t-grok/
+COPY b00t-ipc/ ./b00t-ipc/
+COPY b00t-l3dg3rr-viz/ ./b00t-l3dg3rr-viz/
+COPY b00t-lib-chat/ ./b00t-lib-chat/
+COPY b00t-lsp/ ./b00t-lsp/
+COPY b00t-mcp/ ./b00t-mcp/
+COPY b00t-mcp-npm/ ./b00t-mcp-npm/
+COPY b00t-mermaid-wasm/ ./b00t-mermaid-wasm/
+COPY b00t-pyverse/ ./b00t-pyverse/
+COPY b00t-ui-wasm/ ./b00t-ui-wasm/
+COPY b00t-zellij/ ./b00t-zellij/
+COPY blessed/ ./blessed/
+COPY k0mmand3r/ ./k0mmand3r/
+COPY pm2-tasker/ ./pm2-tasker/
+COPY vendor/embed-anything-b00t/rust/ ./vendor/embed-anything-b00t/rust/
+COPY vendor/embed-anything-b00t/processors/ ./vendor/embed-anything-b00t/processors/
+COPY vendor/irontology-mcp/ ./vendor/irontology-mcp/
+COPY vendor/ledgrrr/crates/b00t-reflect-types/ ./vendor/ledgrrr/crates/b00t-reflect-types/
+COPY vendor/runpod-sdk/ ./vendor/runpod-sdk/
+COPY vendor/tomllm/ ./vendor/tomllm/
 
 RUN cargo build --release --bin b00t-azure-cp
 


### PR DESCRIPTION
## Summary

Adopts cargo-chef's three-stage Docker pattern (chef base -> planner runs
`cargo chef prepare` to produce `recipe.json` -> builder runs
`cargo chef cook` to build only dependencies as a cacheable layer, then
copies full source and does the real build) for the two Rust-building
Dockerfiles found in core `_b00t_` that qualified, following
`vendor/ledgrrr/Dockerfile`'s structure as the reference implementation.

- `Dockerfile.b00t-cli` — builds `b00t-cli` + `b00t-mcp`. This is the
  live, CI-wired one (`.github/workflows/b00t-cli-container.yml`). Before
  this change it `COPY`'d the entire ~25-crate workspace into one
  undifferentiated layer before `cargo install`, so any source edit
  anywhere invalidated the whole dependency compile.
- `b00t-azure-cp/Dockerfile` — builds `b00t-azure-cp`. It already had a
  hand-rolled "stub file" dependency-caching hack; replaced with the real
  cargo-chef mechanism. While making this one actually buildable I found
  and fixed two pre-existing, unrelated bugs (see below) — evidence this
  Dockerfile had never been build-tested.

### Bugs found and fixed along the way (fork-fix-forward)

- `b00t-azure-cp/Dockerfile` pinned `rust:1.82-slim-bookworm`, which
  predates edition2024 stabilization (Rust 1.85+). The workspace root
  `Cargo.toml` sets `edition = "2024"` workspace-wide, so this Dockerfile
  could never have successfully resolved the workspace. Bumped to
  `rust:1.96-slim` to match `Dockerfile.b00t-cli`.
- Its manifest `COPY` list only covered a 10-crate subset (and had a stale
  `tomllm/` path instead of `vendor/tomllm/`). This repo is one big virtual
  Cargo workspace — `cargo` refuses to resolve *any* member, even to build
  just one bin, unless every listed workspace member's `Cargo.toml` is
  present on disk. Expanded the list to the full 25-member workspace +
  vendor path deps, matching `Dockerfile.b00t-cli`'s (already-correct, CI
  verified) list.
- Discovered and worked around a cargo-chef limitation: `cargo chef cook`
  only reconstructs dummy sources for crates in `[workspace] members`.
  `vendor/embed-anything-b00t` and `vendor/runpod-sdk` are deliberately
  `exclude`d from workspace membership yet are real path dependencies of
  workspace members (`b00t-embed`, `b00t-cli`) — chef silently drops them
  from the reconstructed tree during `cook`, which then fails trying to
  read their `Cargo.toml` back out. Fixed by copying their real source in
  before the `cook` step runs, in both Dockerfiles.

### Verification honesty

- `podman build --target planner -f b00t-azure-cp/Dockerfile .` **succeeds
  end-to-end**, producing a real `recipe.json` and a committed image
  (`localhost/b00t-azure-cp-planner-test2`, 962 MB). This confirms
  `cargo chef prepare` correctly resolves this workspace's
  `Cargo.toml`/`Cargo.lock` and the planner stage is sound.
- The full `cook` + final-build stage was **not** run to a finished image
  in this sandbox — a full workspace dependency compile is multi-hour on
  the ARM SBC this was built on, and per the task's own guidance, planner +
  cook-mechanics validation was accepted as sufficient when a full build is
  impractical. I hit and fixed the `cook`-stage bug above by inspection/
  reasoning after a real build run surfaced it, but did not re-run a full
  build afterward to confirm the fix compiles clean end-to-end — that
  should happen on real CI hardware (GitHub Actions already builds
  `Dockerfile.b00t-cli` on every push touching it, `cache-from/to:
  type=gha`, so this will get exercised for real on the next push).
- Also spot-checked `vendor/embed-anything-b00t`'s three cargo-chef
  Dockerfiles (`Dockerfile`, `server.Dockerfile`, `server-cuda.Dockerfile`)
  per the issue's "not yet individually verified" note — all three
  correctly follow the three-stage pattern, no changes needed.
- `oci-tool/kicaddydaddy/Dockerfile`, `pm2-tasker/Dockerfile`,
  `app4dog/sam3-runner/Dockerfile`, `containers/training/Dockerfile`, and
  the root `Dockerfile` (toolchain-import only, no `cargo build`) were
  reviewed and do not qualify — not Rust workspace builds.

Addresses #886 (not "Fixes" — the full multi-stage build was not
confirmed green end-to-end in this sandbox, see above).

## Test plan

- [x] `podman build --target planner -f b00t-azure-cp/Dockerfile .` — PASS,
      produced `recipe.json` and a committed image.
- [ ] Full `podman build -f b00t-azure-cp/Dockerfile .` to a finished
      image — not completed here (time/resource constraints); should be
      run on real CI/build hardware before merge or as a fast-follow.
- [ ] `Dockerfile.b00t-cli` full build — will be exercised automatically by
      `.github/workflows/b00t-cli-container.yml` on the next push touching
      it; recommend confirming that run is green before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)