### PR TITLE
feat(datum): create canonical datum for telnyx external agent skills (#757)

### DIFF
--- a/_b00t_/telnyx-external-agent-skills.api.toml
+++ b/_b00t_/telnyx-external-agent-skills.api.toml
@@ -1,0 +1,17 @@
+[b00t]
+name = "telnyx-external-agent-skills"
+type = "api"
+hint = "Telnyx External Agent Skills — 175 publicly available skills teaching AI coding assistants (Claude Code, Cursor, Windsurf, etc.) to correctly use Telnyx SDKs. Covers 35 Telnyx products across 5 languages (Python, Node.js/JavaScript, Go, Java, Ruby), generated from Telnyx's OpenAPI spec so agents get accurate SDK usage without web search/guesswork."
+keywords = ["telnyx", "agent-skills", "release-notes", "sdk", "ai-coding-assistant"]
+
+[[b00t.references]]
+name = "Telnyx External Agent Skills — release notes"
+url = "https://telnyx.com/release-notes/telnyx-external-agent-skills"
+description = "Announcement (2026-02-06, verified via WebFetch 2026-08-09): 175 skills across 35 Telnyx products in 5 SDK languages, for AI coding assistants to generate accurate Telnyx integrations."
+
+# b00t:map v1
+# summary: Telnyx External Agent Skills — canonical reference datum for Telnyx's AI-coding-assistant SDK skill pack (issue #757)
+# tags: telnyx, agent-skills, release-notes, sdk, api
+# tier: sm0l
+# cmds: b00t-cli datum show telnyx-external-agent-skills.api
+# complexity: 1


### PR DESCRIPTION
Closes #757

## Summary
- Adds `_b00t_/telnyx-external-agent-skills.api.toml`, a canonical b00t datum for Telnyx's "External Agent Skills" feature: 175 skills teaching AI coding assistants (Claude Code, Cursor, Windsurf, etc.) correct usage of Telnyx SDKs across 35 products and 5 languages, generated from Telnyx's OpenAPI spec. Content verified via WebFetch of https://telnyx.com/release-notes/telnyx-external-agent-skills (release date 2026-02-06, fetched 2026-08-09).
- **Deviation from issue's literal spec, following actual repo conventions**: the issue requested `.article.toml` / `[references]` / `type="article"`. `DatumType` (`b00t-cli/src/datum_types.rs`) has no `Article` variant, and no `.article.toml` file or `[references]` (singular, top-level) convention exists anywhere in `_b00t_/`. Instead used `type = "api"` (a real, registered `DatumType`, matching Telnyx being fundamentally an API/SDK platform, and validating cleanly under `--strict`) plus `[[b00t.references]]` — the actual established convention for embedding source URLs, seen in e.g. `_b00t_/sshuttle.cli.toml`.
- No pre-existing telnyx datum found (`grep -ril telnyx _b00t_/` → no hits before this change).

## Test plan
- [x] `b00t-cli -p <worktree>/_b00t_ datum validate telnyx-external-agent-skills.api.toml --strict` → `ok (1 warning(s))`, exit 0. The one warning (`unknown field: b00t.references`) is expected/pre-existing behavior — `references` isn't in `KNOWN_B00T_KEYS` even though the same pattern is used unflagged elsewhere (e.g. sshuttle.cli.toml); not a blocker.
- [ ] Maintainer confirms `type = "api"` classification (vs. `skill`/`reference`) is the desired fit for this datum.

🤖 Generated with [Claude Code](https://claude.com/claude-code)