### PR TITLE
chore: consolidate worktree caches

### DIFF
--- a/_b00t_/agent-hooks/events/agent.start.sh
+++ b/_b00t_/agent-hooks/events/agent.start.sh
@@ -5,7 +5,7 @@
 # Non-blocking — use this for logging/observability, not gating.
 #
 # Lifecycle:
-#   1. Worktree isolation — git worktree in .b00t/worktrees/<agent-id>/
+#   1. Worktree isolation — git worktree in .claude/worktrees/<agent-id>/
 #   2. Ledgerr registration — yei registers for resource budget (GPU, network)
 #   3. Role-specific hooks — roles/<agent-type>/agent.start.sh
 #
@@ -20,16 +20,21 @@ AGENT_ID="$(echo "$INPUT"   | jq -r '.agent_id   // "unknown"' 2>/dev/null || ec
 SESSION_ID="$(echo "$INPUT" | jq -r '.session_id  // "unknown"' 2>/dev/null || echo "unknown")"
 TASK_ID="${B00T_TASK_ID:-${SESSION_ID}}"
 
-PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || echo "")"
+PROJECT_ROOT="${B00T_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || echo "")}"
+HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib/worktree-env.sh
+source "${HOOK_DIR}/../../../scripts/lib/worktree-env.sh"
 
 # ── Phase 1: Worktree isolation ──────────────────────────────────────────
 if [ "${B00T_NO_WORKTREE:-0}" != "1" ] && [ -n "${PROJECT_ROOT}" ] && [ -f "${PROJECT_ROOT}/.git/🥾.tomllmd" ]; then
-  WT_DIR="${PROJECT_ROOT}/.b00t/worktrees/${AGENT_ID}"
+  WT_ROOT="$(b00t_default_agent_worktree_root "${PROJECT_ROOT}")"
+  WT_DIR="${WT_ROOT}/${AGENT_ID}"
   if [ ! -d "${WT_DIR}" ]; then
-    mkdir -p "${PROJECT_ROOT}/.b00t/worktrees"
+    mkdir -p "${WT_ROOT}"
     REF=$(git -C "${PROJECT_ROOT}" rev-parse HEAD 2>/dev/null || echo "")
     if [ -n "${REF}" ]; then
       git -C "${PROJECT_ROOT}" worktree add --detach "${WT_DIR}" "${REF}" 2>/dev/null && {
+        b00t_init_required_submodules "${WT_DIR}"
         ln -sf "${PROJECT_ROOT}/.git/🥾.tomllmd" "${WT_DIR}/.git/🥾.tomllmd" 2>/dev/null || true
         # Stamp per-worktree git identity with the b00t agent + session id so
         # commits made here are attributable, instead of silently inheriting

--- a/_b00t_/agent-hooks/events/agent.stop.sh
+++ b/_b00t_/agent-hooks/events/agent.stop.sh
@@ -23,7 +23,10 @@ AGENT_TYPE="$(echo "$INPUT" | jq -r '.agent_type          // "unknown"' 2>/dev/n
 AGENT_ID="$(  echo "$INPUT" | jq -r '.agent_id            // "unknown"' 2>/dev/null || echo "unknown")"
 LAST_MSG="$(  echo "$INPUT" | jq -r '.last_assistant_message // ""'    2>/dev/null || echo "")"
 
-PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || echo "")"
+PROJECT_ROOT="${B00T_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || echo "")}"
+HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib/worktree-env.sh
+source "${HOOK_DIR}/../../../scripts/lib/worktree-env.sh"
 
 # ── Phase 1: Ledgerr audit receipt (release resource budget) ──────────────
 if [ -n "${PROJECT_ROOT}" ] && [ "${B00T_NO_LEDGERR:-0}" != "1" ]; then
@@ -48,7 +51,8 @@ fi
 
 # ── Phase 2: Worktree cleanup ────────────────────────────────────────────
 if [ -n "${PROJECT_ROOT}" ]; then
