### PR TITLE
docs(datum): track Awesome-Latent-Space as a living-reference datum (#398)

### DIFF
--- a/_b00t_/latent-space.datum.toml
+++ b/_b00t_/latent-space.datum.toml
@@ -1,0 +1,41 @@
+# b00t datum — living knowledge reference (issue #398)
+# 🤓 NOT content-blobbed via `b00t grok assimilate`: the upstream awesome-list is
+#    continually updated, so a one-time git-blob snapshot (the opencode.ai docs
+#    pattern, #460) would go stale. Track source_url + refresh cadence instead;
+#    re-ingest periodically via `b00t grok digest`.
+
+[b00t]
+name = "latent-space"
+type = "datum"
+hint = "Awesome-Latent-Space — curated ML papers on LLM latent-space structure, failure modes, and enhancements. Living reference, periodic refresh (not a static snapshot)."
+
+[datum]
+topic      = "latent-space"
+class      = "Concept"
+tags       = ["ml", "llm", "latent-space", "research"]
+source_url = "https://github.com/YU-deep/Awesome-Latent-Space"
+tier       = "frontier"
+
+[datum.refresh]
+schedule   = "periodic"
+cadence    = "monthly"
+ingest_cmd = "b00t-cli grok digest --topic latent-space --source-url https://github.com/YU-deep/Awesome-Latent-Space"
+rationale  = "Awesome-list is continually updated upstream (see issue #398 discussion). Snapshot-blobbing goes stale; re-ingest content on cadence instead of assimilating once."
+
+[datum.memoized_insights]
+# 🤓 Lessons already extracted from this topic's papers during #398 triage,
+#    memoized so future re-ingestion can diff against what's already known
+#    rather than re-deriving it.
+kv_cache_boilerplate_top = "Lost-in-the-middle degradation validates b00t's CLAUDE.md pattern: stable boilerplate at TOP (KV-cache target), variable session content at BOTTOM."
+skill_description_phrasing = "Prompt sensitivity research implies datum [b00t.skill].description phrasing should be canonical (imperative, specific) for consistent retrieval."
+tier_routing_thresholds = "Emergent-capability-threshold research implies sm0l-tier models are qualitatively incapable of some ch0nky-tier tasks, not just slower — reinforces cognitive-tier routing table in CLAUDE.md."
+
+[validation]
+validate = "b00t-cli datum validate _b00t_/latent-space.datum.toml"
+
+# b00t:map v1
+# summary: living-reference knowledge datum for Awesome-Latent-Space (LLM latent-space research); periodic re-ingestion via grok digest, not a one-time blob snapshot
+# tags: ml, llm, latent-space, research
+# tier: frontier
+# cmds: b00t-cli grok digest --topic latent-space --source-url https://github.com/YU-deep/Awesome-Latent-Space
+# complexity: 2


### PR DESCRIPTION
## Summary
- #398's thread converged on tracking `github.com/YU-deep/Awesome-Latent-Space` as a periodically-refreshed knowledge datum rather than a one-time git-blob snapshot (the upstream list is continually updated, so `grok assimilate`'s static-blob pattern would go stale), modeled on the opencode.ai docs datum from #460.
- Adds `_b00t_/latent-space.datum.toml` with a `[datum.refresh]` block declaring the `b00t grok digest` re-ingestion cadence, and a `[datum.memoized_insights]` block capturing three lessons already extracted in the issue thread.
- Kreuzberg MCP paper-parsing integration (a larger, separate effort, tracked in #341) is explicitly out of scope here.

## Test plan
- [x] `b00t datum validate .../latent-space.datum.toml` → valid — no issues found (EXIT 0)

Issue #398 left open per the thread's own "keep as living reference" verdict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)