### PR TITLE
feat(skill): harmonize Claude Code plugin skills into b00t skill resolver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4419,7 +4419,7 @@ dependencies = [
 
 [[package]]
 name = "embed_anything"
-version = "0.7.2"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -4429,10 +4429,10 @@ dependencies = [
  "candle-transformers 0.11.0",
  "chrono",
  "half",
- "hf-hub 1.0.0",
+ "hf-hub 0.4.3",
  "image",
  "indicatif 0.18.6",
- "itertools 0.15.0",
+ "itertools 0.14.0",
  "log",
  "model2vec-rs",
  "ndarray 0.16.1",
@@ -6954,15 +6954,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "itertools"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
-dependencies = [
- "either",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8003,9 +7994,9 @@ dependencies = [
 
 [[package]]
 name = "model2vec-rs"
-version = "0.2.1"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cbb465c6997e85d6bcb0e9fabedb51cc8a0919d2a3de083157abe83dccbde54"
+checksum = "23693c16304bc11674c991f47aa33794e641204e67547e0cef31c794c38ea00f"
 dependencies = [
  "anyhow",
  "clap",
@@ -8013,10 +8004,8 @@ dependencies = [
  "hf-hub 0.4.3",
  "ndarray 0.15.6",
  "safetensors 0.5.3",
- "serde",
  "serde_json",
  "tokenizers 0.21.4",
- "ureq 2.12.1",
 ]
 
 [[package]]
@@ -9693,7 +9682,7 @@ dependencies = [
 
 [[package]]
 name = "processors-rs"
-version = "0.7.2"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "docx-parser",
@@ -12928,6 +12917,7 @@ dependencies = [
  "derive_builder",
  "esaxx-rs",
  "getrandom 0.3.4",
+ "hf-hub 0.4.3",
  "indicatif 0.17.11",
  "itertools 0.14.0",
  "log",

--- a/b00t-cli/src/commands/provider.rs
+++ b/b00t-cli/src/commands/provider.rs
@@ -1495,12 +1495,12 @@ async fn handle_runpod(cmd: RunpodSubCommands) -> Result<()> {
         }
         RunpodSubCommands::Status { id } => {
             let pod = client.get_pod(&id, Default::default()).await?;
-            println!("{}", fmt_pod_status_line(&id, pod.desired_status, pod.cost_per_hr));
+            println!("{}", fmt_pod_status_line(&id, pod.desired_status, Some(pod.cost_per_hr)));
         }
         RunpodSubCommands::List => {
             for p in client.list_pods(Default::default()).await? {
                 let st = p.desired_status.map(|s| format!("{s:?}")).unwrap_or_default();
-                println!("{}  {st}  {} /hr", p.id, fmt_cost(p.cost_per_hr));
+                println!("{}  {st}  {} /hr", p.id, fmt_cost(Some(p.cost_per_hr)));
             }
         }
         RunpodSubCommands::Stop { id, all } => {

--- a/b00t-cli/src/commands/skill.rs
+++ b/b00t-cli/src/commands/skill.rs
@@ -28,6 +28,14 @@ pub enum SkillCommands {
         json: bool,
     },
 
+    #[clap(
+        about = "List installed Claude Code plugins and the skills they contribute (harmonization report)"
+    )]
+    Plugins {
+        #[clap(long, help = "Output JSON")]
+        json: bool,
+    },
+
     #[clap(about = "Search skills by query (name, description, tags)")]
     Search {
         #[clap(help = "Search query")]
@@ -145,6 +153,8 @@ pub fn handle_skill_command(cmd: &SkillCommands, path: &str) -> Result<()> {
             Ok(())
         }
 
+        SkillCommands::Plugins { json } => handle_plugins(*json),
+
         SkillCommands::Search { query, json } => {
             let metas = resolver.search(query);
 
@@ -231,6 +241,76 @@ pub fn handle_skill_command(cmd: &SkillCommands, path: &str) -> Result<()> {
             depth,
         } => handle_index(dirs, *json, *store, *depth),
     }
+}
+
+/// Count subdirectories containing a `SKILL.md` file (non-recursive).
+fn count_skill_md_dirs(dir: &std::path::Path) -> usize {
+    std::fs::read_dir(dir)
+        .map(|entries| {
+            entries
+                .flatten()
+                .filter(|e| e.path().join("SKILL.md").is_file())
+                .count()
+        })
+        .unwrap_or(0)
+}
+
+/// `b00t skill plugins` — report installed Claude Code plugins (from
+/// `~/.claude/plugins/installed_plugins.json`) and how many skills each
+/// contributes to `b00t skill list`. Read-only: b00t doesn't install or
+/// manage these, only harmonizes their bundled skills into the resolver.
+fn handle_plugins(json: bool) -> Result<()> {
+    let home =
+        dirs::home_dir().ok_or_else(|| anyhow::anyhow!("Cannot resolve home directory"))?;
+    let claude_dir = home.join(".claude");
+    let entries = crate::datum_claude_plugin::read_installed_plugins(&claude_dir);
+
+    if json {
+        let out: Vec<_> = entries
+            .iter()
+            .map(|(key, entry)| {
+                let skills_dir = PathBuf::from(&entry.install_path).join("skills");
+                let skill_count = if skills_dir.is_dir() {
+                    count_skill_md_dirs(&skills_dir)
+                } else {
+                    0
+                };
+                json!({
+                    "plugin": key,
+                    "version": entry.version,
+                    "scope": entry.scope,
+                    "install_path": entry.install_path,
+                    "skill_count": skill_count,
+                })
+            })
+            .collect();
+        println!("{}", serde_json::to_string_pretty(&out)?);
+    } else if entries.is_empty() {
+        println!(
+            "No Claude Code plugins found (checked {}).",
+            claude_dir.join("plugins").join("installed_plugins.json").display()
+        );
+    } else {
+        for (key, entry) in &entries {
+            let skills_dir = PathBuf::from(&entry.install_path).join("skills");
+            let skill_count = if skills_dir.is_dir() {
+                count_skill_md_dirs(&skills_dir)
+            } else {
+                0
+            };
+            let skills_note = if skill_count > 0 {
+                format!(" — {} skill(s), see `b00t skill list`", skill_count)
+            } else {
+                String::new()
+            };
+            println!(
+                "• {} (v{}, scope: {}){}",
+                key, entry.version, entry.scope, skills_note
+            );
+        }
+        println!("\n{} plugin(s) installed", entries.len());
+    }
+    Ok(())
 }
 
 /// Build a `SkillResolver` relative to the provided CLI `path` argument.

--- a/b00t-cli/src/datum_claude_plugin.rs
+++ b/b00t-cli/src/datum_claude_plugin.rs
@@ -1,0 +1,247 @@
+//! Claude Code plugin discovery — harmonizes b00t's skill resolver with
+//! plugins installed via Claude Code's own `/plugin install` marketplace
+//! mechanism (e.g. `superpowers@claude-plugins-official`).
+//!
+//! b00t does not install or manage the lifecycle of these plugins — that's
+//! Claude Code's job, driven by `~/.claude/plugins/installed_plugins.json`.
+//! This module only *reads* that state so plugin-bundled `skills/*/SKILL.md`
+//! directories become visible to `SkillResolver` (and therefore `b00t skill
+//! list/search/load/activate`) alongside project-local and other global
+//! skill sources.
+//!
+//! # File format (`~/.claude/plugins/installed_plugins.json`)
+//! ```json
+//! {
+//!   "version": 2,
+//!   "plugins": {
+//!     "superpowers@claude-plugins-official": [
+//!       {
+//!         "scope": "user",
+//!         "installPath": "/home/user/.claude/plugins/cache/claude-plugins-official/superpowers/6.2.0",
+//!         "version": "6.2.0",
+//!         "installedAt": "2026-08-08T00:00:00.000Z",
+//!         "lastUpdated": "2026-08-08T00:00:00.000Z"
+//!       }
+//!     ]
+//!   }
+//! }
+//! ```
+//! Each plugin key may have multiple entries (e.g. different scopes); all
+//! are surfaced — a stale/duplicate `installPath` just means the same
+//! `skills/` dir is scanned twice, which `SkillResolver::list()` already
+//! dedupes by skill name.
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+/// A single install record for a plugin (one plugin key can have several,
+/// e.g. one per scope).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InstalledPluginEntry {
+    #[serde(default)]
+    pub scope: String,
+    #[serde(rename = "installPath")]
+    pub install_path: String,
+    #[serde(default)]
+    pub version: String,
+    #[serde(default, rename = "installedAt")]
+    pub installed_at: String,
+    #[serde(default, rename = "lastUpdated")]
+    pub last_updated: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct InstalledPluginsFile {
+    #[serde(default)]
+    #[allow(dead_code)]
+    version: u32,
+    #[serde(default)]
+    plugins: HashMap<String, Vec<InstalledPluginEntry>>,
+}
+
+/// Read `<claude_dir>/plugins/installed_plugins.json`, returning
+/// `(plugin_key, entry)` pairs — one per install record.
+///
+/// Tolerant by design: a missing file, unreadable file, or malformed JSON
+/// all return an empty list rather than erroring, matching this codebase's
+/// convention for optional/global discovery paths (e.g. `find_b00t_dir`).
+pub fn read_installed_plugins(claude_dir: &Path) -> Vec<(String, InstalledPluginEntry)> {
+    let path = claude_dir.join("plugins").join("installed_plugins.json");
+    let Ok(content) = std::fs::read_to_string(&path) else {
+        return Vec::new();
+    };
+    let Ok(parsed) = serde_json::from_str::<InstalledPluginsFile>(&content) else {
+        return Vec::new();
+    };
+
+    let mut out = Vec::new();
+    for (key, entries) in parsed.plugins {
+        for entry in entries {
+            out.push((key.clone(), entry));
+        }
+    }
+    out
+}
+
+/// For every installed plugin, resolve `<installPath>/skills` when it
+/// exists as a directory. Returns `(plugin_key, skills_dir)` pairs.
+///
+/// A plugin with no `skills/` directory (e.g. `rust-analyzer-lsp`, which
+/// only registers an MCP server) is silently excluded — not every Claude
+/// Code plugin bundles skills.
+pub fn plugin_skill_dirs(claude_dir: &Path) -> Vec<(String, PathBuf)> {
+    read_installed_plugins(claude_dir)
+        .into_iter()
+        .filter_map(|(key, entry)| {
+            let skills_dir = PathBuf::from(&entry.install_path).join("skills");
+            skills_dir.is_dir().then_some((key, skills_dir))
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    /// Build a fake `<root>/.claude/` tree with one installed plugin entry
+    /// pointing at `<root>/plugin-install/`, optionally containing a
+    /// `skills/<name>/SKILL.md`.
+    fn make_fake_claude_dir(root: &Path, plugin_key: &str, install_path: &Path, with_skill: bool) {
+        let plugins_dir = root.join("plugins");
+        std::fs::create_dir_all(&plugins_dir).unwrap();
+
+        if with_skill {
+            let skill_dir = install_path.join("skills").join("brainstorming");
+            std::fs::create_dir_all(&skill_dir).unwrap();
+            let mut f = std::fs::File::create(skill_dir.join("SKILL.md")).unwrap();
+            f.write_all(
+                b"---\nname: brainstorming\ndescription: Explore ideas before implementing.\n---\n# Brainstorming\nAsk questions first.\n",
+            )
+            .unwrap();
+        } else {
+            std::fs::create_dir_all(install_path).unwrap();
+        }
+
+        let manifest = serde_json::json!({
+            "version": 2,
+            "plugins": {
+                plugin_key: [
+                    {
+                        "scope": "user",
+                        "installPath": install_path.to_string_lossy(),
+                        "version": "6.2.0",
+                        "installedAt": "2026-08-08T00:00:00.000Z",
+                        "lastUpdated": "2026-08-08T00:00:00.000Z",
+                    }
+                ]
+            }
+        });
+        std::fs::write(
+            plugins_dir.join("installed_plugins.json"),
+            serde_json::to_string_pretty(&manifest).unwrap(),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn missing_file_returns_empty() {
+        let tmp = tempfile::tempdir().unwrap();
+        let claude_dir = tmp.path().join(".claude");
+        // Note: no plugins/installed_plugins.json written at all.
+        assert!(read_installed_plugins(&claude_dir).is_empty());
+        assert!(plugin_skill_dirs(&claude_dir).is_empty());
+    }
+
+    #[test]
+    fn malformed_json_returns_empty() {
+        let tmp = tempfile::tempdir().unwrap();
+        let claude_dir = tmp.path().join(".claude");
+        std::fs::create_dir_all(claude_dir.join("plugins")).unwrap();
+        std::fs::write(
+            claude_dir.join("plugins").join("installed_plugins.json"),
+            "{ not valid json",
+        )
+        .unwrap();
+
+        assert!(read_installed_plugins(&claude_dir).is_empty());
+        assert!(plugin_skill_dirs(&claude_dir).is_empty());
+    }
+
+    #[test]
+    fn reads_plugin_with_skills_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let claude_dir = tmp.path().join(".claude");
+        let install_path = tmp.path().join("cache").join("superpowers").join("6.2.0");
+        make_fake_claude_dir(
+            &claude_dir,
+            "superpowers@claude-plugins-official",
+            &install_path,
+            true,
+        );
+
+        let entries = read_installed_plugins(&claude_dir);
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].0, "superpowers@claude-plugins-official");
+        assert_eq!(entries[0].1.version, "6.2.0");
+
+        let dirs = plugin_skill_dirs(&claude_dir);
+        assert_eq!(dirs.len(), 1);
+        assert_eq!(dirs[0].0, "superpowers@claude-plugins-official");
+        assert_eq!(dirs[0].1, install_path.join("skills"));
+    }
+
+    #[test]
+    fn plugin_without_skills_dir_is_excluded() {
+        let tmp = tempfile::tempdir().unwrap();
+        let claude_dir = tmp.path().join(".claude");
+        let install_path = tmp
+            .path()
+            .join("cache")
+            .join("rust-analyzer-lsp")
+            .join("1.0.0");
+        make_fake_claude_dir(
+            &claude_dir,
+            "rust-analyzer-lsp@claude-plugins-official",
+            &install_path,
+            false,
+        );
+
+        // The plugin itself is still readable...
+        assert_eq!(read_installed_plugins(&claude_dir).len(), 1);
+        // ...but contributes no skill directories.
+        assert!(plugin_skill_dirs(&claude_dir).is_empty());
+    }
+
+    #[test]
+    fn multiple_entries_for_same_plugin_key_all_returned() {
+        let tmp = tempfile::tempdir().unwrap();
+        let claude_dir = tmp.path().join(".claude");
+        let plugins_dir = claude_dir.join("plugins");
+        std::fs::create_dir_all(&plugins_dir).unwrap();
+
+        let path_a = tmp.path().join("a");
+        let path_b = tmp.path().join("b");
+        std::fs::create_dir_all(path_a.join("skills")).unwrap();
+        std::fs::create_dir_all(path_b.join("skills")).unwrap();
+
+        let manifest = serde_json::json!({
+            "version": 2,
+            "plugins": {
+                "dual-scope@marketplace": [
+                    { "scope": "user", "installPath": path_a.to_string_lossy(), "version": "1.0.0", "installedAt": "", "lastUpdated": "" },
+                    { "scope": "project", "installPath": path_b.to_string_lossy(), "version": "1.0.0", "installedAt": "", "lastUpdated": "" },
+                ]
+            }
+        });
+        std::fs::write(
+            plugins_dir.join("installed_plugins.json"),
+            serde_json::to_string_pretty(&manifest).unwrap(),
+        )
+        .unwrap();
+
+        let dirs = plugin_skill_dirs(&claude_dir);
+        assert_eq!(dirs.len(), 2);
+    }
+}

--- a/b00t-cli/src/lib.rs
+++ b/b00t-cli/src/lib.rs
@@ -52,6 +52,7 @@ pub mod datum_ai_model;
 pub mod datum_api;
 pub mod datum_apt;
 pub mod datum_bash;
+pub mod datum_claude_plugin;
 pub mod datum_cli;
 pub mod datum_config;
 pub mod datum_database;

--- a/b00t-cli/src/skill_resolver.rs
+++ b/b00t-cli/src/skill_resolver.rs
@@ -24,8 +24,11 @@
 //! 3. `./_b00t_/*.skill.toml[l][md]` — project b00t native (.skill.toml, .skill.tomllm, .skill.tomllmd)
 //! 4. `~/.config/opencode/skills/` — global opencode, SKILL.md format
 //! 5. `~/.claude/skills/`      — Claude Code native, SKILL.md format
-//! 6. `~/.agents/skills/`      — Agent-compatible, SKILL.md format
-//! 7. `~/.b00t/_b00t_/*.skill.toml[l][md]` — global b00t
+//! 6. `~/.claude/plugins/**/skills/` — skills bundled in installed Claude Code
+//!    plugins (e.g. `superpowers@claude-plugins-official`), discovered via
+//!    `~/.claude/plugins/installed_plugins.json`. See `datum_claude_plugin`.
+//! 7. `~/.agents/skills/`      — Agent-compatible, SKILL.md format
+//! 8. `~/.b00t/_b00t_/*.skill.toml[l][md]` — global b00t
 
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
@@ -218,6 +221,18 @@ impl SkillResolver {
             if claude_skills.is_dir() {
                 dirs.push(SkillDir {
                     path: claude_skills,
+                    format: SkillFormat::SkillMd,
+                });
+            }
+            // Skills bundled in installed Claude Code plugins (e.g. Superpowers'
+            // brainstorming/TDD/subagent-driven-development skills), discovered
+            // via ~/.claude/plugins/installed_plugins.json.
+            let claude_dir = home.join(".claude");
+            for (_plugin_key, skills_dir) in
+                crate::datum_claude_plugin::plugin_skill_dirs(&claude_dir)
+            {
+                dirs.push(SkillDir {
+                    path: skills_dir,
                     format: SkillFormat::SkillMd,
                 });
             }

--- a/b00t-embed/src/backends.rs
+++ b/b00t-embed/src/backends.rs
@@ -24,7 +24,7 @@ impl EmbedAnythingBackend {
 
         let embedder = match &config.provider {
             EmbedProvider::HuggingFace { model_id, revision } => {
-                Embedder::from_pretrained_hf(model_id, revision.as_deref(), None, None, None)?
+                Embedder::from_pretrained_hf(model_id, revision.as_deref(), None, None)?
             }
             EmbedProvider::ONNX { model_id } => {
                 Embedder::from_pretrained_onnx("bert", None, None, Some(model_id), None, None)?


### PR DESCRIPTION
## Summary
Claude Code plugins installed via `/plugin install` (e.g. `superpowers@claude-plugins-official`, which bundles brainstorming/TDD/subagent-driven-development skills) were invisible to b00t's `SkillResolver` — it already scans `~/.claude/skills/` but had no awareness of `~/.claude/plugins/`, where plugin-bundled skills actually live.

- `datum_claude_plugin.rs` (new): reads `~/.claude/plugins/installed_plugins.json` (tolerant of missing/malformed file) and resolves each installed plugin's `<installPath>/skills/` directory when present. b00t doesn't install or manage these plugins' lifecycle — that stays Claude Code's job — this only harmonizes discovery.
- `skill_resolver.rs`: wires `plugin_skill_dirs()` into `build_dirs()` alongside the existing `~/.claude/skills/` entry, so plugin-bundled `SKILL.md` files (already in the agentskills.io frontmatter format `SkillDatum::from_skill_md` already parses) surface through the existing `b00t skill list/search/load/activate` commands with no new verbs needed.
- `commands/skill.rs`: adds `b00t skill plugins` as a read-only report of installed plugins + how many skills each contributes, for visibility into what's being harmonized.

### Unrelated fixes required to get a green build
This workspace didn't compile beforehand:
- `b00t-embed/src/backends.rs`: `from_pretrained_hf()` dropped a parameter upstream (`embed_anything` 0.7.2 -> 0.7.0 per `Cargo.lock` resolution); removed the stale extra argument per the compiler's own suggestion.
- `commands/provider.rs`: two call sites passed bare `f64` where `fmt_cost()`/`fmt_pod_status_line()` take `Option<f64>`; wrapped in `Some(..)` per the compiler's suggestion.

## Test plan
- [x] 5 new `datum_claude_plugin` unit tests (missing file, malformed JSON, plugin with/without a skills dir, multiple install entries for one plugin key)
- [x] Full pre-existing `b00t-cli --lib` suite (40 tests) — all green, no regressions