### PR TITLE
docs(gh-runner): explain why allowPrivilegeEscalation stays false

### DIFF
--- a/_b00t_/gh-runner.hive.toml
+++ b/_b00t_/gh-runner.hive.toml
@@ -72,6 +72,12 @@ spec:
     securityContext:
       runAsNonRoot: true
       runAsUser: 1001
+      # Deliberately false. An abandoned stash on feat/gh-runner-podman-socket-passthrough
+      # once set this to true + added capabilities.add: [DAC_OVERRIDE, SETGID, SETUID],
+      # presumably to fix podman-socket permission errors for the rootless runner user —
+      # but it was never validated or merged, and we don't have evidence it's actually
+      # required. If the runner hits podman-socket permission failures, this is the
+      # first thing to revisit — but don't loosen it speculatively.
       allowPrivilegeEscalation: false
   volumes:
   - name: work


### PR DESCRIPTION
## Summary
An abandoned \`git stash\` on \`feat/gh-runner-podman-socket-passthrough\` (recovered separately — see #987) had set this runner pod's \`allowPrivilegeEscalation: true\` + added \`capabilities.add: [DAC_OVERRIDE, SETGID, SETUID]\`, presumably to fix podman-socket permission issues for the rootless runner user. It was never validated or merged.

Decision: keep \`false\` (main's existing, stricter setting). This just records the rationale inline so a future pass doesn't loosen it speculatively without first confirming it's actually needed.

## Test plan
- [x] Comment-only change, no behavior difference