### PR TITLE
feat(datum): add canonical repo datum for MuJoCo

### DIFF
--- a/_b00t_/mujoco.repo.toml
+++ b/_b00t_/mujoco.repo.toml
@@ -1,0 +1,26 @@
+[b00t]
+name = "mujoco"
+type = "repo"
+status = "active"
+hint = "MuJoCo (Multi-Joint dynamics with Contact) — Google DeepMind's physics simulation engine for robotics, biomechanics, graphics/animation, and other domains requiring fast, accurate rigid/soft-body dynamics with contact. C/C++ core with official Python bindings; MJX provides a JAX reimplementation for hardware-accelerated, differentiable, massively parallel simulation."
+url = "https://github.com/google-deepmind/mujoco"
+keywords = ["physics", "simulation", "robotics", "deepmind", "mujoco"]
+
+[[b00t.usage]]
+description = "Install Python bindings"
+command = "uv pip install mujoco"
+
+[[b00t.usage]]
+description = "Verify install and print version"
+command = "python -c 'import mujoco; print(mujoco.__version__)'"
+
+[[b00t.usage]]
+description = "Launch the interactive MuJoCo viewer on a model"
+command = "python -m mujoco.viewer --mjcf=/path/to/model.xml"
+
+# b00t:map v1
+# summary: MuJoCo — DeepMind physics simulation engine (rigid/soft-body dynamics, contact); Python + MJX/JAX bindings
+# tags: physics, simulation, robotics, deepmind, mujoco
+# tier: sm0l
+# cmds: uv pip install mujoco, python -m mujoco.viewer
+# complexity: 2


### PR DESCRIPTION
Closes #767

## Summary
- Adds `_b00t_/mujoco.repo.toml` — canonical datum for MuJoCo (Google DeepMind's physics simulation engine for robotics, biomechanics, and control).
- Fields: `hint`, `url` (GitHub), `keywords`, plus three `[[b00t.usage]]` examples (pip install, version check, viewer launch).
- Deliberately uses the canonical `url` field (not an ad-hoc `[references]` table) — `url` is the schema field BootDatum actually deserializes for source-control metadata; an unstructured `[[b00t.references]]` table (seen in a couple of existing `.cli.toml` datums) isn't in `KNOWN_B00T_KEYS` and produces `datum validate --strict` warnings. This keeps the new datum warning-free.

## Verification
```
$ b00t-cli --path <worktree>/_b00t_ datum validate --strict mujoco.repo.toml
valid — no issues found
```
(exit 0; the accompanying `warn: evidence line 11: trailing characters` lines are pre-existing, unrelated evidence-log noise — reproduced identically against an existing datum, `hf.cli.toml`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)