-  WT_DIR="${PROJECT_ROOT}/.b00t/worktrees/${AGENT_ID}"
+  WT_ROOT="$(b00t_default_agent_worktree_root "${PROJECT_ROOT}")"
+  WT_DIR="${WT_ROOT}/${AGENT_ID}"
   if [ -d "${WT_DIR}" ]; then
     git -C "${PROJECT_ROOT}" worktree remove "${WT_DIR}" --force 2>/dev/null || {
       rm -rf "${WT_DIR}"

--- a/_b00t_/agent-hooks/events/session.start.sh
+++ b/_b00t_/agent-hooks/events/session.start.sh
@@ -10,6 +10,9 @@
 set -euo pipefail
 
 B00T_DIR="${B00T_DIR:-$HOME/.b00t/_b00t_}"
+HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib/worktree-env.sh
+source "${HOOK_DIR}/../../../scripts/lib/worktree-env.sh"
 
 # Determine role from b00t session (if session daemon running)
 ROLE=""
@@ -17,11 +20,21 @@ if command -v b00t-cli >/dev/null 2>&1; then
     ROLE="$(b00t-cli session status --field=role 2>/dev/null || echo "")"
 fi
 
+PROJECT_ROOT="${CLAUDE_PROJECT_DIR:-${B00T_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || echo "$PWD")}}"
+WORKTREE_ROOT="$(b00t_default_hive_worktree_root)"
+AGENT_WORKTREE_ROOT="$(b00t_default_agent_worktree_root "${PROJECT_ROOT}")"
+SHARED_TARGET_DIR="$(b00t_shared_cargo_target_dir)"
+
+mkdir -p "${WORKTREE_ROOT}" "${AGENT_WORKTREE_ROOT}" "${SHARED_TARGET_DIR}" 2>/dev/null || true
+
 # Inject into tool env file (claude-code specific — B00T_ENV_FILE set by adapter)
 if [ -n "${B00T_ENV_FILE:-}" ]; then
     [ -n "$ROLE" ] && echo "export B00T_ROLE=$ROLE" >> "$B00T_ENV_FILE"
     echo "export B00T_DIR=$B00T_DIR"               >> "$B00T_ENV_FILE"
     echo "export B00T_TOOL=${B00T_TOOL:-unknown}"  >> "$B00T_ENV_FILE"
+    printf 'export B00T_WORKTREE_ROOT=%q\n' "${WORKTREE_ROOT}" >> "$B00T_ENV_FILE"
+    printf 'export B00T_AGENT_WORKTREE_ROOT=%q\n' "${AGENT_WORKTREE_ROOT}" >> "$B00T_ENV_FILE"
+    printf 'export CARGO_TARGET_DIR=%q\n' "${SHARED_TARGET_DIR}" >> "$B00T_ENV_FILE"
 fi
 
 exit 0

--- a/_b00t_/agent-hooks/events/tool.post.sh
+++ b/_b00t_/agent-hooks/events/tool.post.sh
@@ -11,6 +11,9 @@
 set -euo pipefail
 
 INPUT="${B00T_HOOK_INPUT:-$(cat)}"
+HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib/worktree-env.sh
+source "${HOOK_DIR}/../../../scripts/lib/worktree-env.sh"
 TOOL="$(     echo "$INPUT" | jq -r '.tool_name           // ""' 2>/dev/null)"
 COMMAND="$(  echo "$INPUT" | jq -r '.tool_input.command  // ""' 2>/dev/null)"
 FILE_PATH="$(echo "$INPUT" | jq -r '.tool_input.file_path // ""' 2>/dev/null)"
@@ -33,9 +36,7 @@ if [ "$TOOL" = "Bash" ] && echo "$COMMAND" | grep -qE 'git\s+commit\b'; then
         echo "✅ b00t: cargo test passed" >&2
 
     elif [ -f "$CWD/package.json" ]; then
-        PKG_MGR="npm"
-        [ -f "$CWD/pnpm-lock.yaml" ] && PKG_MGR="pnpm"
-        [ -f "$CWD/yarn.lock" ]      && PKG_MGR="yarn"
+        PKG_MGR="$(b00t_detect_package_manager "$CWD")"
         echo "🧪 b00t: running $PKG_MGR test after commit..." >&2
         TEST_OUT="$(cd "$CWD" && $PKG_MGR test --passWithNoTests 2>&1 | tail -20 || true)"
         if echo "$TEST_OUT" | grep -qiE 'FAIL|ERROR|failed'; then

--- a/_b00t_/agent-hooks/events/worktree.create.sh
+++ b/_b00t_/agent-hooks/events/worktree.create.sh
@@ -1,15 +1,20 @@
 #!/usr/bin/env bash
 # events/worktree.create.sh — git worktree isolation for sub-agents
 # Fires on WorktreeCreate event from agent harness (claude-code / opencode).
-# Creates a per-agent git worktree in .b00t/worktrees/<agent-id>/
+# Creates a per-agent git worktree in .claude/worktrees/<agent-id>/
 # so each sub-agent has its own checked-out filesystem view without
 # contaminating the captain's working tree.
 set -euo pipefail
 
 AGENT_ID="${1:-${B00T_AGENT_ID:-unknown}}"
 SESSION_ID="${B00T_SESSION_ID:-unknown}"
-PROJECT_ROOT="${B00T_PROJECT_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || echo "$PWD")}"
-WORKTREE_DIR="${PROJECT_ROOT}/.b00t/worktrees/${AGENT_ID}"
+PROJECT_ROOT="${B00T_PROJECT_DIR:-${B00T_PROJECT_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || echo "$PWD")}}"
+HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib/worktree-env.sh
+source "${HOOK_DIR}/../../../scripts/lib/worktree-env.sh"
+
+WORKTREE_ROOT="$(b00t_default_agent_worktree_root "${PROJECT_ROOT}")"
+WORKTREE_DIR="${WORKTREE_ROOT}/${AGENT_ID}"
 
 echo "[worktree.create] agent=${AGENT_ID} project=${PROJECT_ROOT}"
 
@@ -26,10 +31,10 @@ if [ -d "${WORKTREE_DIR}" ]; then
 fi
 
 # Create worktree from current HEAD
-mkdir -p "${PROJECT_ROOT}/.b00t/worktrees"
+mkdir -p "${WORKTREE_ROOT}"
 git -C "${PROJECT_ROOT}" worktree add --detach "${WORKTREE_DIR}" HEAD 2>/dev/null || {
   # Fallback: if HEAD is ambiguous (detached), use current commit
-  local REF
+  REF=""
   REF=$(git -C "${PROJECT_ROOT}" rev-parse HEAD 2>/dev/null || echo "")
   if [ -n "${REF}" ]; then
     git -C "${PROJECT_ROOT}" worktree add "${WORKTREE_DIR}" "${REF}"
@@ -38,6 +43,8 @@ git -C "${PROJECT_ROOT}" worktree add --detach "${WORKTREE_DIR}" HEAD 2>/dev/nul
     exit 1
   fi
 }
+
+b00t_init_required_submodules "${WORKTREE_DIR}"
 
 # Set up the worktree's own _b00t_/ if needed
 if [ ! -d "${WORKTREE_DIR}/_b00t_" ]; then

--- a/_b00t_/agent-hooks/events/worktree.remove.sh
+++ b/_b00t_/agent-hooks/events/worktree.remove.sh
@@ -4,8 +4,13 @@
 set -euo pipefail
 
 AGENT_ID="${1:-${B00T_AGENT_ID:-unknown}}"
-PROJECT_ROOT="${B00T_PROJECT_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || echo "$PWD")}"
-WORKTREE_DIR="${PROJECT_ROOT}/.b00t/worktrees/${AGENT_ID}"
+PROJECT_ROOT="${B00T_PROJECT_DIR:-${B00T_PROJECT_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || echo "$PWD")}}"
+HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib/worktree-env.sh
+source "${HOOK_DIR}/../../../scripts/lib/worktree-env.sh"
+
+WORKTREE_ROOT="$(b00t_default_agent_worktree_root "${PROJECT_ROOT}")"
+WORKTREE_DIR="${WORKTREE_ROOT}/${AGENT_ID}"
 
 echo "[worktree.remove] agent=${AGENT_ID}"
 

--- a/scripts/hive-maintenance/action-issue.sh
+++ b/scripts/hive-maintenance/action-issue.sh
@@ -5,12 +5,17 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib/worktree-env.sh
+source "${SCRIPT_DIR}/../lib/worktree-env.sh"
+
 ISSUE_NUM="${1:?issue_num required}"
 CLUSTER="${2:?cluster required}"
 ISSUE_TITLE="${3:?issue_title required}"
 REPO="${REPO:-elasticdotventures/_b00t_}"
 MAX_CODEX_ITER="${MAX_CODEX_ITER:-3}"
-WORKTREE_ROOT="${WORKTREE_ROOT:-/tmp/b00t-worktrees}"
+WORKTREE_ROOT="${WORKTREE_ROOT:-$(b00t_default_hive_worktree_root)}"
+export CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-$(b00t_shared_cargo_target_dir)}"
 
 SLUG=$(echo "${ISSUE_TITLE}" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | sed 's/--*/-/g' | cut -c1-40 | sed 's/-$//')
 BRANCH="issue-${ISSUE_NUM}-${SLUG}"
