### PR TITLE
pipe SemanticClass shape/colour taxonomy into graph JSON endpoint (#714)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1380,6 +1380,7 @@ version = "0.10.3"
 dependencies = [
  "axum 0.8.9",
  "b00t-c0re-lib",
+ "b00t-cli",
  "b00t-l3dg3rr-viz",
  "chrono",
  "futures",
@@ -1789,6 +1790,15 @@ dependencies = [
  "tokio-test",
  "uuid",
  "zbus",
+]
+
+[[package]]
+name = "b00t-isometric-wasm"
+version = "0.10.3"
+dependencies = [
+ "b00t-l3dg3rr-viz",
+ "serde_json",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,12 @@ members = [
     "b00t-admin",
     "b00t-mermaid-wasm",
     "b00t-ui-wasm",
+    # 🤓 #714: tracked in git (feat 50d13d82) but missing from workspace
+    # members — this is the WASM renderer that actually consumes
+    # /api/admin/viz/entangle/json (see its own module doc), yet was
+    # unbuildable via `cargo build --workspace`. Restoring membership so it
+    # participates in workspace builds/tests again.
+    "b00t-isometric-wasm",
     "b00t-embed-serve",
     "b00t-stt-serve",
 ]

--- a/b00t-admin/Cargo.toml
+++ b/b00t-admin/Cargo.toml
@@ -25,6 +25,9 @@ tokio.workspace = true
 chrono.workspace = true
 b00t-c0re-lib = { workspace = true }
 b00t-l3dg3rr-viz = { workspace = true }
+# 🤓 #714: reuses DatumType/SemanticClass shape+colour taxonomy for the
+# graph JSON endpoint — do NOT duplicate the shape/colour match tables here.
+b00t-cli = { workspace = true }
 
 # HTTP server
 axum = { version = "0.8", features = ["macros", "ws"] }

--- a/b00t-admin/src/graph_json.rs
+++ b/b00t-admin/src/graph_json.rs
@@ -3,10 +3,64 @@
 //! letting the WASM layout engine do SVG rendering client-side.
 
 use axum::extract::Query;
+use b00t_cli::DatumType;
 use b00t_l3dg3rr_viz::InvariantGraph;
 use b00t_l3dg3rr_viz::artifact::curate_orphans;
 use b00t_l3dg3rr_viz::isometric::{filter_orphans, parse_mermaid};
 use std::collections::{HashMap, HashSet};
+
+/// Resolve a node's [`b00t_cli::SemanticClass`] shape/colour from its label.
+///
+/// `datum_graph_to_mermaid` (b00t-cli/src/viz/mod.rs) embeds each node's
+/// `DatumType::type_prefix()` token as the label's second line
+/// (`"key\ntype_token"`, using a literal `\n` mermaid line-break, not a
+/// newline byte). This round-trips that token back through
+/// `DatumType::from_type_token()` to recover the real SemanticClass —
+/// avoiding re-deriving shape/colour tables here (single source of truth
+/// stays `b00t-cli/src/datum_types.rs`).
+///
+/// Returns `None` for labels with no recognizable trailing type token (e.g.
+/// graphs not sourced from `viz entangle`, or nodes with `datum_type: None`
+/// which embed the literal `"?"` placeholder).
+fn semantic_style(label: &str) -> Option<(&'static str, &'static str, &'static str)> {
+    let token = label.rsplit("\\n").next()?.trim();
+    let dtype = DatumType::from_type_token(token)?;
+    let class = dtype.semantic_class();
+    // SemanticClass has no public name accessor; css_class() ("sc-agent")
+    // is the existing stable identifier — strip the "sc-" prefix rather
+    // than adding a new method that duplicates the same information.
+    let class_name = class.css_class().trim_start_matches("sc-");
+    Some((class.shape(), class.color(), class_name))
+}
+
+#[cfg(test)]
+mod semantic_style_tests {
+    use super::*;
+
+    #[test]
+    fn resolves_known_type_token() {
+        // Agent → SemanticClass::Agent → shape "circle"
+        let style = semantic_style("my-agent\\nagent");
+        assert_eq!(style, Some(("circle", "#059669", "agent")));
+    }
+
+    #[test]
+    fn resolves_infra_type_token() {
+        // k8s → SemanticClass::Infra → shape "hexagon"
+        let style = semantic_style("my-cluster\\nk8s");
+        assert_eq!(style, Some(("hexagon", "#326ce5", "infra")));
+    }
+
+    #[test]
+    fn returns_none_for_missing_type_placeholder() {
+        assert_eq!(semantic_style("orphan-node\\n?"), None);
+    }
+
+    #[test]
+    fn returns_none_for_label_without_type_suffix() {
+        assert_eq!(semantic_style("plain label, no type token"), None);
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ContextDepth {
@@ -71,6 +125,11 @@ pub async fn entangle_json_handler(
     }
 
     let depth = ContextDepth::classify(&graph);
+    // 🤓 #714: legend entries keyed by semantic_class name so duplicates
+    // across nodes collapse to one legend row each (BTreeMap for stable,
+    // alphabetical ordering in the response).
+    let mut legend: std::collections::BTreeMap<&'static str, (&'static str, &'static str)> =
+        std::collections::BTreeMap::new();
     let nodes: Vec<serde_json::Value> = graph
         .nodes
         .iter()
@@ -81,12 +140,30 @@ pub async fn entangle_json_handler(
                 ContextDepth::Extended => "extended",
                 ContextDepth::Historical => "historical",
             };
+            let style = semantic_style(&n.label);
+            if let Some((shape, color, class_name)) = style {
+                legend.entry(class_name).or_insert((shape, color));
+            }
             serde_json::json!({
                 "id": n.id,
                 "label": n.label,
                 "role": n.role.as_str(),
                 "invariant": n.invariant,
                 "depth": d_str,
+                "shape": style.map(|s| s.0),
+                "color": style.map(|s| s.1),
+                "semantic_class": style.map(|s| s.2),
+            })
+        })
+        .collect();
+
+    let legend: Vec<serde_json::Value> = legend
+        .into_iter()
+        .map(|(class_name, (shape, color))| {
+            serde_json::json!({
+                "semantic_class": class_name,
+                "shape": shape,
+                "color": color,
             })
         })
         .collect();
@@ -122,6 +199,10 @@ pub async fn entangle_json_handler(
         "nodes": nodes,
         "edges": edges,
         "depth": { "surface": surface, "extended": extended, "historical": historical },
+        // 🤓 #714: distinct SemanticClass values actually present in this
+        // graph, so the dashboard legend updates dynamically per-render
+        // instead of hardcoding all 9 classes regardless of relevance.
+        "legend": legend,
     });
 
     if curate {

--- a/b00t-cli/src/viz/mod.rs
+++ b/b00t-cli/src/viz/mod.rs
@@ -489,10 +489,15 @@ pub fn datum_graph_to_scene(graph: &DatumGraph) -> SceneGraph {
 pub fn datum_graph_to_mermaid(graph: &DatumGraph) -> String {
     let mut out = String::from("graph LR\n");
     for node in &graph.nodes {
+        // 🤓 #714: emit the canonical lowercase type_prefix() token (e.g.
+        // "cli"), not the PascalCase Debug string. Downstream consumers
+        // (b00t-admin/graph_json.rs) round-trip this through
+        // DatumType::from_type_token() to resolve SemanticClass shape/colour
+        // for the dashboard's graph renderer.
         let datum_type = node
             .datum_type
             .as_ref()
-            .map(|dtype| format!("{dtype:?}"))
+            .map(|dtype| dtype.type_prefix().to_string())
             .unwrap_or_else(|| "?".into());
         out.push_str(&format!(
             "    {}[\"{}\"]\n",
@@ -746,6 +751,15 @@ mod tests {
         assert!(mermaid.contains("b00t.cli"));
         assert!(mermaid.contains("rust.c"));
         assert!(mermaid.contains("-->"));
+        // 🤓 #714: the embedded type suffix must be DatumType::type_prefix()'s
+        // canonical lowercase token (e.g. "cli"), not the PascalCase Debug
+        // string ("Cli") — downstream consumers (b00t-admin/graph_json.rs)
+        // round-trip it through DatumType::from_type_token() to recover
+        // SemanticClass shape/colour, which only recognizes the token form.
+        assert!(
+            mermaid.contains("\\ncli"),
+            "expected lowercase type_prefix token '\\ncli' in mermaid output: {mermaid}"
+        );
         let scene = datum_graph_to_scene(&graph);
         assert_eq!(scene.nodes.len(), 2);
         assert_eq!(scene.edges.len(), 1);


### PR DESCRIPTION
Closes #714

## Summary
- `b00t-admin/src/graph_json.rs` (the exact file named in the issue) now emits `shape`, `color`, and `semantic_class` per node in the `/api/admin/viz/entangle/json` response, plus a dynamic `legend` array of only the SemanticClass values actually present in the graph — resolved via `b00t_cli::DatumType::from_type_token(...).semantic_class()`, reusing the single source of truth in `b00t-cli/src/datum_types.rs` rather than duplicating shape/colour tables (per the file's own `DO NOT add manual match arms elsewhere` comment).
- Root-cause fix: `datum_graph_to_mermaid` (`b00t-cli/src/viz/mod.rs`) was embedding each node's `DatumType` as its PascalCase `Debug` string (e.g. `"Cli"`), which nothing downstream could parse back reliably. Switched to the existing canonical `type_prefix()` token (e.g. `"cli"`) so it round-trips through `DatumType::from_type_token()`.
- Restored `b00t-isometric-wasm` to the workspace `members` list in root `Cargo.toml`. It is the actual WASM renderer that consumes this JSON endpoint (per its own module doc), but was missing from `members` — likely an accidental drop in a prior merge — making it unbuildable via `cargo build --workspace`.

## Scoped down from the full issue ask
Consuming `shape`/`color` inside the shared isometric SVG renderer (`b00t-l3dg3rr-viz::isometric::graph_to_isometric_svg`, used by `b00t-isometric-wasm`) is left as explicit follow-up. That renderer draws every node from `VisualizationRole` (a separate, pre-existing text-heuristic taxonomy, not SemanticClass), shared by `InvariantNode` across multiple renderers (mermaid-native, blessing viz, task viz, artifact curation). Threading SemanticClass shape/colour through it safely requires widening `InvariantNode` for all of those consumers — a larger refactor than fits this P4 slice. The backend API contract (shape/color/legend) is now in place for that follow-up to consume.

## Verification status
🚩 **Build/test verification pending.** This worktree's `cargo build`/`cargo test` is blocked by ~28 uninitialized vendor submodules repo-wide (a known, pre-existing issue other agents in this task batch have also hit — unrelated to this change). Initializing them was attempted but did not complete in a bounded window, so no local `cargo test` run could be executed. Changes were reviewed manually line-by-line against the existing `DatumType`/`SemanticClass` API (`b00t-cli/src/datum_types.rs`) for type/lifetime correctness.

## Test plan
- [ ] CI / a submodule-clean environment: `cargo test -p b00t-cli --lib viz::tests::datum_graph_emits_mermaid_and_scene` — new assertion added (TDD) that the mermaid label embeds the lowercase `type_prefix()` token instead of the PascalCase Debug string.
- [ ] `cargo test -p b00t-admin --lib graph_json::semantic_style_tests` — new unit tests covering: known Agent token, known Infra/K8s token, missing-type placeholder (`"?"`), and label with no type suffix.
- [ ] Manual: hit `GET /api/admin/viz/entangle/json` against a running `b00t-admin` and confirm nodes carry `shape`/`color`/`semantic_class` and the response has a non-empty `legend`.
- [ ] `cargo build --workspace` succeeds with `b00t-isometric-wasm` now a member (needs submodule-clean environment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)