### PR TITLE
chore(vendor): sync ledgrrr to reconciled b00t-patches

### DIFF
--- a/_b00t_/lfmf/ledgrrr-sync.md
+++ b/_b00t_/lfmf/ledgrrr-sync.md
@@ -1,0 +1,38 @@
+# ledgrrr-sync
+
+A vendored submodule's checked-out HEAD matching its recorded `.gitmodules`
+pin proves nothing about whether that pin is still reachable from the
+branch `.gitmodules` declares (`branch = ...`). If the declared branch gets
+force-pushed/rebased upstream after the pin was set, the pin silently
+strands on an orphan lineage — `check-submodule-drift.sh` reported
+"ok" the whole time because it only ever compares checked-out HEAD against
+the recorded pin, never the pin against the declared branch's current tip.
+
+This is exactly what happened to `vendor/ledgrrr`: a series of "bump
+vendor/ledgrrr for X fix" commits pinned it straight onto a feature branch
+(`fix/tray-native-windows-rs-062`) instead of the declared `b00t-patches`.
+`b00t-patches` was later force-pushed, and the two lineages diverged for
+weeks — 34 commits on one side, 3 on the other, including two independent
+fixes for the same bug (`windows_registry::*` shadowing `std::result::Result`)
+written on each side without either author knowing about the other's fix.
+Caught only by a manual `git cherry`/`merge-base --is-ancestor` audit, not
+by any existing check.
+
+Fix-forward, don't fast-forward: when a pin and its declared branch have
+diverged, merge both lineages together upstream (resolve conflicts keeping
+the more complete/correct side — see PromptExecution/ledgrrr#167 for the
+worked example), verify it builds, *then* re-bump the pin. Never just move
+the pin to the declared branch's current tip — that silently drops whatever
+commits the old pin had that never made it onto that branch.
+
+`check-submodule-drift.sh` (and `b00t doctor check`'s `submodule-drift`
+entry) now check this directly: every submodule with a `branch=` in
+`.gitmodules` gets a `branch_status` field — `ok` (pin is an ancestor of
+`origin/<branch>`), `stale` (pin unreachable from it — the failure mode
+above, counted as a doctor-check failure), `unknown` (declared branch not
+fetched locally yet — inconclusive, not a failure), or `n/a` (no branch
+declared). It's local-only by design (never fetches over the network at
+check time — a network call per submodule on every `doctor check` would be
+slow, and per the same day's WSL2 + Cloudflare WARP MTU-blackhole incident,
+can hang indefinitely) — run `git -C <path> fetch origin <branch>`
+periodically to keep it informative rather than `unknown`.

--- a/_b00t_/scripts/check-submodule-drift.sh
+++ b/_b00t_/scripts/check-submodule-drift.sh
@@ -25,6 +25,26 @@
 #                    only — NEVER touched, regardless of --fix. Always
 #                    counted as a failure.
 #
+# Orthogonal to the above: for any submodule with a `branch = ` declared in
+# .gitmodules, each entry also carries a `branch_status` field (2026-08-09,
+# after the vendor/ledgrrr incident — see `b00t lfmf ledgrrr-sync`):
+#   n/a      — no branch= declared for this path.
+#   unknown  — branch= declared, but refs/remotes/origin/<branch> isn't
+#              fetched locally. Never fetches over the network itself (this
+#              runs on every `b00t doctor check`; a network call per
+#              submodule would be slow and, per the same day's WSL/WARP MTU
+#              incident, can hang indefinitely) — not a failure, just
+#              inconclusive. Run `git -C <path> fetch origin <branch>` first.
+#   ok       — the RECORDED pin is an ancestor of origin/<branch>.
+#   stale    — the recorded pin is NOT reachable from origin/<branch>: the
+#              declared branch moved (force-push/rebase) out from under a
+#              pin that used to be on it, or the pin was bumped straight to
+#              a side branch that was never merged into the declared one.
+#              This is exactly how vendor/ledgrrr silently stranded 34
+#              commits until a manual audit caught it. Counted as a failure
+#              — there is no mechanical fix (see the doc comment above);
+#              reconcile upstream, don't just re-bump the pin.
+#
 # "Dirty" means uncommitted changes to TRACKED files only
 # (`git status --porcelain --untracked-files=no`), NOT any untracked file.
 # `git submodule update` only moves the checked-out ref via `git checkout`,
