### PR TITLE
feat(experiment): emit OTEL attributes for A/B experiment comparisons (#404)

### DIFF
--- a/b00t-cli/src/commands/experiment.rs
+++ b/b00t-cli/src/commands/experiment.rs
@@ -1187,6 +1187,67 @@ pub fn calculate_and_issue_cake(cmp: &ExperimentComparison) -> b00t_c0re_a2a::ta
     )
 }
 
+// ── OTEL span emission (issue #404: checkmate A/B → OTEL interface) ─────────
+//
+// Closes the gap flagged in github.com/elasticdotventures/_b00t_/issues/404:
+// "CakeLedger → emit OTEL span with agent_tier, task_id, vote, claim_score
+// attributes → Grafana/Jaeger for regression tracking." Reuses the tracer
+// pattern already established by `K0mmand3rTelemetry` in
+// `b00t-cli/src/k0mmand3r/mod.rs` (NRtW: no new tracing plumbing invented).
+
+/// Pure extraction of OTEL span attributes from an experiment comparison.
+/// Kept separate from the actual `tracer.start()` call so it's unit-testable
+/// without an OTEL SDK/exporter wired up (the default global tracer is a
+/// no-op, which makes asserting on emitted attributes impossible upstream).
+pub fn experiment_otel_attributes(cmp: &ExperimentComparison) -> Vec<(String, String)> {
+    let control_claim_score = cmp.control.scores.get("accuracy").copied().unwrap_or(0.0);
+    let treatment_claim_score = cmp
+        .treatment
+        .scores
+        .get("accuracy")
+        .copied()
+        .unwrap_or(0.0);
+
+    vec![
+        ("task_id".to_string(), cmp.experiment_id.clone()),
+        ("vote".to_string(), cmp.recommendation.clone()),
+        (
+            "tie_breaker".to_string(),
+            cmp.tie_breaker.clone().unwrap_or_else(|| "none".to_string()),
+        ),
+        ("control.agent_tier".to_string(), cmp.control.variant.clone()),
+        (
+            "control.claim_score".to_string(),
+            format!("{:.4}", control_claim_score),
+        ),
+        (
+            "treatment.agent_tier".to_string(),
+            cmp.treatment.variant.clone(),
+        ),
+        (
+            "treatment.claim_score".to_string(),
+            format!("{:.4}", treatment_claim_score),
+        ),
+        ("focus_delta".to_string(), format!("{:.4}", cmp.focus_delta)),
+    ]
+}
+
+/// Emit a single OTEL span summarizing the A/B experiment outcome.
+/// Best-effort: with no SDK/exporter configured, the global tracer is a
+/// no-op and this call is inert — matches `emit_focus_to_ledgrrr_mcp`'s
+/// best-effort contract elsewhere in this module.
+pub fn emit_experiment_otel_span(cmp: &ExperimentComparison) {
+    use opentelemetry::KeyValue;
+    use opentelemetry::trace::{Span, Tracer};
+
+    let tracer = opentelemetry::global::tracer("b00t.experiment");
+    let mut span = tracer.start("b00t.experiment.checkmate");
+    for (key, value) in experiment_otel_attributes(cmp) {
+        span.set_attribute(KeyValue::new(key, value));
+    }
+    span.end();
+}
+
 // ── Personality profiles ─────────────────────────────────────────────────────
 
 fn personality(label: &str, c: f64, o: f64, e: f64, a: f64, n: f64) -> PersonalityProfile {
@@ -1247,6 +1308,73 @@ mod tests {
         assert!(cmp.deltas.contains_key("roi"));
         assert!(cmp.deltas.contains_key("cost"));
         assert!(!cmp.recommendation.is_empty());
+    }
+
+    #[test]
+    fn test_experiment_otel_attributes_carries_task_vote_and_claim_scores() {
+        let config = make_config("test-otel-001", TEST_PROMPTS[0]);
+        let cmp = dispatch_experiment(&config).unwrap();
+
+        let attrs = experiment_otel_attributes(&cmp);
+        let get = |k: &str| -> String {
+            attrs
+                .iter()
+                .find(|(key, _)| key == k)
+                .unwrap_or_else(|| panic!("missing OTEL attribute: {k}"))
+                .1
+                .clone()
+        };
+
+        assert_eq!(get("task_id"), "test-otel-001");
+        assert_eq!(get("vote"), cmp.recommendation);
+        assert_eq!(get("control.agent_tier"), "control");
+        assert_eq!(get("treatment.agent_tier"), "treatment");
+        // OTEL attributes are formatted to 4 decimal places for readability, so compare
+        // against the raw f64 with an epsilon rather than exact equality.
+        assert!(
+            (get("control.claim_score").parse::<f64>().unwrap()
+                - cmp.control.scores.get("accuracy").copied().unwrap_or(0.0))
+            .abs()
+                < 1e-4
+        );
+        assert!(
+            (get("treatment.claim_score").parse::<f64>().unwrap()
+                - cmp.treatment
+                    .scores
+                    .get("accuracy")
+                    .copied()
+                    .unwrap_or(0.0))
+            .abs()
+                < 1e-4
+        );
+        assert!(
+            (get("focus_delta").parse::<f64>().unwrap() - cmp.focus_delta).abs() < 1e-4
+        );
+    }
+
+    #[test]
+    fn test_experiment_otel_attributes_defaults_tie_breaker_to_none() {
+        let config = make_config("test-otel-002", TEST_PROMPTS[1]);
+        let cmp = dispatch_experiment(&config).unwrap();
+        assert!(cmp.tie_breaker.is_none(), "dispatch_experiment never sets tie_breaker directly");
+
+        let attrs = experiment_otel_attributes(&cmp);
+        let tie_breaker = attrs
+            .iter()
+            .find(|(key, _)| key == "tie_breaker")
+            .unwrap()
+            .1
+            .clone();
+        assert_eq!(tie_breaker, "none");
+    }
+
+    #[test]
+    fn test_emit_experiment_otel_span_does_not_panic() {
+        // Best-effort emission against the default (no-op) global tracer —
+        // this must never panic even with no OTEL SDK/exporter configured.
+        let config = make_config("test-otel-003", TEST_PROMPTS[0]);
+        let cmp = dispatch_experiment(&config).unwrap();
+        emit_experiment_otel_span(&cmp);
     }
 
     #[test]

--- a/b00t-cli/src/main.rs
+++ b/b00t-cli/src/main.rs
@@ -3003,6 +3003,8 @@ async fn main() {
                             );
                             // emit FOCUS records to ledgrrr-mcp MCP server (best-effort)
                             experiment::emit_focus_to_ledgrrr_mcp(&cmp, "http://localhost:8001");
+                            // emit OTEL span for regression tracking (issue #404)
+                            experiment::emit_experiment_otel_span(&cmp);
                             // Calculate and issue cake payout
                             experiment::calculate_and_issue_cake(&cmp);
                         }


### PR DESCRIPTION
## Summary
- #404 reviewed CheckMate (Collins et al.) — an LLM A/B evaluation benchmark methodology, not a library to vendor. The actionable gap: b00t's existing A/B experiment dispatch (`commands/experiment.rs`) computes comparisons but never surfaces them as observable telemetry.
- Adds `experiment_otel_attributes()` / `emit_experiment_otel_span()`: task_id, vote/recommendation, tie_breaker, per-variant agent_tier + claim_score (accuracy), and focus_delta as OTEL span attributes — best-effort/inert when no exporter is configured, matching the existing `emit_focus_to_ledgrrr_mcp` contract.
- A full CheckMate-style claim-decomposition scorer is out of scope — b00t's existing single `accuracy` score per variant is what's wired through today; decomposing it further has no current consumer.

## Bug found and fixed during verification
- `test_experiment_otel_attributes_carries_task_vote_and_claim_scores` used `assert_eq!` comparing a value the production code deliberately formats to 4 decimal places (for the OTEL attribute string) against the unrounded f64 — could never pass. Switched to a 1e-4 epsilon comparison.

## Test plan
- [x] `cargo test -p b00t-cli commands::experiment:: --lib` → 14 passed; 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)