### PR TITLE
feat: add huggingface-storage config datum for rustfs S3 endpoint (#759)

### DIFF
--- a/_b00t_/huggingface-storage.config.toml
+++ b/_b00t_/huggingface-storage.config.toml
@@ -1,0 +1,56 @@
+[b00t]
+name = "huggingface-storage"
+type = "config"
+hint = "HuggingFace Storage Buckets exposed as an S3-compatible gateway — usable as a rustfs S3 backend"
+
+lfmf_category = "rustfs"
+
+[[b00t.usage]]
+description = "List buckets in your HF Storage namespace (AWS CLI, path-style addressing required)"
+command = "aws --endpoint-url https://s3.hf.co/$HF_STORAGE_NAMESPACE --region us-east-1 s3 ls"
+
+[[b00t.usage]]
+description = "Upload an object to an HF Storage bucket"
+command = "aws --endpoint-url https://s3.hf.co/$HF_STORAGE_NAMESPACE --region us-east-1 s3 cp ./model.safetensors s3://my-bucket/models/model.safetensors"
+
+[[b00t.usage]]
+description = "Point rustfs-mcp at HF Storage as its S3 backend (see rustfs-mcp.mcp.toml)"
+command = "RUSTFS_S3_ENDPOINT=https://s3.hf.co/$HF_STORAGE_NAMESPACE RUSTFS_S3_REGION=us-east-1 RUSTFS_S3_ADDRESSING_STYLE=path RUSTFS_S3_ACCESS_KEY=$HF_STORAGE_ACCESS_KEY_ID RUSTFS_S3_SECRET_KEY=$HF_STORAGE_SECRET_ACCESS_KEY cargo run --package rustfs-mcp -- mcp-server"
+
+[[b00t.references]]
+name = "HuggingFace Storage Buckets (product overview)"
+url = "https://huggingface.co/storage"
+
+[[b00t.references]]
+name = "HuggingFace Storage S3 Compatibility (endpoint, credentials, limitations)"
+url = "https://huggingface.co/docs/hub/en/storage-buckets-s3"
+
+[[b00t.references]]
+name = "RustFS MCP datum (S3-compatible consumer this endpoint targets)"
+url = "https://github.com/rustfs/rustfs"
+
+[env]
+# S3-compatible gateway credentials — NOT the same HF_TOKEN used by huggingface.ai.toml
+# for Inference API calls. Generate via https://huggingface.co/settings/tokens ->
+# token row dropdown -> "Generate S3 credentials". Access key ID is prefixed "HFAK...".
+# The token's own permission (Read/Write) becomes the S3 credential's permission.
+HF_STORAGE_NAMESPACE = ""
+HF_STORAGE_ACCESS_KEY_ID = ""
+HF_STORAGE_SECRET_ACCESS_KEY = ""
+
+# 🤓 tribal knowledge (verified against docs.huggingface.co/hub/storage-buckets-s3, 2026-08-09):
+# - Gateway is single-region (us-east-1) and namespace-scoped:
+#   https://s3.hf.co/<namespace> (namespace = your username or org). The bucket name
+#   passed to the S3 client is the bare HF bucket name, NOT "namespace/bucket" — most
+#   S3 SDKs reject "/" in a bucket name.
+# - MUST use path-style addressing (s3.addressing_style=path / force_path_style=true);
+#   virtual-hosted style (bucket.s3.hf.co) is not served by the gateway.
+# - Set request_checksum_calculation=when_required and
+#   response_checksum_validation=when_required — AWS CLI >=2.23 / recent boto3 send
+#   trailing CRC32 checksums by default that the gateway does not parse.
+# - ListObjectsV1 unsupported (ListObjectsV2 only). No ACLs, bucket policies, object
+#   tagging, versioning, SSE, or bucket notifications. Cross-namespace CopyObject /
+#   UploadPartCopy unsupported — server-side copy works only within one namespace.
+# - GetObject typically 302-redirects to the nearest HF CDN edge; aws-cli/botocore/
+#   aws-sdk-rust are proxied transparently, other clients (rclone, s5cmd, curl) must
+#   follow the redirect themselves.

--- a/_b00t_/rustfs-mcp.mcp.toml
+++ b/_b00t_/rustfs-mcp.mcp.toml
@@ -41,6 +41,13 @@ url = "https://modelcontextprotocol.io"
 name = "S3 Compatible Storage"
 url = "https://aws.amazon.com/s3/"
 
+# HuggingFace Storage Buckets are a supported S3-compatible backend for this
+# server — see huggingface-storage.config.toml for endpoint, credential, and
+# limitation details (path-style addressing, single-region, namespace-scoped).
+[[b00t.references]]
+name = "HuggingFace Storage as an S3 backend (see huggingface-storage.config.toml)"
+url = "https://huggingface.co/docs/hub/en/storage-buckets-s3"
+
 [env]
 RUSTFS_MCP_PORT = "8080"
 RUSTFS_MCP_HOST = "127.0.0.1"


### PR DESCRIPTION
Closes #759

## Summary
- Adds `_b00t_/huggingface-storage.config.toml` — a b00t `config`-type datum documenting HuggingFace Storage Buckets' S3-compatible gateway (`https://s3.hf.co/<namespace>`) so it can be used as an S3 backend for `rustfs`/`rustfs-mcp`.
- Content (endpoint URL, required env vars, path-style addressing requirement, single-region/ListObjectsV2-only/no-ACL limitations) verified against the current HuggingFace docs at https://huggingface.co/docs/hub/en/storage-buckets-s3 rather than assumed — the gateway credentials (`HF_STORAGE_ACCESS_KEY_ID`/`HF_STORAGE_SECRET_ACCESS_KEY`, prefix `HFAK...`) are distinct from the `HF_TOKEN` used elsewhere for HF Inference API calls (`huggingface.ai.toml`), which the issue's original wording conflated.
- Cross-referenced from `_b00t_/rustfs-mcp.mcp.toml` per the issue's "optionally update" ask.

## Scoping note
Issue #759 asked for `.endpoint.toml` (or `.config.toml`) — `endpoint` is not a registered `DatumType` in `b00t-cli/src/datum_types.rs`, so this uses the valid `.config.toml` (`Config`) suffix as the issue itself allowed. Scope is a documentation/config datum only (endpoint + env + usage + limitations), not a code-level rustfs S3-driver implementation — no such driver code exists in this repo to extend, and the issue's own requirement list is datum-shaped, not code-shaped.

## Test plan
- [x] `python3 -c "import tomllib; tomllib.load(open('_b00t_/huggingface-storage.config.toml','rb'))"` — valid TOML (PASS)
- [ ] `just datum-validate-graph` — blocked in this environment by pre-existing uninitialized vendor submodules cascading through the cargo workspace (`vendor/ledgrrr`, `vendor/runpod-sdk`, `vendor/embed-anything-b00t`, ... — same category as the known `vendor/linkml-b00t` issue). Verification pending a clean/fully-initialized checkout.