### PR TITLE
feat(datum): add canonical repo datum for SysMD

### DIFF
--- a/_b00t_/sysmd.repo.toml
+++ b/_b00t_/sysmd.repo.toml
@@ -1,0 +1,34 @@
+[b00t]
+name = "sysmd"
+type = "repo"
+hint = "SysMD — executable SysML v2 / KerML models with integrated constraint solving (SAT/SMT-like consistency checks + auto-compute missing values)"
+url = "https://github.com/tukcps/SysMD"
+type_tags = ["sysml", "kerml", "executable-models", "constraint-solving", "sat", "smt"]
+
+# References and links
+[b00t.references]
+sysmd = "https://github.com/tukcps/SysMD"
+sysml_v2 = "https://www.omg.org/spec/SysML/2.0/"
+kerml = "https://www.omg.org/spec/KerML/1.0/"
+
+[[b00t.references.documentation]]
+name = "SysMD"
+url = "https://github.com/tukcps/SysMD"
+description = "Executable SysML v2 models integrated with an SAT/SMT-like constraint solver: verifies model consistency and auto-computes missing values from requirements, constraints, and calculations."
+
+[[b00t.references.documentation]]
+name = "SysML v2 Specification (OMG)"
+url = "https://www.omg.org/spec/SysML/2.0/"
+description = "Systems Modeling Language v2 standard that SysMD targets."
+
+[[b00t.references.documentation]]
+name = "KerML Specification (OMG)"
+url = "https://www.omg.org/spec/KerML/1.0/"
+description = "Kernel Modeling Language — the metamodel SysMD translates model cells into, underlying SysML v2."
+
+# b00t:map v1
+# summary: SysMD — executable SysML v2/KerML systems models with an integrated SAT/SMT-like constraint solver; verifies consistency and computes missing values.
+# tags: sysml, kerml, executable-models, constraint-solving, sat, smt
+# tier: frontier
+# cmds: b00t-cli datum validate --strict _b00t_/sysmd.repo.toml
+# complexity: 4


### PR DESCRIPTION
Closes #764

Adds `_b00t_/sysmd.repo.toml`, a canonical `repo`-type datum for [SysMD](https://github.com/tukcps/SysMD) (tukcps/SysMD, Apache-2.0) — an executable SysML v2 / KerML modeling tool with an integrated SAT/SMT-like constraint solver that verifies model consistency and auto-computes missing values.

- `type = "repo"`, `url` set to the GitHub repo
- `[b00t.references]` section (following the `ralph-b00t-enhanced.toml` precedent) linking SysMD, the SysML v2 spec, and the KerML spec
- `type_tags`: sysml, kerml, executable-models, constraint-solving, sat, smt

## Verification
```
$ b00t-cli datum validate --strict _b00t_/sysmd.repo.toml
==> _b00t_/sysmd.repo.toml
  WARN: unknown field: b00t.references (not in BootDatum schema)
ok (1 warning(s))
EXIT: 0
```
The `b00t.references` WARN is pre-existing/tolerated — the same warning fires on `ralph-b00t-enhanced.toml`, which already uses this section shape; no `repo`-type datum in the tree currently has a `[references]` block to follow more strictly, and BootDatum has no `references` field in its schema today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)