@@ -38,6 +43,7 @@ ISSUE_BODY=$(gh issue view "${ISSUE_NUM}" --repo "${REPO}" --json body -q '.body
 
 # ── 2. Create worktree on feature branch ─────────────────────────────────────
 mkdir -p "${WORKTREE_ROOT}"
+mkdir -p "${CARGO_TARGET_DIR}"
 REPO_ROOT=$(git rev-parse --show-toplevel)
 
 # Check if branch already exists
@@ -51,6 +57,8 @@ else
     log "creating branch ${BRANCH}"
     git -C "${REPO_ROOT}" worktree add -b "${BRANCH}" "${WORKTREE}" main
 fi
+
+b00t_init_required_submodules "${WORKTREE}"
 
 # ── 3. Write implementation prompt ───────────────────────────────────────────
 IMPL_PROMPT="${WORKTREE}/.codex-impl-prompt.md"
@@ -199,5 +207,7 @@ gh issue comment "${ISSUE_NUM}" --repo "${REPO}" \
 **PR:** ${PR_URL}
 
 Implementation dispatched via action-issue.sh (codex worker, iter ${ITER}/${MAX_CODEX_ITER})" 2>/dev/null || true
+
+git -C "${REPO_ROOT}" worktree remove --force "${WORKTREE}" 2>/dev/null || true
 
 log "✅ done — issue #${ISSUE_NUM}"

--- a/scripts/hive-maintenance/ooda-issue.sh
+++ b/scripts/hive-maintenance/ooda-issue.sh
@@ -5,12 +5,17 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib/worktree-env.sh
+source "${SCRIPT_DIR}/../lib/worktree-env.sh"
+
 ISSUE_NUM="${1:?issue_num required}"
 CLUSTER="${2:?cluster required}"
 ISSUE_TITLE="${3:?issue_title required}"
 REPO="${REPO:-elasticdotventures/_b00t_}"
 MAX_OODA="${MAX_OODA:-5}"
-WORKTREE_ROOT="${WORKTREE_ROOT:-/tmp/b00t-wt}"
+WORKTREE_ROOT="${WORKTREE_ROOT:-$(b00t_default_hive_worktree_root)}"
+export CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-$(b00t_shared_cargo_target_dir)}"
 
 SLUG=$(echo "${ISSUE_TITLE}" | tr '[:upper:]' '[:lower:]' \
     | sed 's/[^a-z0-9]/-/g' | sed 's/--*/-/g' | cut -c1-40 | sed 's/-$//')
