### PR TITLE
browser-plugin: selector-forge propose-verify-settle loop (#770)

### DIFF
--- a/_b00t_/browser-plugin/README.md
+++ b/_b00t_/browser-plugin/README.md
@@ -143,11 +143,31 @@ window.__b00t.enrichAll()
 browser-plugin/
 ├── manifest.json       # Chrome extension v3 manifest
 ├── content.js          # DOM Enrichment Engine (injected into every page)
+├── selector-forge.js   # propose→verify→settle selector resolution (see below)
+├── selector-forge.test.js # node --test unit tests for selector-forge.js
 ├── b00t-client.js      # CDP bridge + RPA command definitions
 ├── panel.html          # Side panel UI (dark terminal theme)
 ├── panel.js            # Panel UI logic (search, filter, script curation)
 ├── icon.png            # Generated green dot icon
 └── README.md           # This file
+```
+
+### 5. Selector Resolution (`selector-forge.js`)
+Deterministic "propose → verify → settle" selector resolution, adapted from
+[Intuned/selector-forge](https://github.com/Intuned/selector-forge)'s trust
+boundary (see `_b00t_/datums/VENDOR-SELECTOR-FORGE.tomllmd`): candidates are
+ranked by a stability heuristic (`#id` > `[data-b00t-*]` > `[name]` > class
+> nth-child) and each is re-verified against the live DOM — the browser
+decides, not a ranking score — before one is returned. No AI/network call;
+this is the local, offline re-verification loop the datum's integration
+point #2 describes, reused as a building block b00t's own automation
+pipeline can call. Exposed as the `resolve_selector <type> <label>` command
+in the side panel, routed via `chrome.tabs.sendMessage` to a bridge in
+`content.js` (CDP `Runtime.evaluate` only reaches the MAIN world, and this
+logic lives in the isolated content-script world alongside `document`).
+Unit-tested with Node's built-in test runner:
+```bash
+node --test selector-forge.test.js
 ```
 
 ## Roadmap
@@ -157,6 +177,7 @@ browser-plugin/
 - [x] Side panel with command palette + script curation
 - [x] Visible + full-page screenshot capture
 - [x] MutationObserver for SPA compatibility
