### PR TITLE
feat(datum): add grit.cli.toml for gitbutlerapp/grit

### DIFF
--- a/_b00t_/grit.cli.toml
+++ b/_b00t_/grit.cli.toml
@@ -1,0 +1,48 @@
+[b00t]
+name = "grit"
+type = "cli"
+desires = "latest"
+install = '''
+curl -fsSL https://grit-scm.com/install | sh
+'''
+update = '''
+curl -fsSL https://grit-scm.com/install | sh
+'''
+version = "grit --version"
+version_regex = '\d+\.\d+\.\d+'
+hint = "grit (gitbutlerapp/grit) is a from-scratch Rust reimplementation of Git, built nearly entirely by AI coding agents, targeting the C Git test suite for behavior parity (42k+ tests passing). `grit` is a simplified, workflow-oriented CLI (status as home screen, plain-language output); `grit-git` (cargo install grit-git) is a drop-in git-compatible CLI with 140+ commands. Do NOT confuse with `gritql` (see gritql.tomllmd) — an unrelated AST query language from biomejs."
+unlocks = ["grit *", "grit-git *"]
+lfmf_category = "grit"
+
+# 🤓 Maintenance: deterministic version-check automation
+[b00t.maintenance]
+check_interval_days = 30
+check_command = "curl -sL https://api.github.com/repos/gitbutlerapp/grit/releases/latest | jq -r '.tag_name // empty' | sed 's/^v//'"
+version_source = "github:gitbutlerapp/grit"
+check_regex = "(\\d+\\.\\d+\\.\\d+)"
+
+[[b00t.usage]]
+description = "Check repo status (grit's home screen)"
+command = "grit status"
+
+[[b00t.usage]]
+description = "Install the drop-in git-compatible CLI (140+ commands)"
+command = "cargo install grit-git"
+
+[[b00t.usage]]
+description = "Use grit-git as a git-compatible binary"
+command = "grit-git <git-subcommand>"
+
+[validate]
+command = "grit --version"
+regex = "\\d+\\.\\d+\\.\\d+"
+
+[roles]
+optional_for = ["developer"]
+
+# b00t:map v1
+# summary: grit (gitbutlerapp/grit) — Rust reimplementation of Git, AI-agent-built, targets C Git test suite parity; NOT gritql
+# tags: git, rust, gitbutler, grit, version-control, agent-written
+# tier: sm0l
+# cmds: curl -fsSL https://grit-scm.com/install | sh, grit status, cargo install grit-git
+# complexity: 2


### PR DESCRIPTION
Closes #794

Adds `_b00t_/grit.cli.toml` for `gitbutlerapp/grit` — a from-scratch Rust
reimplementation of Git, built nearly entirely by AI coding agents, targeting
the C Git test suite for behavior parity (42k+ tests passing).

Explicitly disambiguated from the existing `_b00t_/datums/gritql.tomllmd`
(biomejs/gritql — an unrelated AST query language). No prior grit datum
existed (`grep -ril "gitbutlerapp/grit" _b00t_/` returned nothing before
this change).

Covers both CLIs mentioned in the issue:
- `grit` — simplified workflow-oriented CLI (status as home screen)
- `grit-git` — drop-in git-compatible CLI (140+ commands, `cargo install grit-git`)

## Validation

```
$ b00t-cli -p <worktree>/_b00t_ datum validate grit.cli.toml
ok (1 warning(s))   # WARN: unknown field b00t.maintenance — same false-positive
                     # schema-lag warning as existing just.cli.toml/gh.cli.toml
$ python3 -c "import tomllib; tomllib.load(open('_b00t_/grit.cli.toml','rb'))"
TOML syntax OK
```

🤓 Note: `b00t-cli datum validate` resolves relative to a hardcoded
`~/.dotfiles/_b00t_/` path regardless of cwd; used `-p <worktree>/_b00t_`
as a workaround.