@@ -67,6 +87,7 @@ cd "$REPO_ROOT"
 FAIL_COUNT=0
 DIRTY_COUNT=0
 UNFIXED_CLEAN_COUNT=0
+STALE_BRANCH_COUNT=0
 ITEMS=()
 HUMAN_LINES=()
 
@@ -74,31 +95,65 @@ HUMAN_LINES=()
 # Uses jq -n to build it (handles quoting/escaping of non-ASCII paths like
 # python.🐍/DALLE2-pytorch correctly, avoids hand-rolled JSON escaping).
 emit_json() {
-    local path="$1" recorded="$2" checked_out="$3" status="$4" action="$5"
+    local path="$1" recorded="$2" checked_out="$3" status="$4" action="$5" branch_status="$6" branch_detail="$7"
     jq -nc \
         --arg path "$path" \
         --arg recorded "$recorded" \
         --arg checked_out "$checked_out" \
         --arg status "$status" \
         --arg action "$action" \
+        --arg branch_status "$branch_status" \
+        --arg branch_detail "$branch_detail" \
         '{path:$path,
           recorded: (if $recorded == "" then null else $recorded end),
           checked_out: (if $checked_out == "" then null else $checked_out end),
           status: $status,
-          action: $action}'
+          action: $action,
+          branch_status: $branch_status,
+          branch_detail: $branch_detail}'
 }
 
 # Record one submodule's classification: builds the JSON item, tracks
 # failure counts, and queues a human-readable line (OK lines only shown
 # with --verbose).
 record() {
-    local path="$1" recorded="$2" checked_out="$3" status="$4" action="$5" is_fail="$6"
-    ITEMS+=("$(emit_json "$path" "$recorded" "$checked_out" "$status" "$action")")
+    local path="$1" recorded="$2" checked_out="$3" status="$4" action="$5" is_fail="$6" branch_status="${7:-n/a}" branch_detail="${8:-}"
+    ITEMS+=("$(emit_json "$path" "$recorded" "$checked_out" "$status" "$action" "$branch_status" "$branch_detail")")
     if [[ "$is_fail" == "1" ]]; then
         FAIL_COUNT=$((FAIL_COUNT + 1))
     fi
-    if [[ "$status" != "ok" || "$VERBOSE" == "true" ]]; then
+    if [[ "$status" != "ok" || "$branch_status" == "stale" || "$VERBOSE" == "true" ]]; then
         HUMAN_LINES+=("  $(printf '%-14s' "$status") $path  recorded=${recorded:-<none>} checked_out=${checked_out:-<none>}  -- $action")
+        if [[ "$branch_status" == "stale" ]]; then
+            HUMAN_LINES+=("                 ⚠️  branch_status=stale -- $branch_detail")
+        fi
+    fi
+}
+
+# Declared-branch ancestry check (2026-08-09, see doc comment at top).
+# Deliberately local-only: never fetches. Sets globals BRANCH_STATUS /
+# BRANCH_DETAIL for the caller to pass into record().
+check_branch_ancestry() {
+    local path="$1" recorded="$2"
+    BRANCH_STATUS="n/a"
+    BRANCH_DETAIL=""
+    local branch
+    branch=$(git config --file .gitmodules --get "submodule.$path.branch" 2>/dev/null || true)
+    [[ -z "$branch" ]] && return
+
+    if ! git -C "$path" rev-parse -q --verify "refs/remotes/origin/$branch" >/dev/null 2>&1; then
+        BRANCH_STATUS="unknown"
+        BRANCH_DETAIL="origin/$branch not fetched locally in the submodule -- run: git -C $path fetch origin $branch"
+        return
+    fi
+
+    if git -C "$path" merge-base --is-ancestor "$recorded" "refs/remotes/origin/$branch" 2>/dev/null; then
+        BRANCH_STATUS="ok"
+        BRANCH_DETAIL="recorded pin is an ancestor of origin/$branch"
+    else
+        BRANCH_STATUS="stale"
+        BRANCH_DETAIL="recorded pin is NOT reachable from origin/$branch -- the declared branch moved (force-push/rebase?) and stranded this pin, or it was bumped straight to an unmerged side branch. Reconcile upstream (merge/rebase both lineages together, verify, then re-bump) -- do not just fast-forward the pin, that silently drops whatever the pin has that the declared branch doesn't. See: b00t lfmf ledgrrr-sync"
+        STALE_BRANCH_COUNT=$((STALE_BRANCH_COUNT + 1))
     fi
 }
 
