### PR TITLE
feat(datum): add canonical repo datum for awesome-android-agent-skills

### DIFF
--- a/_b00t_/awesome-android-agent-skills.repo.toml
+++ b/_b00t_/awesome-android-agent-skills.repo.toml
@@ -1,0 +1,30 @@
+# b00t Repo Datum — awesome-android-agent-skills (curated Android agent-skills catalog)
+# 🤓 Standardized "Agent Skills" that teach GitHub Copilot, Claude, Gemini, and Cursor
+#    modern Android development conventions (Kotlin, Jetpack Compose, etc.).
+# 🤓 Reference-only: not vendored, no build/install steps — this datum exists so the hive
+#    can discover and cite the catalog when researching Android agent-skill conventions.
+
+[b00t]
+name = "awesome-android-agent-skills"
+type = "repo"
+hint = "Curated collection of standardized Agent Skills for modern Android development (Kotlin, Jetpack Compose) across Copilot, Claude, Gemini, Cursor (github.com/new-silvermoon/awesome-android-agent-skills)"
+
+[b00t.source]
+url = "https://github.com/new-silvermoon/awesome-android-agent-skills"
+
+[b00t.repo]
+description = "A collection of standardized Agent Skills to teach GitHub Copilot, Claude, Gemini and Cursor about modern Android development (Kotlin, Jetpack Compose, etc.)."
+license = "Apache-2.0"
+topics = ["android", "agent-skills", "awesome-list", "mobile-automation"]
+# ⚠️ verify: star/fork counts drift over time; last checked 2026-08-09 via GitHub API (915★ / 88 forks, Apache-2.0, not archived)
+
+[[b00t.references]]
+name = "awesome-android-agent-skills (GitHub)"
+url = "https://github.com/new-silvermoon/awesome-android-agent-skills"
+
+# b00t:map v1
+# summary: Curated catalog of standardized Android Agent Skills (external awesome-list); reference-only, not vendored
+# tags: android, agent-skills, awesome-list, mobile-automation, catalog
+# tier: sm0l
+# cmds: b00t-cli datum show awesome-android-agent-skills.repo
+# complexity: 1


### PR DESCRIPTION
Closes #771

## Summary
- Creates `_b00t_/awesome-android-agent-skills.repo.toml`, a reference-only repo datum for the [awesome-android-agent-skills](https://github.com/new-silvermoon/awesome-android-agent-skills) catalog (standardized Agent Skills teaching Copilot/Claude/Gemini/Cursor modern Android dev — Kotlin, Jetpack Compose).
- Follows the `awesome-openclaw-usecases.repo.toml` (#753) precedent shape: `[b00t]`, `[b00t.source]`, `[b00t.repo]` with license/topics, `[[b00t.references]]`, and a `b00t:map v1` tail.
- Verified upstream repo via GitHub API: 915★, 88 forks, Apache-2.0, not archived, active (pushed 2026-07-27).

## Validation
```
$ b00t-cli datum validate --strict _b00t_/awesome-android-agent-skills.repo.toml
==> .../awesome-android-agent-skills.repo.toml
  WARN: unknown field: b00t.references (not in BootDatum schema)
  WARN: unknown field: b00t.repo (not in BootDatum schema)
  WARN: unknown field: b00t.source (not in BootDatum schema)
ok (3 warning(s))
```
These warnings are the known, pre-existing benign strict-mode warnings that `[[b00t.references]]`/`b00t.repo`/`b00t.source` produce on many existing datums (see #753 precedent) — not introduced by this change.

## Test plan
- [x] `b00t-cli datum validate --strict` passes (ok, only known benign warnings)
- [x] Confirmed no pre-existing datum for this project via `grep -ril android-agent-skills _b00t_/` and `grep -rliE "android.*skills"` (no hits)
- [x] Confirmed upstream repo is real/active via `gh api repos/new-silvermoon/awesome-android-agent-skills`