### PR TITLE
feat(store): expose store.status over NATS request-reply (#716 PoC)

### DIFF
--- a/b00t-cli/src/commands/store.rs
+++ b/b00t-cli/src/commands/store.rs
@@ -49,6 +49,50 @@ pub enum StoreCommands {
     Status,
     #[clap(about = "Cross-engine consistency check: Store ↔ knowledge backend ↔ blobs")]
     Validate,
+    #[clap(about = "Serve store.status over a NATS request-reply subject (#716 proof-of-concept)")]
+    Serve {
+        #[clap(long, help = "NATS server URL (defaults to NATS_URL env or nats://localhost:4222)")]
+        nats_url: Option<String>,
+    },
+}
+
+/// NATS subject exposing `store::status()` as a request-reply endpoint.
+///
+/// 🤓 #716 proof-of-concept: only `status` is exposed for this first slice.
+/// `store.get` / `store.validate` are natural follow-ups on the same pattern
+/// once this subject is proven out on the hive-lan NATS deployment.
+pub const STORE_STATUS_SUBJECT: &str = "b00t.store.status";
+
+/// Build the JSON reply payload for a `store.status` request.
+/// Pure/sync so it is unit-testable without a live NATS broker.
+pub fn store_status_reply_payload(count: usize, bytes: u64) -> Vec<u8> {
+    serde_json::json!({
+        "object_count": count,
+        "total_bytes": bytes,
+    })
+    .to_string()
+    .into_bytes()
+}
+
+#[cfg(test)]
+mod nats_serve_tests {
+    use super::*;
+
+    #[test]
+    fn store_status_subject_is_stable() {
+        // 🤓 subject naming follows the existing b00t.<domain>.<verb> convention
+        // used by b00t-lib-chat (b00t.tasks.*, b00t.notify.>).
+        assert_eq!(STORE_STATUS_SUBJECT, "b00t.store.status");
+    }
+
+    #[test]
+    fn store_status_reply_payload_round_trips() {
+        let payload = store_status_reply_payload(42, 1024);
+        let parsed: serde_json::Value = serde_json::from_slice(&payload)
+            .expect("store_status_reply_payload must produce valid JSON");
+        assert_eq!(parsed["object_count"], 42);
+        assert_eq!(parsed["total_bytes"], 1024);
+    }
 }
 
 fn parse_key_val(s: &str) -> Result<(String, String), String> {
@@ -58,7 +102,7 @@ fn parse_key_val(s: &str) -> Result<(String, String), String> {
     Ok((k.to_string(), v.to_string()))
 }
 
-pub fn handle_store_command(cmd: &StoreCommands) -> anyhow::Result<()> {
+pub async fn handle_store_command(cmd: &StoreCommands) -> anyhow::Result<()> {
     match cmd {
         StoreCommands::Put {
             file,
@@ -150,6 +194,64 @@ pub fn handle_store_command(cmd: &StoreCommands) -> anyhow::Result<()> {
                 println!("\n⚠️  Cross-engine consistency: DEGRADED");
             }
         }
+        StoreCommands::Serve { nats_url } => {
+            serve_nats(nats_url.clone()).await?;
+        }
     }
+    Ok(())
+}
+
+/// #716: expose `store.status` as a NATS request-reply subject so agents on
+/// other hosts can query the store without SSH/shelling into this host.
+///
+/// Proof-of-concept scope: one subject (`b00t.store.status`). `store.get` and
+/// `store.validate` follow the identical pattern once this is proven on the
+/// hive-lan NATS deployment — see issue #716.
+async fn serve_nats(nats_url: Option<String>) -> anyhow::Result<()> {
+    use anyhow::Context;
+    use futures::StreamExt;
+
+    // Auth (B00T_HIVE_NATS_USER/PASSWORD) and URL (NATS_URL) env fallbacks are
+    // applied inside b00t_chat::ChatTransport::from_config regardless of what
+    // we pass here — matches the existing `b00t chat send --transport nats` path.
+    let client = b00t_chat::ChatClient::nats(nats_url, None, None)
+        .context("failed to configure NATS chat client")?;
+    let nats = client
+        .raw_nats_client()
+        .await
+        .context("failed to connect to NATS")?;
+
+    let mut subscriber = nats
+        .subscribe(STORE_STATUS_SUBJECT.to_string())
+        .await
+        .context("failed to subscribe to store.status subject")?;
+
+    println!("🥾 Serving store.status on NATS subject: {STORE_STATUS_SUBJECT}");
+    println!("   Ctrl-C to stop.");
+
+    loop {
+        tokio::select! {
+            _ = tokio::signal::ctrl_c() => {
+                println!("\n🥾 store serve --nats shutting down");
+                break;
+            }
+            msg = subscriber.next() => {
+                let Some(msg) = msg else {
+                    println!("⚠️  NATS subscription closed");
+                    break;
+                };
+                let Some(reply) = msg.reply else {
+                    tracing::warn!("store.status request on {} had no reply subject; ignoring", msg.subject);
+                    continue;
+                };
+                let (count, bytes) = b00t_c0re_lib::store::status();
+                let payload = store_status_reply_payload(count, bytes);
+                if let Err(e) = nats.publish(reply, payload.into()).await {
+                    tracing::warn!("failed to publish store.status reply: {}", e);
+                }
+            }
+        }
+    }
+
     Ok(())
 }

--- a/b00t-cli/src/main.rs
+++ b/b00t-cli/src/main.rs
@@ -3062,7 +3062,7 @@ async fn main() {
             }
         }
         Some(Commands::Store(args)) => {
-            if let Err(e) = b00t_cli::commands::store::handle_store_command(&args) {
+            if let Err(e) = b00t_cli::commands::store::handle_store_command(&args).await {
                 eprintln!("Error: {}", e);
                 std::process::exit(1);
             }

--- a/b00t-lib-chat/src/client.rs
+++ b/b00t-lib-chat/src/client.rs
@@ -109,6 +109,13 @@ impl ChatClient {
     pub async fn send_raw(&self, subject: &str, payload: &[u8]) -> ChatResult<()> {
         self.transport.send_raw(subject, payload).await
     }
+
+    /// Escape hatch to the underlying `async_nats::Client` (NATS transport
+    /// only) for request-reply servers and other patterns not yet wrapped
+    /// by this client. See #716's `store serve --nats`.
+    pub async fn raw_nats_client(&self) -> ChatResult<async_nats::Client> {
+        self.transport.raw_nats_client().await
+    }
 }
 
 impl From<ChatTransportKind> for ChatTransportConfig {

--- a/b00t-lib-chat/src/transport.rs
+++ b/b00t-lib-chat/src/transport.rs
@@ -161,6 +161,19 @@ impl ChatTransport {
             }
         }
     }
+
+    /// Escape hatch to the underlying `async_nats::Client` for callers that
+    /// need patterns this wrapper doesn't cover yet (e.g. request-reply
+    /// servers — see #716's `store serve --nats`). Prefer the typed
+    /// send/subscribe helpers above where they fit.
+    pub async fn raw_nats_client(&self) -> ChatResult<async_nats::Client> {
+        match self {
+            ChatTransport::Nats(t) => t.client().await,
+            ChatTransport::Local(_) => Err(ChatError::Other(
+                "raw_nats_client requires NATS transport".into(),
+            )),
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -234,6 +247,12 @@ impl RealNatsTransport {
             max_reconnect_attempts: 3,
             reconnect_delay_ms: 1000,
         }
+    }
+
+    /// Public accessor for the underlying connected `async_nats::Client`,
+    /// reusing the same connect/reconnect machinery as the typed helpers.
+    pub async fn client(&self) -> ChatResult<async_nats::Client> {
+        self.ensure_connected().await
     }
 
     async fn ensure_connected(&self) -> ChatResult<async_nats::Client> {


### PR DESCRIPTION
Closes #716

## Summary
- Proof-of-concept slice of #716: `b00t store serve --nats` subscribes to the `b00t.store.status` NATS subject and replies with `{object_count, total_bytes}`, so an agent on another host can query the store without SSH/shelling into the host running it.
- `store.get` / `store.validate` are natural follow-ups on the identical pattern once this subject is proven out on the hive-lan NATS deployment — scoped down to one method for this PR per the "proportionate slice" guidance, since NATS request-reply-serving is a new usage pattern in this codebase (existing NATS usage in `b00t-lib-chat` is pub/sub only: `send`/`publish`/`subscribe`, no reply-subject handling).
- Adds `raw_nats_client()` to `b00t_chat::ChatTransport`/`ChatClient` as a thin escape hatch to the existing `async_nats::Client` (already a workspace dependency at `async-nats = "0.45.0"` in `b00t-lib-chat`, `b00t-c0re-lib` (via `b00t-ipc`), and `b00t-cli`) — no new dependency introduced.
- `b00t_c0re_lib::store::status()` already existed with the exact `(usize, u64)` shape the issue asked for; reused as-is.

## Research notes (for reviewers)
- NATS is **not** a new dependency for this repo: `async-nats 0.45.0` is already used by `b00t-lib-chat/src/transport.rs` (`RealNatsTransport`, task/notification pub-sub over subjects like `b00t.tasks.*`, `b00t.notify.>`), and declared in `b00t-ipc`, `b00t-c0re-lib`, `b00t-cli` Cargo.toml files.
- The MCP `b00t_agent_message`/`b00t_agent_notify` tools (CLAUDE.md "Hive A2A Collaboration") solve agent-to-agent *chat* messaging, not store data access — no functional overlap with this issue, so it is not a duplicate of that mechanism.

## Test plan
- [x] Added unit tests for the pure, testable slice (`STORE_STATUS_SUBJECT` constant, `store_status_reply_payload` JSON shape) in `b00t-cli/src/commands/store.rs`
- [x] `cargo build -p b00t-chat` — PASS
- [x] `cargo build -p b00t-cli` — PASS (full binary build, exit 0)
- [ ] `cargo test -p b00t-cli nats_serve_tests` — running, will confirm before taking out of draft
- [ ] Manual: `b00t store serve --nats` against a live NATS broker, request `b00t.store.status` from a second host, confirm JSON reply

```
$ cargo build -p b00t-chat
   Compiling b00t-chat v0.10.3 (.../b00t-lib-chat)
   ...
   Compiling async-nats v0.45.0
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 40s

$ cargo build -p b00t-cli
   Compiling b00t-ipc v0.10.3 (.../b00t-ipc)
   ...
   Compiling b00t-chat v0.10.3 (.../b00t-lib-chat)
   Compiling b00t-c0re-lib v0.10.3 (.../b00t-c0re-lib)
   Compiling b00t-c0re-gov v0.10.3 (.../b00t-c0re-gov)
   Compiling b00t-c0re-hierarchy v0.10.3 (.../b00t-c0re-hierarchy)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 10m 24s
```

(Full workspace build required initializing several previously-uninitialized vendor submodules — `vendor/ledgrrr`, `vendor/runpod-sdk`, `vendor/embed-anything-b00t` — a known repo-wide sharp corner unrelated to this change.)