+- [x] selector-forge propose→verify→settle resolution loop (issue #770 — local/offline; AI-backed ranking and MCP exposure still open)
 - [ ] monty WASM MObject integration for animation
 - [ ] Blender-MCP bridge for 3D visualization
 - [ ] Record/replay: capture user interactions as b00t scripts

--- a/_b00t_/browser-plugin/b00t-client.js
+++ b/_b00t_/browser-plugin/b00t-client.js
@@ -60,6 +60,9 @@ const B00T_CLIENT = {
     { action: 'list_enriched', args: '<type_filter>', desc: 'List enriched elements (filter by type)',
       eval: (type) => `JSON.stringify(window.__b00t?.findB00t(${type ? `'${type}'` : ''}) || [])` },
 
+    { action: 'resolve_selector', args: '<type> <label>',
+      desc: 'selector-forge propose→verify→settle: rank candidates, return the first that re-verifies' },
+
     { action: 'enrich_counts', args: '', desc: 'Count enriched elements by type',
       eval: () => {
         const counts = {};
@@ -146,6 +149,19 @@ const B00T_CLIENT = {
       return new Promise((resolve) => {
         chrome.tabs.update(this.tabId, { url: args[0] }, resolve);
       }).then(() => 'navigating...');
+    }
+    if (cmd.action === 'resolve_selector') {
+      // Routed via chrome.tabs.sendMessage (not CDP Runtime.evaluate, which
+      // only reaches the MAIN world) to content.js's isolated-world bridge,
+      // which calls the tested selector-forge.js module directly.
+      const [type, label] = args;
+      return new Promise((resolve) => {
+        chrome.tabs.sendMessage(
+          this.tabId,
+          { action: 'b00t_resolve_selector', type, label },
+          (result) => resolve(JSON.stringify(result ?? null))
+        );
+      });
     }
     const js = typeof cmd.eval === 'function' ? cmd.eval(...args) : cmd.eval;
     return await this.evaluate(js);

--- a/_b00t_/browser-plugin/content.js
+++ b/_b00t_/browser-plugin/content.js
@@ -115,4 +115,35 @@
   `;
   document.documentElement.appendChild(script);
   script.remove();
+
+  // Bridge for selector-forge resolve requests from the side panel
+  // (b00t-client.js). Handled here, in the isolated content-script world,
+  // rather than the MAIN-world injection above, so the tested logic in
+  // selector-forge.js (loaded before this file — see manifest.json) stays
+  // the single source of truth instead of being duplicated into the
+  // injected script string, which CDP Runtime.evaluate cannot reach it
+  // from anyway. See _b00t_/datums/VENDOR-SELECTOR-FORGE.tomllmd.
+  if (typeof chrome !== 'undefined' && chrome.runtime && chrome.runtime.onMessage) {
+    chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
+      if (!msg || msg.action !== 'b00t_resolve_selector') return;
+      const el = document.querySelector(
+        '[data-b00t-type="' + msg.type + '"][data-b00t-label="' + msg.label + '"]'
+      );
+      if (!el) { sendResponse(null); return; }
+      const desc = {
+        id: el.id || '',
+        tagName: el.tagName.toLowerCase(),
+        dataB00tType: el.dataset.b00tType,
+        dataB00tLabel: el.dataset.b00tLabel,
+        dataB00tName: el.dataset.b00tName,
+        name: el.getAttribute('name') || '',
+        classList: Array.from(el.classList || []),
+      };
+      const verify = (sel) => {
+        try { return document.querySelectorAll(sel).length; } catch (e) { return 0; }
+      };
+      sendResponse(window.__b00tSelectorForge.resolveSelector(desc, verify));
+      return true; // keep the message channel open (sendResponse called sync above, but harmless)
+    });
+  }
 })();

--- a/_b00t_/browser-plugin/manifest.json
+++ b/_b00t_/browser-plugin/manifest.json
@@ -25,11 +25,11 @@
   },
   "content_scripts": [{
     "matches": ["<all_urls>"],
-    "js": ["content.js"],
+    "js": ["selector-forge.js", "content.js"],
     "run_at": "document_end"
   }],
   "web_accessible_resources": [{
-    "resources": ["panel.html", "panel.js", "b00t-client.js"],
+    "resources": ["panel.html", "panel.js", "b00t-client.js", "selector-forge.js"],
     "matches": ["<all_urls>"]
   }]
 }

--- a/_b00t_/browser-plugin/selector-forge.js
+++ b/_b00t_/browser-plugin/selector-forge.js
@@ -1,0 +1,80 @@
+// b00t Selector Forge — deterministic "propose -> verify -> settle" selector
+// resolution, adapted from Intuned/selector-forge's trust boundary:
+//   "extension holds session state; browser is source of truth (re-verifies
+//    every candidate); AI proposes/ranks but doesn't prove correctness."
+// (see _b00t_/datums/VENDOR-SELECTOR-FORGE.tomllmd, integration point #2)
+//
+// This module has no AI/network dependency by design — it ranks candidates
+// with a stability heuristic (id > [data-b00t-*] > name > class > nth-child,
+// matching b00t's own enrichment story: [data-b00t-*] attrs are stable
+// across redesigns where CSS classes are not) and re-verifies each against
+// a caller-supplied `verify(selector) -> matchCount` before settling. In the
+// browser that verify function is `document.querySelectorAll(sel).length`;
+// in tests it's a plain lookup table (see selector-forge.test.js). This
+// split keeps the ranking/settling logic pure and unit-testable under
+// Node's built-in test runner without a real DOM or jsdom dependency.
+(function (root, factory) {
+  if (typeof module === 'object' && module.exports) {
+    module.exports = factory();
+  } else {
+    root.__b00tSelectorForge = factory();
+  }
+}(typeof self !== 'undefined' ? self : this, function () {
+  'use strict';
+
+  function esc(s) {
+    return String(s).replace(/(["\\])/g, '\\$1');
+  }
+
+  // Build ranked selector candidates for a plain element descriptor.
+  // Descriptor fields are all optional; absent ones are skipped silently.
+  function buildCandidates(desc) {
+    desc = desc || {};
+    const candidates = [];
+
+    if (desc.id) {
+      candidates.push('#' + desc.id);
+    }
+    if (desc.dataB00tType && desc.dataB00tLabel) {
+      candidates.push(
+        '[data-b00t-type="' + esc(desc.dataB00tType) + '"][data-b00t-label="' + esc(desc.dataB00tLabel) + '"]'
+      );
+    }
+    if (desc.dataB00tType && desc.dataB00tName) {
+      candidates.push(
+        '[data-b00t-type="' + esc(desc.dataB00tType) + '"][data-b00t-name="' + esc(desc.dataB00tName) + '"]'
+      );
+    }
+    if (desc.name) {
+      candidates.push((desc.tagName || '') + '[name="' + esc(desc.name) + '"]');
+    }
+    if (desc.classList && desc.classList.length) {
+      candidates.push((desc.tagName || '') + '.' + desc.classList.map(esc).join('.'));
+    }
+    if (desc.nthChildSelector) {
+      candidates.push(desc.nthChildSelector);
+    }
+    return candidates;
+  }
+
+  // propose -> test against live DOM -> settle. `verify(selector)` must
+  // return the number of elements the selector currently matches; a
+  // candidate is accepted the moment it uniquely resolves (count === 1).
+  // If none are unique, the lowest-ranked (least stable) candidate is
+  // returned as a best-effort fallback with `verified: false` so callers
+  // can decide whether to trust it.
+  function resolveSelector(desc, verify) {
+    const candidates = buildCandidates(desc);
+    if (candidates.length === 0) {
+      return { selector: null, verified: false, candidates: [] };
+    }
+    for (const candidate of candidates) {
+      if (verify(candidate) === 1) {
+        return { selector: candidate, verified: true, candidates };
+      }
+    }
+    return { selector: candidates[candidates.length - 1], verified: false, candidates };
+  }
+
+  return { buildCandidates, resolveSelector };
+}));

--- a/_b00t_/browser-plugin/selector-forge.test.js
+++ b/_b00t_/browser-plugin/selector-forge.test.js
@@ -1,0 +1,64 @@
+// Tests for selector-forge.js — the propose -> verify -> settle candidate
+// resolution pattern borrowed from Intuned/selector-forge (see
+// _b00t_/datums/VENDOR-SELECTOR-FORGE.tomllmd), reimplemented locally without
+// an AI backend: candidates are ranked by stability heuristics, then
+// re-verified against a live-DOM stand-in before one is chosen. Runs under
+// Node's built-in test runner: `node --test selector-forge.test.js`.
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { buildCandidates, resolveSelector } = require('./selector-forge.js');
+
+test('buildCandidates ranks id above data-b00t attrs above class/nth-child', () => {
+  const desc = {
+    id: 'email-input',
+    tagName: 'input',
+    dataB00tType: 'input',
+    dataB00tLabel: 'Email',
+    dataB00tName: 'email',
+    name: 'email',
+    classList: ['form-control', 'v2'],
+    nthChildSelector: 'form > div:nth-child(3) > input',
+  };
+  const candidates = buildCandidates(desc);
+  assert.equal(candidates[0], '#email-input');
+  assert.ok(candidates.includes('[data-b00t-type="input"][data-b00t-label="Email"]'));
+  assert.equal(candidates[candidates.length - 1], desc.nthChildSelector);
+});
+
+test('buildCandidates skips absent fields without throwing', () => {
+  const candidates = buildCandidates({ tagName: 'button' });
+  assert.deepEqual(candidates, []);
+});
+
+test('resolveSelector settles on the first candidate that uniquely re-verifies', () => {
+  const desc = {
+    id: 'dup-id', // pretend two elements share this id (invalid HTML but happens)
+    dataB00tType: 'button',
+    dataB00tLabel: 'Submit',
+  };
+  // Fake DOM: '#dup-id' matches 2 elements (not unique), the data-b00t
+  // candidate matches exactly 1 (the real element) -> re-verification wins.
+  const fakeCounts = {
+    '#dup-id': 2,
+    '[data-b00t-type="button"][data-b00t-label="Submit"]': 1,
+  };
+  const verify = (sel) => fakeCounts[sel] ?? 0;
+  const result = resolveSelector(desc, verify);
+  assert.equal(result.selector, '[data-b00t-type="button"][data-b00t-label="Submit"]');
+  assert.equal(result.verified, true);
+});
+
+test('resolveSelector falls back to the last candidate when none are unique, flagged unverified', () => {
+  const desc = { id: 'ambiguous' };
+  const verify = () => 3; // every candidate matches multiple elements
+  const result = resolveSelector(desc, verify);
+  assert.equal(result.selector, '#ambiguous');
+  assert.equal(result.verified, false);
+});
+
+test('resolveSelector returns null selector when there are no candidates', () => {
+  const result = resolveSelector({}, () => 0);
+  assert.equal(result.selector, null);
+  assert.equal(result.verified, false);
+});


### PR DESCRIPTION
Closes #770

## What this does
Implements Integration Point #2 from #770 — "Reuse selector-forge's re-verification loop (propose → test against live DOM → settle) in b00t's automation pipeline" — as a small, tested, offline building block in `_b00t_/browser-plugin/`:

- `selector-forge.js` — pure candidate ranking (`#id` > `[data-b00t-*]` > `[name]` > class > nth-child) + re-verification loop, settling on the first candidate that uniquely matches the live DOM. Dual CommonJS/browser-global module, unit-testable under Node's built-in test runner without jsdom.
- `selector-forge.test.js` — 5 tests, written first (TDD), all passing: `node --test selector-forge.test.js`.
- `content.js` — isolated-world `chrome.runtime.onMessage` bridge calling the module against the real DOM.
- `b00t-client.js` — new `resolve_selector <type> <label>` command, routed via `chrome.tabs.sendMessage` (CDP `Runtime.evaluate` only reaches the MAIN world, where this logic doesn't live, to avoid duplicating it there).
- `manifest.json` — loads `selector-forge.js` as a content script.
- `README.md` — documents the new file and command.

## Why scoped this way
The issue's literal "Requirement" line ("Create a datum for selector-forge and document the integration plan") is already satisfied on `main` by `_b00t_/datums/VENDOR-SELECTOR-FORGE.tomllmd` (commit `9d933e7d`). The broader "Integration Points" (embedding Selector Forge's actual AI backend, MCP exposure) aren't scoped here: Selector Forge ships only as a packaged Chrome/Firefox extension, not an installable library or API, so there's nothing to add as a dependency. This PR is the first slice of real code integration on top of the existing datum's plan — the re-verification *pattern*, reimplemented locally and deterministically (no AI/network call), reusable as a pipeline building block. AI-backed ranking and MCP exposure remain open follow-ups.

## Test plan
- [x] `node --test selector-forge.test.js` — 5/5 passing
- [x] `node --check` on all touched `.js` files — no syntax errors
- [x] `manifest.json` validated as JSON
- [ ] Manual smoke test loading the unpacked extension in Chrome (not done — no Chrome available in this environment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)