@@ -124,9 +179,16 @@ while IFS= read -r path; do
         continue
     fi
 
+    # Declared-branch ancestry — orthogonal to the recorded-vs-checked-out
+    # comparison below, so computed once here and threaded into every
+    # record() call in this iteration regardless of which status it gets.
+    check_branch_ancestry "$path" "$rec"
+    branch_is_fail=0
+    [[ "$BRANCH_STATUS" == "stale" ]] && branch_is_fail=1
+
     if [[ "$rec" == "$act" ]]; then
         # OK — HEAD matches recorded pin.
-        record "$path" "$rec" "$act" "ok" "none" 0
+        record "$path" "$rec" "$act" "ok" "none" "$branch_is_fail" "$BRANCH_STATUS" "$BRANCH_DETAIL"
         continue
     fi
 
@@ -137,21 +199,21 @@ while IFS= read -r path; do
     if [[ -n "$dirty" ]]; then
         # DRIFTED+DIRTY — report only, NEVER touched regardless of --fix.
         DIRTY_COUNT=$((DIRTY_COUNT + 1))
-        record "$path" "$rec" "$act" "drifted_dirty" "manual resolution required (tracked changes present) — NOT touched" 1
+        record "$path" "$rec" "$act" "drifted_dirty" "manual resolution required (tracked changes present) — NOT touched" 1 "$BRANCH_STATUS" "$BRANCH_DETAIL"
         continue
     fi
 
     # DRIFTED+CLEAN — safe to auto-sync.
     if [[ "$FIX" == "true" ]]; then
         if git submodule update -- "$path" >/dev/null 2>&1; then
-            record "$path" "$rec" "$act" "drifted_fixed" "synced to recorded pin ($act -> $rec)" 0
+            record "$path" "$rec" "$act" "drifted_fixed" "synced to recorded pin ($act -> $rec)" "$branch_is_fail" "$BRANCH_STATUS" "$BRANCH_DETAIL"
         else
             UNFIXED_CLEAN_COUNT=$((UNFIXED_CLEAN_COUNT + 1))
-            record "$path" "$rec" "$act" "drifted_clean" "sync attempted but failed" 1
+            record "$path" "$rec" "$act" "drifted_clean" "sync attempted but failed" 1 "$BRANCH_STATUS" "$BRANCH_DETAIL"
         fi
     else
         UNFIXED_CLEAN_COUNT=$((UNFIXED_CLEAN_COUNT + 1))
-        record "$path" "$rec" "$act" "drifted_clean" "sync available — safe, run with --fix" 1
+        record "$path" "$rec" "$act" "drifted_clean" "sync available — safe, run with --fix" 1 "$BRANCH_STATUS" "$BRANCH_DETAIL"
     fi
 done < <(git config --file .gitmodules --get-regexp '\.path$' 2>/dev/null | cut -d' ' -f2- || true)
 
@@ -169,7 +231,7 @@ else
     if [[ "$FAIL_COUNT" -eq 0 ]]; then
         echo "PASS: 0 drifted submodules"
     else
-        echo "FAIL: $FAIL_COUNT drifted submodules (dirty: $DIRTY_COUNT, clean-unfixed: $UNFIXED_CLEAN_COUNT)"
+        echo "FAIL: $FAIL_COUNT drifted submodules (dirty: $DIRTY_COUNT, clean-unfixed: $UNFIXED_CLEAN_COUNT, stale-branch-pin: $STALE_BRANCH_COUNT)"
     fi
 fi
 

--- a/_b00t_/test/submodule-drift.bats
+++ b/_b00t_/test/submodule-drift.bats
@@ -20,6 +20,11 @@ status_of() {
     echo "$json" | jq -r --arg p "$path" '.[] | select(.path==$p) | .status'
 }
 
