### PR TITLE
refactor: adopt ControlFlow<QuitReason,()> in k0mmand3r REPL loop (#799)

### DIFF
--- a/b00t-cli/src/k0mmand3r_repl.rs
+++ b/b00t-cli/src/k0mmand3r_repl.rs
@@ -10,12 +10,31 @@
 use anyhow::{Context, Result};
 use b00t_ipc::{Agent, Message, MessageBus, VoteChoice};
 use std::io::{self, Write};
+use std::ops::ControlFlow;
 use std::sync::Arc;
 use uuid::Uuid;
 
 pub struct Repl {
     agent: Agent,
     bus: Arc<MessageBus>,
+}
+
+/// Why the REPL command loop should stop.
+///
+/// # 🤓 issue #799 PoC: `ControlFlow<B, C>` compositional flow control
+/// `handle_command` previously returned `Result<bool>`, overloading the
+/// `Ok`/`Err` split for genuine errors while separately smuggling
+/// continue-vs-quit intent through the wrapped `bool`. That's the exact
+/// anti-pattern flagged in issue #799: a caller has to remember "true means
+/// keep going" out-of-band instead of reading it off the type. Swapping the
+/// inner `bool` for `ControlFlow<QuitReason, ()>` keeps `Result` doing only
+/// its one job (did this call itself fail?) while `ControlFlow` carries the
+/// loop's actual decision (`Break` = stop, with why; `Continue` = keep
+/// going) — compositional and self-documenting at the call site.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum QuitReason {
+    /// User issued `/quit` or `/exit`.
+    UserExit,
 }
 
 /// Resolve executable templates `<|:code:|>` in a command string.
