### PR TITLE
docs: SeaORM migration sharp edges

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -228,3 +228,22 @@ TLDR: `~/.dotfiles` is bare — never edit or build in it directly. `b00t learn 
 edges (submodule init, shared target-dir, tmpfs contention), and fixes all live in the
 datum — MUST `b00t learn worktree` before the first `git`/`cargo` command against any
 bare/worktree-layout repo rather than rediscovering them the hard way.
+
+## SeaORM Migration Sharp Edges (recorded 2026-08-07)
+
+TLDR: before writing a SeaORM Postgres migration that does `CREATE EXTENSION`/
+`CREATE TYPE`/`ALTER TYPE`, schema-qualify everything (`WITH SCHEMA public`,
+`public.foo`) and join `pg_namespace` on any `pg_type`/`pg_extension` existence check —
+those catalogs are database-wide, so an unqualified check false-positives against a
+same-named object in an unrelated schema (bites hardest under a per-test isolated-schema
+test harness). The non-obvious one: never wrap a `CREATE TYPE` in a
+`DO $$ ... EXCEPTION ... END $$` block if a later migration in the same run does
+`ALTER TYPE ... ADD VALUE` on it and a further-later migration uses that value — the
+`EXCEPTION` clause implicitly opens a Postgres subtransaction, which breaks Postgres's
+"enum value usable in this transaction only if its type was also created in this
+transaction" exemption, producing `unsafe use of new value` (SQLSTATE 55P04) even with
+zero real concurrency. A serializing `pg_advisory_xact_lock` around the shared-object
+section removes the actual concurrent-test-thread race without needing exception
+handling at all. Verify by recreating a genuinely fresh DB and running real tests
+(including a single isolated `--test-threads=1 --exact` run to rule out a race before
+assuming one) — not by code inspection alone.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -233,17 +233,29 @@ bare/worktree-layout repo rather than rediscovering them the hard way.
 
 TLDR: before writing a SeaORM Postgres migration that does `CREATE EXTENSION`/
 `CREATE TYPE`/`ALTER TYPE`, schema-qualify everything (`WITH SCHEMA public`,
-`public.foo`) and join `pg_namespace` on any `pg_type`/`pg_extension` existence check —
-those catalogs are database-wide, so an unqualified check false-positives against a
-same-named object in an unrelated schema (bites hardest under a per-test isolated-schema
-test harness). The non-obvious one: never wrap a `CREATE TYPE` in a
-`DO $$ ... EXCEPTION ... END $$` block if a later migration in the same run does
-`ALTER TYPE ... ADD VALUE` on it and a further-later migration uses that value — the
-`EXCEPTION` clause implicitly opens a Postgres subtransaction, which breaks Postgres's
-"enum value usable in this transaction only if its type was also created in this
-transaction" exemption, producing `unsafe use of new value` (SQLSTATE 55P04) even with
-zero real concurrency. A serializing `pg_advisory_xact_lock` around the shared-object
-section removes the actual concurrent-test-thread race without needing exception
-handling at all. Verify by recreating a genuinely fresh DB and running real tests
-(including a single isolated `--test-threads=1 --exact` run to rule out a race before
-assuming one) — not by code inspection alone.
+`public.foo`) and join `pg_namespace` on any `pg_type` existence check — that catalog is
+database-wide, so an unqualified check false-positives against a same-named type in an
+unrelated schema (bites hardest under a per-test isolated-schema test harness). This does
+NOT apply to `pg_extension`: extension names are unique database-wide (Postgres rejects
+installing the same extension into a second schema outright), so there's no cross-schema
+false positive to guard against there — `WITH SCHEMA public` still matters for
+extensions, but only for where the extension's own objects land, not for existence
+checks. The non-obvious one, confirmed on PostgreSQL 17.5 (re-confirmed twice against a
+real instance, not just reasoned about — an independent check against PostgreSQL 15.13
+reported different behavior for the non-`EXCEPTION` case, unreproduced and unexplained,
+so verify on your own major version before trusting this claim): never wrap a
+`CREATE TYPE` in a `DO $$ ... EXCEPTION ... END $$` block if a later migration in the
+same run does `ALTER TYPE ... ADD VALUE` on it and a further-later migration uses that
+value — the `EXCEPTION` clause implicitly opens a Postgres subtransaction, which breaks
+Postgres's "enum value usable in this transaction only if its type was also created in
+this transaction" exemption, producing `unsafe use of new value` (SQLSTATE 55P04) even
+with zero real concurrency. A serializing `pg_advisory_xact_lock` around the shared-object
+section removes the actual concurrent-test-thread race without needing exception handling
+at all — but note that lock only serializes *concurrent* migrations within one deploy; an
+`ALTER TYPE ... ADD VALUE` migration whose type-creating migration already committed in an
+*earlier, separate* deploy still needs its own connection to add+commit the value
+independently (Postgres's other safe case: value committed in a prior transaction), or the
+identical error resurfaces. Verify by recreating a genuinely fresh DB and running real
+tests (including a single isolated `--test-threads=1 --exact` run to rule out a race
+before assuming one, and a real two-batch incremental-deploy repro for the ADD VALUE
+case) — not by code inspection alone.


### PR DESCRIPTION
## Summary
- Adds a "SeaORM Migration Sharp Edges" entry to `AGENTS.md`: schema-qualification requirement for `CREATE EXTENSION`/`CREATE TYPE` and the non-obvious Postgres subtransaction interaction where wrapping `CREATE TYPE` in a `DO $$ ... EXCEPTION ... END $$` block breaks the same-transaction enum-value-reuse exemption, producing `unsafe use of new value` (SQLSTATE 55P04) even with zero real concurrency.
- Written as general tool wisdom (no specific repo/PR references), matching the style of the other dated entries in this file (e.g. Worktree Discipline, Just Recipe Boundary).

## Test plan
- [x] Doc-only change; `pre-push` hook ran and reported "no Rust packages affected — skipping test gate"