+branch_status_of() {
+    local json="$1" path="$2"
+    echo "$json" | jq -r --arg p "$path" '.[] | select(.path==$p) | .branch_status'
+}
+
 setup() {
     FIXTURE_DIR="$(mktemp -d)"
 
@@ -38,6 +43,7 @@ setup() {
     echo "v2" > "$SRC/file.txt"
     git -C "$SRC" commit -q -am c2
     C2_SHA="$(git -C "$SRC" rev-parse HEAD)"
+    SRC_DEFAULT_BRANCH="$(git -C "$SRC" symbolic-ref --short HEAD)"
 
     # 2. Origin superproject: sub-a, sub-b, sub-c, sub-d all pinned @c2.
     #    Modern git disables the file:// submodule transport by default —
@@ -65,7 +71,7 @@ setup() {
     chmod +x "$SUPER/_b00t_/scripts/check-submodule-drift.sh"
     SCRIPT="$SUPER/_b00t_/scripts/check-submodule-drift.sh"
 
-    export FIXTURE_DIR SRC ORIGIN SUPER SCRIPT C1_SHA C2_SHA
+    export FIXTURE_DIR SRC ORIGIN SUPER SCRIPT C1_SHA C2_SHA SRC_DEFAULT_BRANCH
 }
 
 teardown() {
@@ -150,4 +156,50 @@ EOF
     assert_equal "$(git -C "$SUPER/sub-c" rev-parse HEAD)" "$C2_SHA"
     # The untracked file survives the sync (git checkout never touches it).
     assert [ -f "$SUPER/sub-c/newfile.txt" ]
+}
+
+@test "branch-ok: recorded pin is an ancestor of the declared branch's tip" {
+    git -C "$SUPER" -c protocol.file.allow=always submodule update --init -- sub-d
+    git -C "$SUPER" config --file .gitmodules "submodule.sub-d.branch" "$SRC_DEFAULT_BRANCH"
+
+    # Recorded pin is C2, which IS the current tip of SRC_DEFAULT_BRANCH —
+    # `submodule update --init` clones all branches by default, so
+    # refs/remotes/origin/<branch> already exists inside sub-d.
+    run bash "$SCRIPT" --json
+    assert_equal "$(branch_status_of "$output" "sub-d")" "ok"
+}
+
+@test "branch-stale: declared branch moved (force-push/rebase) out from under the recorded pin (2026-08-09 ledgrrr regression)" {
+    git -C "$SUPER" -c protocol.file.allow=always submodule update --init -- sub-d
+    git -C "$SUPER" config --file .gitmodules "submodule.sub-d.branch" "$SRC_DEFAULT_BRANCH"
+
+    # Simulate a force-push/rebase on the upstream branch that drops the
+    # commit our pin (C2) points at — exactly what stranded vendor/ledgrrr's
+    # pin off b00t-patches until a manual audit caught it.
+    git -C "$SRC" checkout -q "$SRC_DEFAULT_BRANCH"
+    git -C "$SRC" reset --hard "$C1_SHA"
+    git -C "$SUPER/sub-d" fetch -q origin "$SRC_DEFAULT_BRANCH"
+
+    run bash "$SCRIPT" --json
+    assert_equal "$status" 1
+    assert_equal "$(status_of "$output" "sub-d")" "ok"
+    assert_equal "$(branch_status_of "$output" "sub-d")" "stale"
+
+    run bash "$SCRIPT"
+    assert_output --partial "stale-branch-pin: 1"
+}
+
+@test "branch-unknown: declared branch not yet fetched locally is inconclusive, not a failure" {
+    # --single-branch limits the submodule's own clone to whichever branch
+    # is configured at init time, so only refs/remotes/origin/$SRC_DEFAULT_BRANCH
+    # ends up fetched. Re-pointing .gitmodules at a different branch
+    # afterward reproduces "declared branch changed, nothing's fetched it
+    # locally yet" without needing a real second remote branch.
+    git -C "$SUPER" config --file .gitmodules "submodule.sub-d.branch" "$SRC_DEFAULT_BRANCH"
+    git -C "$SUPER" -c protocol.file.allow=always submodule update --init --single-branch -- sub-d
+    git -C "$SUPER" config --file .gitmodules "submodule.sub-d.branch" "never-fetched-branch"
+
+    run bash "$SCRIPT" --json
+    assert_success
+    assert_equal "$(branch_status_of "$output" "sub-d")" "unknown"
 }

--- a/b00t-cli/src/commands/doctor_cmd.rs
+++ b/b00t-cli/src/commands/doctor_cmd.rs
@@ -117,6 +117,20 @@ fn check_submodule_drift(b00t_path: &str, fix: bool) -> Value {
                             .count()
                     })
                     .unwrap_or(0);
+                // branch_status: stale (2026-08-09, see check-submodule-drift.sh
+                // doc comment) — recorded pin unreachable from the .gitmodules
+                // branch=; a separate axis from checked-out-vs-recorded drift,
+                // so counted separately here even though it's the same
+                // `pass`/exit-code from the script.
+                let stale_branch_pins: Vec<&str> = submodules
+                    .as_array()
+                    .map(|a| {
+                        a.iter()
+                            .filter(|s| s["branch_status"].as_str() == Some("stale"))
+                            .filter_map(|s| s["path"].as_str())
+                            .collect()
+                    })
+                    .unwrap_or_default();
                 let pass = o.status.success();
                 json!({
                     "id": "submodule-drift",
@@ -124,7 +138,15 @@ fn check_submodule_drift(b00t_path: &str, fix: bool) -> Value {
                     "detail": if pass {
                         "0 drifted submodules".to_string()
                     } else {
-                        format!("{unresolved} unresolved submodule drift (see submodules[])")
+                        format!(
+                            "{unresolved} unresolved submodule drift, {} stale branch pin(s){} (see submodules[])",
+                            stale_branch_pins.len(),
+                            if stale_branch_pins.is_empty() {
+                                String::new()
+                            } else {
+                                format!(" [{}]", stale_branch_pins.join(", "))
+                            }
+                        )
                     },
                     "submodules": submodules,
                     "latency_ms": ms,
@@ -738,6 +760,17 @@ pub fn handle_doctor_command(args: &DoctorCommands, b00t_path: &str) -> Result<(
                                         status,
                                         s["path"].as_str().unwrap_or("?"),
                                         s["action"].as_str().unwrap_or("")
+                                    );
+                                }
+                                // branch_status: stale can co-occur with an
+                                // otherwise-clean "ok" status — surfaced
+                                // separately since it's a different failure
+                                // mode (see check-submodule-drift.sh).
+                                if s["branch_status"] == "stale" {
+                                    println!(
+                                        "      ⚠️  stale-branch-pin  {}  {}",
+                                        s["path"].as_str().unwrap_or("?"),
+                                        s["branch_detail"].as_str().unwrap_or("")
                                     );
                                 }
                             }


### PR DESCRIPTION
## Summary
- The `vendor/ledgrrr` pin had drifted onto a feature branch (`fix/tray-native-windows-rs-062`) instead of the `b00t-patches` branch `.gitmodules` declares, after `b00t-patches` was force-pushed upstream and the two lineages diverged (34 vs 3 unique commits, including a duplicate independent fix for the same bug).
- Reconciled both lineages upstream: PromptExecution/ledgrrr#167 (squash-merged into `b00t-patches`). Bumps the pin to the reconciled tip.
- Codifies the practice that would have caught this earlier: `check-submodule-drift.sh` (and `b00t doctor check`) now report a `branch_status` (ok/stale/unknown/n/a) per submodule — `stale` means the recorded pin is unreachable from the branch `.gitmodules` declares, which the existing checked-out-vs-recorded-pin comparison alone could never catch. Memoized as `b00t lfmf ledgrrr-sync`.

## Test plan
- [x] Verified no conflict markers remain in the reconciled ledgrrr merge; `cargo check --target x86_64-pc-windows-gnu` on the two touched crates hits a pre-existing, unrelated toolchain gap (confirmed identical failure on plain `b00t-patches` pre-merge)
- [x] `cargo test -p b00t-cli --lib doctor_cmd` — all pass
- [x] `_b00t_/test/bats/bin/bats _b00t_/test/submodule-drift.bats` — 8/8 pass, including 3 new tests (ok/stale/unknown) reproducing the incident's shape via a force-pushed fixture branch
- [x] `cargo clippy -p b00t-cli --lib` — clean on touched code
- [x] Live-ran `b00t doctor check` against this repo — `vendor/ledgrrr` now reports `branch_status: ok`
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)