@@ -77,11 +96,8 @@ impl Repl {
             let input = resolved.as_str();
 
             match self.handle_command(input).await {
-                Ok(should_continue) => {
-                    if !should_continue {
-                        break;
-                    }
-                }
+                Ok(ControlFlow::Continue(())) => {}
+                Ok(ControlFlow::Break(QuitReason::UserExit)) => break,
                 Err(e) => {
                     eprintln!("❌ Error: {}", e);
                 }
@@ -91,8 +107,12 @@ impl Repl {
         Ok(())
     }
 
-    /// Returns Ok(true) to continue, Ok(false) to quit
-    async fn handle_command(&mut self, input: &str) -> Result<bool> {
+    /// `Ok(ControlFlow::Continue(()))` to keep the loop running,
+    /// `Ok(ControlFlow::Break(QuitReason::UserExit))` to stop it.
+    /// `Err` is reserved for genuine failures (e.g. bus send errors) —
+    /// unlike the `bool` this replaces, it is never overloaded to mean
+    /// "quit".
+    async fn handle_command(&mut self, input: &str) -> Result<ControlFlow<QuitReason, ()>> {
         if !input.starts_with('/') {
             // Non-command input, broadcast to crew
             self.bus
@@ -101,7 +121,7 @@ impl Repl {
                     content: input.to_string(),
                 })
                 .await?;
-            return Ok(true);
+            return Ok(ControlFlow::Continue(()));
         }
 
         let parts: Vec<&str> = input.split_whitespace().collect();
@@ -113,7 +133,7 @@ impl Repl {
             }
             "/quit" | "/exit" => {
                 println!("👋 Goodbye!");
-                return Ok(false);
+                return Ok(ControlFlow::Break(QuitReason::UserExit));
             }
             "/handshake" => {
                 self.cmd_handshake(&parts[1..]).await?;
@@ -151,7 +171,7 @@ impl Repl {
             }
         }
 
-        Ok(true)
+        Ok(ControlFlow::Continue(()))
     }
 
     fn print_help(&self) {
@@ -466,5 +486,44 @@ mod tests {
 
         assert_eq!(repl.agent.id, "test-agent");
         assert_eq!(repl.agent.skills, vec!["rust", "testing"]);
+    }
+
+    /// issue #799 PoC: `/quit` must yield `Break(QuitReason::UserExit)`,
+    /// matching the old contract where it returned `Ok(false)`.
+    #[tokio::test]
+    async fn test_handle_command_quit_breaks_with_user_exit() {
+        let mut repl = Repl::new("test-agent".to_string(), vec!["rust".to_string()])
+            .await
+            .unwrap();
+
+        let flow = repl.handle_command("/quit").await.unwrap();
+        assert_eq!(flow, ControlFlow::Break(QuitReason::UserExit));
+
+        let flow = repl.handle_command("/exit").await.unwrap();
+        assert_eq!(flow, ControlFlow::Break(QuitReason::UserExit));
+    }
+
+    /// issue #799 PoC: any non-quit command must yield `Continue(())`,
+    /// matching the old contract where it returned `Ok(true)`.
+    #[tokio::test]
+    async fn test_handle_command_help_continues() {
+        let mut repl = Repl::new("test-agent".to_string(), vec!["rust".to_string()])
+            .await
+            .unwrap();
+
+        let flow = repl.handle_command("/help").await.unwrap();
+        assert_eq!(flow, ControlFlow::Continue(()));
+    }
+
+    /// issue #799 PoC: an unknown slash command still keeps the loop
+    /// running rather than being mistaken for a quit signal.
+    #[tokio::test]
+    async fn test_handle_command_unknown_continues() {
+        let mut repl = Repl::new("test-agent".to_string(), vec!["rust".to_string()])
+            .await
+            .unwrap();
+
+        let flow = repl.handle_command("/nonexistent").await.unwrap();
+        assert_eq!(flow, ControlFlow::Continue(()));
     }
 }


### PR DESCRIPTION
Closes #799 (partially — this is a deliberately scoped proof-of-concept slice, not the full 30+ call-site catalog).

## Summary
Issue #799 asked for `std::ops::ControlFlow<B, C>` to replace `Result<bool>` / `(bool, String)` flow-control encodings across the codebase (30+ candidate call sites cataloged). I verified the cited patterns are real (confirmed `Result<bool>` ×119 across the workspace, `(bool, String)` ×5, zero existing `ControlFlow` usage, and spot-checked all 5 of the issue's "top 5" file/line citations — all accurate, give or take a couple lines of drift since filing).

Given the scope (30+ sites across many files/crates), this PR migrates **one** concrete, self-contained call site as a proof of concept rather than attempting a sweeping migration:

- `b00t-cli/src/k0mmand3r_repl.rs`: `Repl::handle_command()` changes from `Result<bool>` (`Ok(true)`=continue, `Ok(false)`=quit) to `Result<ControlFlow<QuitReason, ()>>`. The single call site (`Repl::run`'s loop) is updated to match. `Err` remains reserved for genuine failures (e.g. `MessageBus::send` errors) — it is no longer overloaded to also mean "quit," which was the exact anti-pattern the issue flagged.

## Test plan
- [x] Added `test_handle_command_quit_breaks_with_user_exit` — `/quit` and `/exit` both yield `ControlFlow::Break(QuitReason::UserExit)`.
- [x] Added `test_handle_command_help_continues` — `/help` yields `ControlFlow::Continue(())`.
- [x] Added `test_handle_command_unknown_continues` — an unrecognized command still yields `Continue(())` rather than being mistaken for quit.
- [ ] `cargo check -p b00t-cli` / `cargo test -p b00t-cli k0mmand3r_repl` — **verification pending**. This crate transitively depends on several previously-uninitialized submodules (`vendor/ledgrrr`, `vendor/runpod-sdk`, `vendor/embed-anything-b00t`); I initialized them and kicked off a scoped `cargo check -p b00t-cli`, but the first-time build of that dependency tree (embed_anything, etc.) did not finish within this triage session's time budget. The diff is small and mechanical (signature + one match arm + trailing return, mirrored 1:1 against the old `bool` contract), but I have not observed a green compile locally — please run CI / a local `cargo check` before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)