@@ -20,6 +25,8 @@ REPO_ROOT="${REPO_ROOT:-$(git rev-parse --show-toplevel)}"
 LOG="${WORKTREE_ROOT}/ooda-${ISSUE_NUM}.log"
 
 mkdir -p "${WORKTREE_ROOT}"
+mkdir -p "${CARGO_TARGET_DIR}"
+: > "${LOG}"
 
 log() { echo "[ooda #${ISSUE_NUM}] $*" | tee -a "${LOG}" >&2; }
 
@@ -57,6 +64,8 @@ decide_act() {
             git -C "${REPO_ROOT}" worktree add -b "${BRANCH}" "${WORKTREE}" main 2>/dev/null
         fi
     fi
+
+    b00t_init_required_submodules "${WORKTREE}"
 
     # Write OODA-enriched prompt
     cat > "${WORKTREE}/.ooda-prompt.md" <<PROMPT
@@ -171,6 +180,7 @@ for iter in $(seq 1 "${MAX_OODA}"); do
         log "✅ PR: ${PR_URL}"
         gh issue comment "${ISSUE_NUM}" --repo "${REPO}" \
             --body "## 🚀 PR Opened (OODA iter ${iter})\n\n${PR_URL}" 2>/dev/null || true
+        git -C "${REPO_ROOT}" worktree remove --force "${WORKTREE}" 2>/dev/null || true
         echo "${PR_URL}"
         exit 0
     fi

--- a/scripts/hive-maintenance/sequential-action.sh
+++ b/scripts/hive-maintenance/sequential-action.sh
@@ -5,16 +5,21 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib/worktree-env.sh
+source "${SCRIPT_DIR}/../lib/worktree-env.sh"
+
 REPO="${REPO:-elasticdotventures/_b00t_}"
 MAX_OODA="${MAX_OODA:-5}"
-WORKTREE_ROOT="${WORKTREE_ROOT:-/tmp/b00t-wt}"
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORKTREE_ROOT="${WORKTREE_ROOT:-$(b00t_default_hive_worktree_root)}"
+export CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-$(b00t_shared_cargo_target_dir)}"
 OODA="${SCRIPT_DIR}/ooda-issue.sh"
 START_FROM="${1:-0}"
 [[ "${1:-}" == "--start-from" ]] && START_FROM="${2:-0}"
 
 RESULTS_LOG="${SCRIPT_DIR}/logs/sequential-$(date +%Y%m%d-%H%M%S).log"
 mkdir -p "$(dirname "${RESULTS_LOG}")"
