### PR TITLE
feat(datum): add canonical browser-harness datum

### DIFF
--- a/_b00t_/browser-harness.repo.toml
+++ b/_b00t_/browser-harness.repo.toml
@@ -1,0 +1,27 @@
+# b00t browser-harness Repo Datum — self-healing LLM browser automation
+# 🤓 Companion project to browser-use, entangled via entangled_mcp on
+#    browser-use.mcp — browser-harness wraps browser-use to add self-healing
+#    task completion (LLM retries/repairs failed browser steps automatically).
+
+[b00t]
+name = "browser-harness"
+type = "repo"
+hint = "Self-healing browser automation harness for LLM agents — companion to browser-use"
+url = "https://github.com/browser-use/browser-harness"
+
+entangled_mcp = ["browser-use.mcp"]
+
+[[b00t.references]]
+name = "browser-harness GitHub"
+url = "https://github.com/browser-use/browser-harness"
+
+[[b00t.references]]
+name = "browser-harness homepage"
+url = "https://browser-harness.com"
+
+# b00t:map v1
+# summary: Canonical datum for browser-harness — self-healing LLM browser automation harness, entangled with browser-use.mcp
+# tags: browser-automation, harness, testing, browser-use
+# tier: ch0nky
+# cmds: b00t-cli datum show browser-harness.repo
+# complexity: 2


### PR DESCRIPTION
Closes #784

Creates `_b00t_/browser-harness.repo.toml` for https://github.com/browser-use/browser-harness (self-healing LLM browser automation harness).

- `entangled_mcp = ["browser-use.mcp"]` — couples to the existing `browser-use.mcp.toml` datum, following the established `entangled_mcp`/`entangled_cli` convention (see `gemini-mcp-tool.mcp.toml`, `azure-ai-foundry.mcp.toml`) rather than the issue's suggested `entangled_with` (not a recognized `BootDatum` field per `b00t-cli/src/boot_datum.rs`).
- `[[b00t.references]]` embeds GitHub + homepage URLs.
- `b00t:map` tail carries the requested tags: browser-automation, harness, testing, browser-use.

## Verification
`b00t-cli datum validate --strict _b00t_/browser-harness.repo.toml` → `ok (1 warning(s))`, the only warning being the known benign `b00t.references` strict-mode warning (documented in project CLAUDE.md as pre-existing/unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)