### PR TITLE
feat(datum): add canonical rotz repo datum

### DIFF
--- a/_b00t_/rotz.repo.toml
+++ b/_b00t_/rotz.repo.toml
@@ -1,0 +1,30 @@
+# b00t rotz Repository Datum
+#
+# rotz (github:volllly/rotz) — fully cross-platform dotfile manager and dev
+# environment bootstrapper, written in Rust. Links dotfiles from a repo to
+# the local system and drives per-machine application install via YAML/TOML/
+# JSON config. Install via `cargo install rotz`, Homebrew (volllly/tap/rotz),
+# or Scoop (volllly/rotz).
+
+[b00t]
+name = "rotz"
+type = "repo"
+status = "reference"
+hint = "rotz — cross-platform dotfile manager & dev environment bootstrapper (Rust). Links dotfiles + drives per-machine install via rotz.yaml. cargo install rotz."
+url = "https://github.com/volllly/rotz"
+
+[[b00t.references]]
+name = "rotz GitHub"
+url = "https://github.com/volllly/rotz"
+description = "Source repo, README, releases, and issue tracker for rotz."
+
+[[b00t.references]]
+name = "rotz crates.io"
+url = "https://crates.io/crates/rotz"
+description = "cargo install rotz — Rust crate registry entry."
+
+# b00t:map v1
+# summary: rotz repo datum — cross-platform Rust dotfile manager/bootstrapper, canonical reference link
+# tags: rotz, dotfiles, bootstrap, rust, volllly
+# tier: sm0l
+# complexity: 1


### PR DESCRIPTION
Closes #758

Adds `_b00t_/rotz.repo.toml` — a canonical datum for [volllly/rotz](https://github.com/volllly/rotz), a cross-platform dotfile manager and dev environment bootstrapper written in Rust. Includes `[[b00t.references]]` entries for the GitHub source and crates.io package, per the issue spec.

## Test plan
- [x] Confirmed no prior `rotz` datum existed (`grep -ril rotz _b00t_/*.toml` empty)
- [x] Confirmed no duplicate open/closed issue mentions `rotz` (`gh issue list --search rotz`)
- [x] Verified project identity via README (Rust, cross-platform dotfile manager, `cargo install rotz`)
- [x] `b00t-cli datum validate --strict _b00t_/rotz.repo.toml` → `ok (1 warning(s))` — the lone warning (`unknown field: b00t.references`) is pre-existing/systemic, reproduced identically on `podman.cli.toml` and other shipped datums using the same `[[b00t.references]]` convention
- [ ] Maintainer review of `type = "repo"` vs `type = "cli"` classification (issue explicitly specified `.repo.toml`; existing `.repo.toml` precedent (`kubic.repo.toml`) is for package/apt repos rather than tool-source repos — flagging for confirmation)