+mkdir -p "${WORKTREE_ROOT}" "${CARGO_TARGET_DIR}"
 chmod +x "${OODA}"
 
 log() { echo "[sequential] $*" | tee -a "${RESULTS_LOG}"; }

--- a/scripts/lib/worktree-env.sh
+++ b/scripts/lib/worktree-env.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Shared defaults for worktree placement, build-cache reuse, and package-manager detection.
+
+b00t_default_hive_worktree_root() {
+    printf '%s\n' "${B00T_WORKTREE_ROOT:-$HOME/.cache/b00t-worktrees}"
+}
+
+b00t_default_agent_worktree_root() {
+    local project_root="${1:?project_root required}"
+    printf '%s\n' "${B00T_AGENT_WORKTREE_ROOT:-${project_root}/.claude/worktrees}"
+}
+
+b00t_shared_cargo_target_dir() {
+    if [ -n "${CARGO_TARGET_DIR:-}" ]; then
+        printf '%s\n' "${CARGO_TARGET_DIR}"
+        return 0
+    fi
+    printf '%s\n' "${B00T_SHARED_CARGO_TARGET_DIR:-$HOME/.cache/b00t-cargo-target}"
+}
+
+b00t_detect_package_manager() {
+    local project_root="${1:-$PWD}"
+    local detect_script="${project_root}/scripts/setup-package-manager.js"
+    local detected=""
+
+    if command -v node >/dev/null 2>&1 && [ -f "${detect_script}" ]; then
+        detected="$(
+            (
+                cd "${project_root}" && \
+                node "${detect_script}" --detect
+            ) 2>/dev/null \
+                | awk -F': *' '/Selected:/ { print $2; exit }'
+        )"
+    fi
+
+    if [ -n "${detected}" ]; then
+        printf '%s\n' "${detected}"
+        return 0
+    fi
+
+    if [ -f "${project_root}/pnpm-lock.yaml" ]; then
+        printf '%s\n' "pnpm"
+    elif [ -f "${project_root}/bun.lockb" ]; then
+        printf '%s\n' "bun"
+    elif [ -f "${project_root}/yarn.lock" ]; then
+        printf '%s\n' "yarn"
+    else
+        printf '%s\n' "npm"
+    fi
+}
+
+b00t_init_required_submodules() {
+    local worktree_dir="${1:?worktree_dir required}"
+    git -C "${worktree_dir}" submodule update --init -- \
+        vendor/ledgrrr \
+        vendor/runpod-sdk \
+        vendor/embed-anything-b00t
+}


### PR DESCRIPTION
## Summary
- centralize shared worktree and Cargo target defaults in a single shell helper
- route Claude agent hooks and hive-maintenance scripts to shared cache/worktree paths and initialize required submodules
- clean up successful issue worktrees and keep package-manager detection scoped per project directory

## Validation
- PASS: bash -n
- PASS: bash -n targeted
- session.start exports B00T_WORKTREE_ROOT, B00T_AGENT_WORKTREE_ROOT, and CARGO_TARGET_DIR correctly
- package manager detection resolves root=pnpm and b00t-vscode=npm from the same shell

## Disk state
- reclaimed space by clearing duplicate worktree targets and stale user-owned caches; / now has ~23G free