### PR TITLE
feat: bridge Claude Code /b00t slash command into existing k0mmand3r infra (#787)

### DIFF
--- a/.claude/commands/b00t.md
+++ b/.claude/commands/b00t.md
@@ -1,0 +1,16 @@
+---
+description: Show b00t hive status — git, zellij, governance gates, cake balance, open issues
+allowed-tools: Bash(just b00t::slash-b00t:*)
+---
+
+# /b00t
+
+🥾 Bridges this repo's already-existing `just b00t::slash-b00t` recipe
+(`_b00t_/scripts/slash-b00t.sh`) into Claude Code's native slash-command
+surface, so operators get hive status without leaving chat (see issue #787).
+
+Run the recipe and report its output verbatim — do not summarize or omit
+sections (git, zellij, governance gates, cake balance, open issues, exercise
+reminder):
+
+!`just b00t::slash-b00t`

--- a/_b00t_/test/claude-code-slash-commands.bats
+++ b/_b00t_/test/claude-code-slash-commands.bats
@@ -1,0 +1,51 @@
+#!/usr/bin/env bats
+
+# claude-code-slash-commands.bats — proof-of-concept bridge from a real
+# Claude Code custom slash command into b00t (#787).
+#
+# Claude Code discovers project-level slash commands as markdown files under
+# .claude/commands/<name>.md (frontmatter + prompt body); typing "/<name>" in
+# the chat runs the file's prompt. Before this change b00t had no such file,
+# so the "/b00t slash command" referenced by _b00t_/scripts/slash-b00t.sh's
+# own header comment was unreachable from Claude Code — the recipe existed,
+# but nothing wired it to Claude Code's actual discovery mechanism.
+#
+# This test locks in the minimal PoC: a real .claude/commands/b00t.md file
+# that shells out to the already-existing, already-tested
+# `just b00t::slash-b00t` recipe.
+
+load 'test_helper/bats-support/load'
+load 'test_helper/bats-assert/load'
+
+REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+COMMAND_FILE="$REPO_ROOT/.claude/commands/b00t.md"
+
+@test "claude code command file .claude/commands/b00t.md exists" {
+    [ -f "$COMMAND_FILE" ]
+}
+
+@test "command file has YAML frontmatter with a description" {
+    run head -n 10 "$COMMAND_FILE"
+    assert_success
+    assert_line --index 0 "---"
+    assert_output --partial "description:"
+}
+
+@test "command file body invokes the real just b00t::slash-b00t recipe" {
+    run cat "$COMMAND_FILE"
+    assert_success
+    assert_output --partial "just b00t::slash-b00t"
+}
+
+@test "the recipe the command file shells out to actually exists in justfile" {
+    run just --list b00t
+    assert_success
+    assert_output --partial "slash-b00t"
+}
+
+@test "the recipe the command file shells out to runs successfully end to end" {
+    cd "$REPO_ROOT"
+    run just b00t::slash-b00t
+    assert_success
+    assert_output --partial "b00t Status"
+}


### PR DESCRIPTION
Closes #787

## What this is

Issue #787 was based on a paywalled Medium article listing 6 Claude Code slash commands, 2 of which were identified (`/ultrareview`, `/team-onboarding`) — neither is a real built-in Claude Code command; they're the article author's own custom command definitions. Rather than write documentation around invented/paywalled commands, this PR delivers the honest, minimal, real integration the issue was actually reaching for.

## What was found

b00t already has substantial, tested slash-command infrastructure:
- `k0mmand3r` crate — a full Rust "/slash" command grammar parser (packaged for Rust/wasm/python)
- `b00t-cli`'s hidden `k0mmand3r` subcommand — datum-driven slash aliases, internal command dispatch, agent-coordination verbs (`/vote`, `/delegate`, `/handshake`, `/crew`, `/status`), backed by 1190 lines of integration tests (`b00t-cli/tests/k0mmand3r_tests.rs`)
- `_b00t_/scripts/slash-b00t.sh` + `just b00t::slash-b00t` recipe, whose own header comment says "for Claude Code /b00t slash command"

What was **missing**: no `.claude/commands/*.md` file existed, so Claude Code's chat UI had no way to discover `/b00t` — the recipe was orphaned from Claude Code's actual slash-command discovery mechanism (project-level markdown files under `.claude/commands/`).

## What this PR adds

- `.claude/commands/b00t.md` — a real Claude Code custom slash command that invokes the existing `just b00t::slash-b00t` recipe. Force-added past the repo's blanket `.claude/` gitignore, mirroring the existing `.claude/agents/*.md` precedent.
- `_b00t_/test/claude-code-slash-commands.bats` — TDD'd bats coverage (written red, then green) verifying the command file exists, has valid frontmatter, references the real recipe, and that the recipe it shells out to actually runs end-to-end.

## Test plan

```
$ _b00t_/test/bats/bin/bats _b00t_/test/claude-code-slash-commands.bats
1..5
ok 1 claude code command file .claude/commands/b00t.md exists
ok 2 command file has YAML frontmatter with a description
ok 3 command file body invokes the real just b00t::slash-b00t recipe
ok 4 the recipe the command file shells out to actually exists in justfile
ok 5 the recipe the command file shells out to runs successfully end to end
```

- [x] bats suite passes locally (evidence above)
- [ ] `bats-core`/`bats-support`/`bats-assert` submodules were uninitialized in this sandbox and had to be `git submodule update --init` before the suite could run — CI should already have these initialized, but flagging in case a fresh clone needs it too

🤖 Generated with [Claude Code](https://claude.com/claude-code)