### PR TITLE
feat: evaluate gate preconditions before RuntimeConfig sandbox dispatch (#712)

### DIFF
--- a/b00t-cli/src/config_types.rs
+++ b/b00t-cli/src/config_types.rs
@@ -355,6 +355,12 @@ pub struct RuntimeConfig {
     pub isolation: Option<IsolationConfig>,
     pub hook_pre: Option<String>,
     pub hook_post: Option<String>,
+    /// Gate preconditions carried over from the owning datum's `[[b00t.gate]]`
+    /// list (#712). Populated by `load_runtime_datum`, not read directly from
+    /// a `[b00t.runtime]` TOML table — evaluated by `spawn_sandboxed` before
+    /// the sandbox forks, so a `requires_gpu`-style gate fails with a clear
+    /// pre-flight message instead of a confusing in-sandbox crash.
+    pub gate: Option<Vec<crate::GateSpec>>,
 }
 
 // ── MCP method types ───────────────────────────────────────────────────

--- a/b00t-cli/src/lifecycle.rs
+++ b/b00t-cli/src/lifecycle.rs
@@ -263,10 +263,18 @@ pub fn load_runtime_datum(name: &str, path: &str) -> Result<RuntimeConfig> {
     let config: UnifiedConfig =
         toml::from_str(&content).context(format!("Failed to parse {}", file_path.display()))?;
 
-    config
+    let datum_gate = config.b00t.gate.clone();
+    let mut runtime = config
         .b00t
         .runtime
-        .ok_or_else(|| anyhow::anyhow!("datum '{}' missing [b00t.runtime] section", name))
+        .ok_or_else(|| anyhow::anyhow!("datum '{}' missing [b00t.runtime] section", name))?;
+    // 🤓 #712: gate preconditions live on the datum (`[[b00t.gate]]`), not
+    //    nested under `[b00t.runtime]` — carry them onto RuntimeConfig here so
+    //    spawn_sandboxed can evaluate them before forking the sandbox.
+    if runtime.gate.is_none() {
+        runtime.gate = datum_gate;
+    }
+    Ok(runtime)
 }
 
 // ── Generic datum provider loader ──────────────────────────────────────

--- a/b00t-cli/src/main.rs
+++ b/b00t-cli/src/main.rs
@@ -2099,6 +2099,7 @@ async fn main() {
                                         match b00t_cli::runtime_sandbox::spawn_sandboxed(
                                             &cfg,
                                             &passthrough,
+                                            &expanded,
                                         ) {
                                             Ok(code) => std::process::exit(code),
                                             Err(err) => {
@@ -2154,7 +2155,11 @@ async fn main() {
 
                     match matches.into_iter().next() {
                         Some(b00t_cli::DatumDispatch::Runtime(cfg)) => {
-                            match b00t_cli::runtime_sandbox::spawn_sandboxed(&cfg, &passthrough) {
+                            match b00t_cli::runtime_sandbox::spawn_sandboxed(
+                                &cfg,
+                                &passthrough,
+                                &expanded,
+                            ) {
                                 Ok(code) => std::process::exit(code),
                                 Err(err) => {
                                     eprintln!("[b00t] runtime launch failed: {err}");
@@ -2186,6 +2191,7 @@ async fn main() {
                                             match b00t_cli::runtime_sandbox::spawn_sandboxed(
                                                 &cfg,
                                                 &passthrough,
+                                                &expanded,
                                             ) {
                                                 Ok(code) => std::process::exit(code),
                                                 Err(err) => {
@@ -3310,7 +3316,8 @@ async fn main() {
             let passthrough: Vec<String> = args.iter().map(|s| s.to_string()).collect();
             match b00t_cli::resolve_datum_dispatch(name, &expanded) {
                 Some(b00t_cli::DatumDispatch::Runtime(cfg)) => {
-                    match b00t_cli::runtime_sandbox::spawn_sandboxed(&cfg, &passthrough) {
+                    match b00t_cli::runtime_sandbox::spawn_sandboxed(&cfg, &passthrough, &expanded)
+                    {
                         Ok(code) => std::process::exit(code),
                         Err(err) => {
                             eprintln!("[b00t] runtime launch failed: {err}");

--- a/b00t-cli/src/runtime_sandbox.rs
+++ b/b00t-cli/src/runtime_sandbox.rs
@@ -13,13 +13,46 @@
 //! The child uses only async-signal-safe syscalls. Errors are communicated
 //! via a single-byte code written to the pre-fork pipe.
 
-use crate::{IsolationConfig, RuntimeConfig};
+use crate::{GateSpec, IsolationConfig, RuntimeConfig};
 use anyhow::{Result, anyhow, bail};
 use std::ffi::CString;
 
 /// Fork, launch sandboxed child, wait, run post-hook.
 /// Returns the child's exit status.
-pub fn spawn_sandboxed(config: &RuntimeConfig, passthrough_args: &[String]) -> Result<i32> {
+///
+/// `datum_path` is the datum directory (same `path` convention used by
+/// `evaluate_gates`/`GatePreconditions` elsewhere) — needed to resolve
+/// relative `file` gates. Pass whatever `path` was used to resolve the
+/// runtime datum in the first place.
+pub fn spawn_sandboxed(
+    config: &RuntimeConfig,
+    passthrough_args: &[String],
+    datum_path: &str,
+) -> Result<i32> {
+    // ═══════ Gate preconditions (#712) ═══════
+    // RuntimeConfig previously carried no gate information at all, so a
+    // `requires_gpu`-style precondition on the datum went unchecked here —
+    // the sandbox would fork/exec and crash inside with a confusing runtime
+    // error instead of a clear pre-flight message. Reuses the same
+    // `evaluate_gates()` already relied on by `commands/install.rs` for the
+    // install path, applied here to the runtime dispatch path.
+    if let Some(gates) = &config.gate {
+        if !gates.is_empty() {
+            let results = crate::gates::evaluate_gates(gates, datum_path);
+            let failed: Vec<&str> = results
+                .iter()
+                .filter(|r| !r.passed)
+                .map(|r| r.reason.as_str())
+                .collect();
+            if !failed.is_empty() {
+                bail!(
+                    "gate precondition failed — sandbox launch blocked: {}",
+                    failed.join("; ")
+                );
+            }
+        }
+    }
+
     // ═══════ Pre-resolve everything in the PARENT (before fork) ═══════
     let binary = resolve_binary(&config.binary)?;
     let c_binary = CString::new(binary.clone()).map_err(|e| anyhow!("binary: {e}"))?;
@@ -377,6 +410,7 @@ mod tests {
             isolation: None,
             hook_pre: None,
             hook_post: None,
+            gate: None,
         }
     }
 
@@ -414,7 +448,8 @@ mod tests {
     #[cfg(target_os = "linux")]
     fn test_spawn_sandboxed_no_isolation() {
         let config = empty_runtime_config("/bin/true");
-        let exit_code = spawn_sandboxed(&config, &[]).expect("spawn_sandboxed should succeed");
+        let exit_code =
+            spawn_sandboxed(&config, &[], "/tmp").expect("spawn_sandboxed should succeed");
         assert_eq!(exit_code, 0, "/bin/true should exit 0, got {exit_code}");
     }
 
@@ -422,10 +457,49 @@ mod tests {
     #[cfg(target_os = "linux")]
     fn test_spawn_sandboxed_binary_not_found() {
         let config = empty_runtime_config("__nonexistent_binary_xyz__");
-        let result = spawn_sandboxed(&config, &[]);
+        let result = spawn_sandboxed(&config, &[], "/tmp");
         assert!(
             result.is_err(),
             "expected error for nonexistent binary, got: {result:?}"
         );
+    }
+
+    // ── #712: gate preconditions must block sandbox dispatch ────────────
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn test_spawn_sandboxed_blocked_by_unmet_gate() {
+        // /bin/true would succeed on its own — proves the gate short-circuits
+        // BEFORE fork/exec, not that the binary itself failed.
+        let mut config = empty_runtime_config("/bin/true");
+        config.gate = Some(vec![GateSpec {
+            command: Some("__nonexistent_command_xyz__".to_string()),
+            ..Default::default()
+        }]);
+
+        let result = spawn_sandboxed(&config, &[], "/tmp");
+        assert!(
+            result.is_err(),
+            "expected unmet gate to block sandbox launch, got: {result:?}"
+        );
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("gate precondition failed"),
+            "error should surface a clear gate pre-flight message, got: {err}"
+        );
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn test_spawn_sandboxed_proceeds_when_gate_satisfied() {
+        let mut config = empty_runtime_config("/bin/true");
+        config.gate = Some(vec![GateSpec {
+            command: Some("sh".to_string()),
+            ..Default::default()
+        }]);
+
+        let exit_code = spawn_sandboxed(&config, &[], "/tmp")
+            .expect("satisfied gate should not block sandbox launch");
+        assert_eq!(exit_code, 0, "/bin/true should exit 0, got {exit_code}");
     }
 }


### PR DESCRIPTION
Closes #712

## Summary
`DatumDispatch::Runtime`'s `spawn_sandboxed()` forked/exec'd directly into
the sandbox without ever checking the datum's `[[b00t.gate]]` preconditions.
A datum with e.g. a `requires_gpu` gate would go unchecked and fail with a
confusing in-sandbox crash instead of a clear pre-flight message, exactly
as described in the issue.

- `RuntimeConfig` gains an optional `gate: Option<Vec<GateSpec>>` field.
- `load_runtime_datum` (lifecycle.rs) populates it from the owning
  `BootDatum.gate` (gates are declared at the datum level, not nested under
  `[b00t.runtime]`).
- `spawn_sandboxed` (runtime_sandbox.rs) evaluates the gate list via the
  existing `evaluate_gates()` helper — the same one `commands/install.rs`
  already uses for the install path — before any fork/exec work, and bails
  with `"gate precondition failed — sandbox launch blocked: <reasons>"`
  when unmet.
- All 4 `spawn_sandboxed` call sites in `main.rs` now pass the datum's
  resolved path through for gate evaluation.

Reuses prior-art gate infrastructure (`GateSpec::eval_disposition`,
`evaluate_gates`) already in the tree from earlier issues in this backlog —
no new gate evaluation engine, just wiring the existing one into the
runtime dispatch path that was bypassing it.

## Test plan
- [x] New unit tests in `runtime_sandbox.rs`:
  - `test_spawn_sandboxed_blocked_by_unmet_gate` — an unmet `command` gate
    blocks launch of an otherwise-succeeding `/bin/true`, proving the gate
    short-circuits before fork/exec.
  - `test_spawn_sandboxed_proceeds_when_gate_satisfied` — a satisfied gate
    does not block launch.
  - Existing `test_spawn_sandboxed_no_isolation` / `_binary_not_found`
    updated for the new `datum_path` parameter.
- [ ] `cargo build -p b00t-cli` / `cargo test -p b00t-cli` — **verification
  pending**. This worktree's full workspace resolution requires several
  vendored git submodules (`vendor/ledgrrr`, `vendor/runpod-sdk`,
  `vendor/embed-anything-b00t`, ...) that are not checked out and slow/flaky
  to initialize in this environment — a known repo-wide issue hitting other
  agents in this batch, not specific to this change. The diff is small,
  self-contained to 4 files, and was reviewed line-by-line for type/borrow
  correctness; CI should confirm.