### PR TITLE
feat(council): add b00t-council — shared player messaging + generic voting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1486,6 +1486,7 @@ name = "b00t-c0re-hierarchy"
 version = "0.10.3"
 dependencies = [
  "b00t-c0re-gov",
+ "b00t-council",
  "chrono",
  "serde",
  "serde_json",
@@ -1709,6 +1710,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "b00t-council"
+version = "0.10.3"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "serde",
+ "serde_json",
+ "uuid",
+]
+
+[[package]]
 name = "b00t-datum-core"
 version = "0.10.3"
 dependencies = [
@@ -1780,6 +1792,7 @@ dependencies = [
  "anyhow",
  "async-nats",
  "async-trait",
+ "b00t-council",
  "bincode 1.3.3",
  "chrono",
  "futures",
@@ -1838,6 +1851,7 @@ dependencies = [
  "b00t-c0re-lib",
  "b00t-chat",
  "b00t-cli",
+ "b00t-council",
  "b00t-reflect-types",
  "base64 0.22.1",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ members = [
     "b00t-isometric-wasm",
     "b00t-embed-serve",
     "b00t-stt-serve",
+    "b00t-council",
 ]
 exclude = ["vendor/embed-anything-b00t",
     "vendor/rust-docs-mcp-b00t",

--- a/b00t-c0re-hierarchy/Cargo.toml
+++ b/b00t-c0re-hierarchy/Cargo.toml
@@ -10,3 +10,4 @@ uuid = { version = "1", features = ["v4", "serde"] }
 chrono = { version = "0.4", features = ["serde"] }
 thiserror = "2"
 b00t-c0re-gov = { path = "../b00t-c0re-gov" }
+b00t-council = { path = "../b00t-council" }

--- a/b00t-c0re-hierarchy/src/roles.rs
+++ b/b00t-c0re-hierarchy/src/roles.rs
@@ -53,6 +53,19 @@ pub struct Agent {
     pub is_player: bool,            // true if this Agent represents a human user
 }
 
+/// First behavioral use of `is_player` in this codebase — previously set at
+/// construction but never read. Lets hive messaging (`b00t-council`) tag
+/// traffic as human- vs. software-originated.
+impl b00t_council::Player for Agent {
+    fn player_id(&self) -> &str {
+        &self.id
+    }
+
+    fn is_human(&self) -> bool {
+        self.is_player
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Team {
     pub captain_id: String,

--- a/b00t-cli/src/commands/crew_handler.rs
+++ b/b00t-cli/src/commands/crew_handler.rs
@@ -255,6 +255,19 @@ fn update_meta(store: &AgentStore, name: &str, f: impl FnOnce(&mut CrewMeta)) {
     save_meta(&mp, &meta);
 }
 
+/// Look up whether `agent_id` is recorded as a human player in the crew
+/// roster (`Agent::is_player`, via `_crew_meta.json`). Returns `false` for
+/// unknown agent ids — i.e. "assume software agent" absent other evidence.
+/// Used by `b00t-mcp` to tag outgoing messages/votes with sender identity.
+pub fn is_player(agent_id: &str) -> bool {
+    let store = AgentStore::with_path(default_store_dir());
+    all_agents(&store)
+        .into_iter()
+        .find(|a| a.id == agent_id)
+        .map(|a| a.is_player)
+        .unwrap_or(false)
+}
+
 // ---------------------------------------------------------------------------
 // Public entry point
 // ---------------------------------------------------------------------------

--- a/b00t-council/Cargo.toml
+++ b/b00t-council/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "b00t-council"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Shared abstraction layer for player identity, serializable player-to-player messages, and generic (pluggable-quorum) voting across the b00t hive"
+
+[lib]
+name = "b00t_council"
+
+[dependencies]
+serde = { workspace = true }
+serde_json = { workspace = true }
+anyhow = { workspace = true }
+chrono = { workspace = true }
+uuid = { version = "1.0", features = ["v4", "serde"] }

--- a/b00t-council/src/council.rs
+++ b/b00t-council/src/council.rs
@@ -1,0 +1,235 @@
+//! Generic voting: pluggable quorum strategies instead of a hardcoded
+//! threshold. Generalizes the logic already written and unit-tested in
+//! `b00t-ipc`'s `Proposal::is_passed`/`is_rejected` (there, hardcoded to
+//! "2 yes votes") so any subsystem's vote type can plug in as `O`.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::hash::Hash;
+
+/// How many cast ballots an option needs to win.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum Quorum {
+    /// Strict majority of all non-abstain ballots cast so far.
+    Majority,
+    /// A fixed count, independent of how many players are eligible.
+    AtLeast(usize),
+    /// Every non-abstain ballot cast so far must agree.
+    Unanimous,
+    /// Liberum veto (Polish–Lithuanian Sejm, 16th–18th c.): any single bare
+    /// [`Ballot::Veto`] blocks immediately — unlike `Unanimous`, which just
+    /// stays [`Outcome::Pending`] forever on disagreement, a veto here
+    /// resolves straight to [`Outcome::Rejected`]. Non-veto `Cast` ballots
+    /// still must all agree on one option to `Pass`, exactly as under
+    /// `Unanimous`.
+    LiberumVeto,
+}
+
+/// A single player's vote.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum Ballot<O> {
+    /// A vote for a specific option.
+    Cast(O),
+    /// A block. `alternative: None` rejects outright, regardless of quorum
+    /// (mirrors `b00t_c0re_lib`'s `VotingType::VetoCapable`); `Some(o)`
+    /// instead casts for the proposed alternative.
+    Veto { alternative: Option<O> },
+    /// Recorded but does not count toward quorum.
+    Abstain,
+}
+
+/// A proposal open for voting.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Proposal<O> {
+    pub id: String,
+    pub subject: String,
+    pub options: Vec<O>,
+    pub quorum: Quorum,
+    pub deadline: Option<DateTime<Utc>>,
+    /// Informational only — `tally` does not restrict who may vote.
+    /// Empty means unrestricted.
+    #[serde(default)]
+    pub eligible_voters: Vec<String>,
+}
+
+/// Result of [`tally`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Outcome<O> {
+    Passed(O),
+    Rejected,
+    Pending,
+}
+
+/// Tally `ballots` against `options` under `quorum`.
+///
+/// - Under [`Quorum::LiberumVeto`], any bare [`Ballot::Veto`] (no
+///   alternative) rejects immediately, regardless of other ballots. Under
+///   every other quorum, a bare veto doesn't count toward any option —
+///   same as [`Ballot::Abstain`] — and does not block.
+/// - Otherwise, counts [`Ballot::Cast`] (and vetoes-with-an-alternative) per
+///   option, in `options` order, and returns the first option whose count
+///   meets the threshold `quorum` implies. Ties are broken by `options`
+///   order. Returns [`Outcome::Pending`] if no option has met the threshold
+///   yet — more ballots may still arrive.
+pub fn tally<O: Eq + Hash + Clone>(
+    options: &[O],
+    ballots: &[(String, Ballot<O>)],
+    quorum: &Quorum,
+) -> Outcome<O> {
+    if matches!(quorum, Quorum::LiberumVeto)
+        && ballots
+            .iter()
+            .any(|(_, b)| matches!(b, Ballot::Veto { alternative: None }))
+    {
+        return Outcome::Rejected;
+    }
+
+    let mut counts: HashMap<&O, usize> = HashMap::new();
+    let mut total_cast = 0usize;
+    for (_, ballot) in ballots {
+        let cast_for = match ballot {
+            Ballot::Cast(o) => Some(o),
+            Ballot::Veto {
+                alternative: Some(o),
+            } => Some(o),
+            // Only blocks under `LiberumVeto`, handled above; under every
+            // other quorum it's a no-op, same as `Abstain`.
+            Ballot::Veto { alternative: None } => None,
+            Ballot::Abstain => None,
+        };
+        if let Some(o) = cast_for {
+            *counts.entry(o).or_insert(0) += 1;
+            total_cast += 1;
+        }
+    }
+
+    for option in options {
+        let count = counts.get(option).copied().unwrap_or(0);
+        let needed = match quorum {
+            Quorum::AtLeast(n) => *n,
+            Quorum::Majority => total_cast / 2 + 1,
+            Quorum::Unanimous | Quorum::LiberumVeto => total_cast.max(1),
+        };
+        if count > 0 && count >= needed {
+            return Outcome::Passed(option.clone());
+        }
+    }
+
+    Outcome::Pending
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ballots<O: Clone>(pairs: &[(&str, Ballot<O>)]) -> Vec<(String, Ballot<O>)> {
+        pairs
+            .iter()
+            .map(|(voter, b)| ((*voter).to_string(), b.clone()))
+            .collect()
+    }
+
+    #[test]
+    fn at_least_n_passes_once_threshold_met() {
+        let options = ["yes", "no"];
+        let quorum = Quorum::AtLeast(2);
+
+        let one_vote = ballots(&[("a", Ballot::Cast("yes"))]);
+        assert_eq!(tally(&options, &one_vote, &quorum), Outcome::Pending);
+
+        let two_votes = ballots(&[("a", Ballot::Cast("yes")), ("b", Ballot::Cast("yes"))]);
+        assert_eq!(tally(&options, &two_votes, &quorum), Outcome::Passed("yes"));
+
+        let two_no = ballots(&[("a", Ballot::Cast("no")), ("b", Ballot::Cast("no"))]);
+        assert_eq!(tally(&options, &two_no, &quorum), Outcome::Passed("no"));
+    }
+
+    #[test]
+    fn matches_b00t_ipc_semantics_ported_to_bool_options() {
+        // b00t-ipc's Proposal::is_passed/is_rejected: yes>=2 passes, no>=2
+        // rejects, quorum default 2. Ported here with O = bool.
+        let options = [true, false];
+        let quorum = Quorum::AtLeast(2);
+
+        let mixed = ballots(&[
+            ("a", Ballot::Cast(true)),
+            ("b", Ballot::Cast(false)),
+            ("c", Ballot::Abstain),
+        ]);
+        assert_eq!(tally(&options, &mixed, &quorum), Outcome::Pending);
+    }
+
+    #[test]
+    fn majority_needs_more_than_half_of_cast_ballots() {
+        let options = ["a", "b", "c"];
+        let quorum = Quorum::Majority;
+
+        let three_two = ballots(&[
+            ("1", Ballot::Cast("a")),
+            ("2", Ballot::Cast("a")),
+            ("3", Ballot::Cast("b")),
+        ]);
+        // 2 of 3 cast ballots > half (1.5) -> "a" passes.
+        assert_eq!(tally(&options, &three_two, &quorum), Outcome::Passed("a"));
+
+        let tie = ballots(&[("1", Ballot::Cast("a")), ("2", Ballot::Cast("b"))]);
+        assert_eq!(tally(&options, &tie, &quorum), Outcome::Pending);
+    }
+
+    #[test]
+    fn unanimous_requires_every_cast_ballot_to_agree() {
+        let options = ["a", "b"];
+        let quorum = Quorum::Unanimous;
+
+        let split = ballots(&[("1", Ballot::Cast("a")), ("2", Ballot::Cast("b"))]);
+        assert_eq!(tally(&options, &split, &quorum), Outcome::Pending);
+
+        let agree = ballots(&[("1", Ballot::Cast("a")), ("2", Ballot::Cast("a"))]);
+        assert_eq!(tally(&options, &agree, &quorum), Outcome::Passed("a"));
+    }
+
+    #[test]
+    fn liberum_veto_blocks_on_any_bare_veto() {
+        let options = ["a", "b"];
+        let quorum = Quorum::LiberumVeto;
+
+        let vetoed = ballots(&[
+            ("1", Ballot::Cast("a")),
+            ("2", Ballot::Veto { alternative: None }),
+        ]);
+        assert_eq!(tally(&options, &vetoed, &quorum), Outcome::Rejected);
+    }
+
+    #[test]
+    fn bare_veto_only_blocks_under_liberum_veto_quorum() {
+        let options = ["a", "b"];
+        let quorum = Quorum::AtLeast(1);
+
+        // Same ballots as `liberum_veto_blocks_on_any_bare_veto`, but under
+        // a plain AtLeast quorum: the veto doesn't block, and "a" passes on
+        // its own single Cast vote.
+        let vetoed = ballots(&[
+            ("1", Ballot::Cast("a")),
+            ("2", Ballot::Veto { alternative: None }),
+        ]);
+        assert_eq!(tally(&options, &vetoed, &quorum), Outcome::Passed("a"));
+    }
+
+    #[test]
+    fn veto_with_alternative_counts_as_a_cast_vote() {
+        let options = ["a", "b"];
+        let quorum = Quorum::AtLeast(2);
+
+        let votes = ballots(&[
+            ("1", Ballot::Cast("b")),
+            (
+                "2",
+                Ballot::Veto {
+                    alternative: Some("b"),
+                },
+            ),
+        ]);
+        assert_eq!(tally(&options, &votes, &quorum), Outcome::Passed("b"));
+    }
+}

--- a/b00t-council/src/lib.rs
+++ b/b00t-council/src/lib.rs
@@ -1,0 +1,19 @@
+//! Shared abstraction layer for the b00t hive's player-to-player messaging.
+//!
+//! This crate does not replace any existing transport (Redis `AgentCoordinator`,
+//! NATS `b00t-mcp` tools, the in-process `b00t-ipc::MessageBus`, ...). It gives
+//! them a common, generic vocabulary — [`player::Player`] identity,
+//! [`message::Envelope`] as a serializable wrapper generic over payload type,
+//! [`observe::MessageSink`] for durable/observable recording, and
+//! [`council::tally`] for pluggable-quorum voting — so each subsystem can adopt
+//! pieces of it without a rewrite.
+
+pub mod council;
+pub mod message;
+pub mod observe;
+pub mod player;
+
+pub use council::{Ballot, Outcome, Proposal, Quorum, tally};
+pub use message::{Envelope, Recipient};
+pub use observe::{JsonlSink, MessageSink, NoopSink, ReplayFilter};
+pub use player::Player;

--- a/b00t-council/src/message.rs
+++ b/b00t-council/src/message.rs
@@ -1,0 +1,84 @@
+//! One generic, serializable envelope for player-to-player traffic.
+//!
+//! Deliberately generic over the payload type `T` rather than a closed enum —
+//! each existing subsystem's own payload shape (`CoordinationMessage` in
+//! `b00t-c0re-lib`, `b00t_ipc::Message`, the ad hoc JSON payload behind
+//! `b00t-mcp`'s `NotificationMessage`) can be wrapped in [`Envelope<T>`]
+//! without every subsystem first agreeing on one shared variant list.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+/// Where an [`Envelope`] is addressed.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Recipient {
+    /// A specific player, by [`crate::Player::player_id`].
+    Direct(String),
+    /// Every player currently listening.
+    Broadcast,
+    /// A named logical channel (team, mission, proposal, ...).
+    Channel(String),
+}
+
+/// A serializable, observable message between players.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Envelope<T> {
+    pub id: Uuid,
+    pub from: String,
+    pub to: Recipient,
+    pub sent_at: DateTime<Utc>,
+    /// True if `from` is a human player ([`crate::Player::is_human`]).
+    pub sender_is_player: bool,
+    pub body: T,
+}
+
+impl<T> Envelope<T> {
+    pub fn new(from: impl Into<String>, to: Recipient, sender_is_player: bool, body: T) -> Self {
+        Self {
+            id: Uuid::new_v4(),
+            from: from.into(),
+            to,
+            sent_at: Utc::now(),
+            sender_is_player,
+            body,
+        }
+    }
+}
+
+impl<T: Serialize> Envelope<T> {
+    /// Erase the payload type to `serde_json::Value` for storage in a
+    /// [`crate::MessageSink`], which is transport/payload-agnostic.
+    pub fn to_value_envelope(&self) -> serde_json::Result<Envelope<serde_json::Value>> {
+        Ok(Envelope {
+            id: self.id,
+            from: self.from.clone(),
+            to: self.to.clone(),
+            sent_at: self.sent_at,
+            sender_is_player: self.sender_is_player,
+            body: serde_json::to_value(&self.body)?,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trips_through_json_and_erases_payload_type() {
+        #[derive(Serialize, Deserialize, PartialEq, Debug)]
+        struct Ping {
+            n: u32,
+        }
+
+        let env = Envelope::new("agentA", Recipient::Direct("agentB".into()), false, Ping { n: 7 });
+        let erased = env.to_value_envelope().unwrap();
+        assert_eq!(erased.body["n"], 7);
+
+        let json = serde_json::to_string(&env).unwrap();
+        let back: Envelope<Ping> = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.body, Ping { n: 7 });
+        assert_eq!(back.from, "agentA");
+    }
+}

--- a/b00t-council/src/observe.rs
+++ b/b00t-council/src/observe.rs
@@ -1,0 +1,185 @@
+//! Durable, observable recording of [`Envelope`]s.
+//!
+//! Today none of the hive's messaging subsystems keep any durable record of
+//! what was sent — Redis `PUBLISH`, NATS core, and the in-process
+//! `b00t-ipc::MessageBus` are all fire-and-forget. [`JsonlSink`] closes that
+//! gap, following the same local-first append-only JSONL idiom already used
+//! by `b00t-lib-chat`'s `LocalLedgrrr` (`OpenOptions::create(true).append(true)`,
+//! replay-on-open, one JSON object per line).
+
+use crate::message::{Envelope, Recipient};
+use anyhow::{Context, Result};
+use std::io::{BufRead, BufReader, Write};
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+/// Default location for the hive's message log, mirroring the
+/// `~/.local/share/b00t/agents/` convention `crew_handler.rs` already uses
+/// for its `AgentStore`/`_crew_meta.json`.
+pub fn default_log_path() -> PathBuf {
+    dirs_next_home()
+        .join(".local")
+        .join("share")
+        .join("b00t")
+        .join("messages.jsonl")
+}
+
+// Kept tiny/dependency-free rather than pulling in the `dirs` crate just for
+// this: falls back to "." only if $HOME is unset, which should not happen in
+// any real hive session.
+fn dirs_next_home() -> PathBuf {
+    std::env::var_os("HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("."))
+}
+
+/// Optional filter for [`MessageSink::replay`].
+#[derive(Debug, Clone, Default)]
+pub struct ReplayFilter {
+    /// Only envelopes addressed to this `Recipient::Channel(..)` name — the
+    /// convention used to scope a vote's messages to `Channel(proposal_id)`.
+    pub channel: Option<String>,
+    /// Only envelopes from this player id.
+    pub from: Option<String>,
+}
+
+impl ReplayFilter {
+    pub fn channel(name: impl Into<String>) -> Self {
+        Self {
+            channel: Some(name.into()),
+            from: None,
+        }
+    }
+
+    fn matches(&self, env: &Envelope<serde_json::Value>) -> bool {
+        if let Some(channel) = &self.channel {
+            let is_match = matches!(&env.to, Recipient::Channel(c) if c == channel);
+            if !is_match {
+                return false;
+            }
+        }
+        if let Some(from) = &self.from {
+            if &env.from != from {
+                return false;
+            }
+        }
+        true
+    }
+}
+
+/// Where [`Envelope`]s get recorded so hive traffic is observable/replayable.
+pub trait MessageSink: Send + Sync {
+    fn record(&self, envelope: &Envelope<serde_json::Value>) -> Result<()>;
+    fn replay(&self, filter: &ReplayFilter) -> Result<Vec<Envelope<serde_json::Value>>>;
+}
+
+/// Default sink: records nothing. Lets existing callers (e.g.
+/// `b00t-ipc::MessageBus`) adopt the `MessageSink` plumbing without changing
+/// behavior until a real sink is supplied.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct NoopSink;
+
+impl MessageSink for NoopSink {
+    fn record(&self, _envelope: &Envelope<serde_json::Value>) -> Result<()> {
+        Ok(())
+    }
+
+    fn replay(&self, _filter: &ReplayFilter) -> Result<Vec<Envelope<serde_json::Value>>> {
+        Ok(Vec::new())
+    }
+}
+
+/// Append-only JSONL sink — one [`Envelope<serde_json::Value>`] per line.
+pub struct JsonlSink {
+    path: PathBuf,
+    lock: Mutex<()>,
+}
+
+impl JsonlSink {
+    pub fn at(path: impl AsRef<Path>) -> Self {
+        Self {
+            path: path.as_ref().to_path_buf(),
+            lock: Mutex::new(()),
+        }
+    }
+
+    pub fn default_location() -> Self {
+        Self::at(default_log_path())
+    }
+}
+
+impl MessageSink for JsonlSink {
+    fn record(&self, envelope: &Envelope<serde_json::Value>) -> Result<()> {
+        let _guard = self.lock.lock().unwrap();
+        if let Some(parent) = self.path.parent() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("creating {parent:?} for message log"))?;
+        }
+        let mut file = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&self.path)
+            .with_context(|| format!("opening message log {:?}", self.path))?;
+        let line = serde_json::to_string(envelope)?;
+        writeln!(file, "{line}").with_context(|| format!("appending to {:?}", self.path))?;
+        Ok(())
+    }
+
+    fn replay(&self, filter: &ReplayFilter) -> Result<Vec<Envelope<serde_json::Value>>> {
+        let _guard = self.lock.lock().unwrap();
+        if !self.path.exists() {
+            return Ok(Vec::new());
+        }
+        let file = std::fs::File::open(&self.path)
+            .with_context(|| format!("opening message log {:?}", self.path))?;
+        let mut out = Vec::new();
+        for line in BufReader::new(file).lines() {
+            let line = line?;
+            if line.trim().is_empty() {
+                continue;
+            }
+            let env: Envelope<serde_json::Value> = serde_json::from_str(&line)
+                .with_context(|| format!("parsing message log line: {line}"))?;
+            if filter.matches(&env) {
+                out.push(env);
+            }
+        }
+        Ok(out)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::message::Envelope;
+
+    fn tmp_path(name: &str) -> PathBuf {
+        std::env::temp_dir().join(format!("b00t-council-test-{}-{}.jsonl", name, std::process::id()))
+    }
+
+    #[test]
+    fn appends_and_replays_filtered_by_channel() {
+        let path = tmp_path("replay");
+        let _ = std::fs::remove_file(&path);
+        let sink = JsonlSink::at(&path);
+
+        let a = Envelope::new("agentA", Recipient::Channel("prop-1".into()), false, serde_json::json!({"n": 1}));
+        let b = Envelope::new("agentB", Recipient::Channel("prop-2".into()), false, serde_json::json!({"n": 2}));
+        sink.record(&a).unwrap();
+        sink.record(&b).unwrap();
+
+        let only_prop1 = sink.replay(&ReplayFilter::channel("prop-1")).unwrap();
+        assert_eq!(only_prop1.len(), 1);
+        assert_eq!(only_prop1[0].from, "agentA");
+
+        std::fs::remove_file(&path).unwrap();
+    }
+
+    #[test]
+    fn noop_sink_records_nothing_observable() {
+        let sink = NoopSink;
+        let env = Envelope::new("x", Recipient::Broadcast, false, serde_json::json!(null));
+        sink.record(&env).unwrap();
+        assert!(sink.replay(&ReplayFilter::default()).unwrap().is_empty());
+    }
+}

--- a/b00t-council/src/player.rs
+++ b/b00t-council/src/player.rs
@@ -1,0 +1,12 @@
+//! Identity abstraction over whatever struct a subsystem already uses to
+//! represent an agent or human ("player"). Several existing types already
+//! carry an `is_player: bool` field that nothing reads — implementing this
+//! trait for them is what activates it.
+
+/// A participant in hive messaging/voting — software agent or human.
+pub trait Player {
+    /// Stable identifier used as the `from`/`to`/voter key in messages and ballots.
+    fn player_id(&self) -> &str;
+    /// True if this player represents a human, not a software agent.
+    fn is_human(&self) -> bool;
+}

--- a/b00t-ipc/Cargo.toml
+++ b/b00t-ipc/Cargo.toml
@@ -13,6 +13,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }
 anyhow = { workspace = true }
+b00t-council = { path = "../b00t-council" }
 
 # IPC-specific
 rmp-serde = "1.3"  # msgpack serialization

--- a/b00t-ipc/src/lib.rs
+++ b/b00t-ipc/src/lib.rs
@@ -43,6 +43,7 @@ pub mod dbus_client;
 pub mod dbus_interface;
 
 use anyhow::{Context, Result};
+use b00t_council::{Ballot, Envelope, MessageSink, NoopSink, Outcome, Quorum, Recipient, tally};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -179,6 +180,30 @@ pub enum Message {
     },
 }
 
+/// Best-effort `(from, to)` for recording a [`Message`] as an [`Envelope`] —
+/// variants without an explicit recipient (broadcasts, status, crew-wide
+/// announcements) route to [`Recipient::Broadcast`].
+fn message_route(msg: &Message) -> (String, Recipient) {
+    match msg {
+        Message::Handshake { from, to, .. }
+        | Message::HandshakeReply { from, to, .. }
+        | Message::Delegate { from, to, .. } => (from.clone(), Recipient::Direct(to.clone())),
+        Message::Vote {
+            from, proposal_id, ..
+        } => (from.clone(), Recipient::Channel(proposal_id.clone())),
+        Message::CrewForm { initiator, .. } => (initiator.clone(), Recipient::Broadcast),
+        Message::Status { agent_id, .. } => (agent_id.clone(), Recipient::Broadcast),
+        Message::Negotiate { from, .. } | Message::Broadcast { from, .. } => {
+            (from.clone(), Recipient::Broadcast)
+        }
+        Message::Ahoy { from, ahoy_id, .. }
+        | Message::Apply { from, ahoy_id, .. }
+        | Message::Award { from, ahoy_id, .. } => {
+            (from.clone(), Recipient::Channel(ahoy_id.clone()))
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub enum VoteChoice {
     Yes,
@@ -193,7 +218,10 @@ pub struct Proposal {
     pub description: String,
     pub initiator: String,
     pub votes: HashMap<String, VoteChoice>,
-    pub quorum: usize,
+    /// Pluggable pass/reject threshold — see [`b00t_council::tally`].
+    /// Default `AtLeast(2)` preserves this type's original "2 yes votes"
+    /// behavior exactly.
+    pub quorum: Quorum,
     pub expires_at: Option<std::time::SystemTime>,
 }
 
@@ -204,7 +232,7 @@ impl Proposal {
             description: description.into(),
             initiator: initiator.into(),
             votes: HashMap::new(),
-            quorum: 2, // Simple majority
+            quorum: Quorum::AtLeast(2),
             expires_at: None,
         }
     }
@@ -213,22 +241,30 @@ impl Proposal {
         self.votes.insert(agent, vote);
     }
 
-    pub fn is_passed(&self) -> bool {
-        let yes_votes = self
+    /// Tally `self.votes` as a two-option ballot (`true` = yes, `false` =
+    /// no; `Abstain` doesn't count toward quorum) via [`b00t_council::tally`].
+    fn outcome(&self) -> Outcome<bool> {
+        let ballots: Vec<(String, Ballot<bool>)> = self
             .votes
-            .values()
-            .filter(|v| matches!(v, VoteChoice::Yes))
-            .count();
-        yes_votes >= self.quorum
+            .iter()
+            .filter_map(|(agent, vote)| {
+                let ballot = match vote {
+                    VoteChoice::Yes => Ballot::Cast(true),
+                    VoteChoice::No => Ballot::Cast(false),
+                    VoteChoice::Abstain => return None,
+                };
+                Some((agent.clone(), ballot))
+            })
+            .collect();
+        tally(&[true, false], &ballots, &self.quorum)
+    }
+
+    pub fn is_passed(&self) -> bool {
+        matches!(self.outcome(), Outcome::Passed(true))
     }
 
     pub fn is_rejected(&self) -> bool {
-        let no_votes = self
-            .votes
-            .values()
-            .filter(|v| matches!(v, VoteChoice::No))
-            .count();
-        no_votes >= self.quorum
+        matches!(self.outcome(), Outcome::Passed(false))
     }
 }
 
@@ -238,16 +274,28 @@ pub struct MessageBus {
     proposals: Arc<RwLock<HashMap<String, Proposal>>>,
     tx: mpsc::UnboundedSender<Message>,
     rx: Arc<RwLock<mpsc::UnboundedReceiver<Message>>>,
+    /// Where every sent [`Message`] is recorded for observability. Defaults
+    /// to [`NoopSink`], so existing callers see no behavior change unless
+    /// they opt in via [`MessageBus::with_sink`].
+    sink: Arc<dyn MessageSink>,
 }
 
 impl MessageBus {
     pub async fn new() -> Result<Self> {
+        Self::with_sink(Arc::new(NoopSink)).await
+    }
+
+    /// Same as [`MessageBus::new`], but every [`Message`] sent through this
+    /// bus is also recorded via `sink` (e.g. a `b00t_council::JsonlSink`),
+    /// making traffic durable/observable instead of purely in-process.
+    pub async fn with_sink(sink: Arc<dyn MessageSink>) -> Result<Self> {
         let (tx, rx) = mpsc::unbounded_channel();
         Ok(Self {
             agents: Arc::new(RwLock::new(HashMap::new())),
             proposals: Arc::new(RwLock::new(HashMap::new())),
             tx,
             rx: Arc::new(RwLock::new(rx)),
+            sink,
         })
     }
 
@@ -258,8 +306,15 @@ impl MessageBus {
         Ok(())
     }
 
-    /// Send a message
+    /// Send a message, recording it through this bus's [`MessageSink`]
+    /// before enqueueing it.
     pub async fn send(&self, msg: Message) -> Result<()> {
+        let (from, to) = message_route(&msg);
+        let envelope = Envelope::new(from, to, false, serde_json::to_value(&msg)?);
+        // Sink failures are observability-only — never block message delivery.
+        if let Err(e) = self.sink.record(&envelope) {
+            eprintln!("MessageBus sink record failed: {e:#}");
+        }
         self.tx.send(msg).context("Failed to send message to bus")?;
         Ok(())
     }

--- a/b00t-mcp/Cargo.toml
+++ b/b00t-mcp/Cargo.toml
@@ -38,6 +38,7 @@ b00t-cli = { workspace = true }
 b00t-c0re-lib = { workspace = true }
 b00t-reflect-types = { workspace = true }
 b00t-chat = { workspace = true }
+b00t-council = { path = "../b00t-council" }
 shellexpand = "3.1.0"
 shlex = "1.3"
 dirs = "6.0"

--- a/b00t-mcp/src/mcp_tools.rs
+++ b/b00t-mcp/src/mcp_tools.rs
@@ -2,6 +2,7 @@ use crate::clap_reflection::{McpCommandRegistry, McpExecutor, McpReflection};
 use crate::impl_mcp_tool;
 use crate::tools::pipeline::BPipelineCommand;
 use anyhow::Result;
+use b00t_council::MessageSink;
 use clap::Parser;
 use serde_json::{Map, Value, json};
 use std::collections::HashMap;
@@ -359,6 +360,12 @@ impl crate::clap_reflection::McpExecutor for AgentMessageCommand {
             .and_then(|v| v.as_str())
             .unwrap_or("message");
 
+        record_message(
+            &caller_agent_id(),
+            b00t_council::Recipient::Direct(to_agent.to_string()),
+            serde_json::json!({"subject": subject, "content": content}),
+        );
+
         let rt = tokio::runtime::Runtime::new()?;
         rt.block_on(async {
             let client = get_nats_client().await?;
@@ -546,20 +553,63 @@ impl crate::clap_reflection::McpExecutor for AgentVoteCreateCommand {
             .get("description")
             .and_then(|v| v.as_str())
             .unwrap_or("");
+        let vote_type = params
+            .get("vote_type")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        let deadline_minutes = params.get("deadline").and_then(|v| v.as_u64()).unwrap_or(0);
+        let voters: Vec<String> = params
+            .get("voters")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .split(',')
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .collect();
 
+        // `options` arrives as a JSON array (per the tool's own help text);
+        // fall back to a single literal option if it isn't valid JSON so a
+        // caller passing a bare string doesn't just fail outright.
+        let raw_options = params
+            .get("options")
+            .and_then(|v| v.as_str())
+            .unwrap_or("[]");
+        let options: Vec<String> = serde_json::from_str(raw_options)
+            .unwrap_or_else(|_| vec![raw_options.to_string()]);
+
+        let proposal = b00t_council::Proposal {
+            id: uuid::Uuid::new_v4().to_string(),
+            subject: subject.to_string(),
+            options,
+            quorum: quorum_for_vote_type(vote_type),
+            deadline: (deadline_minutes > 0)
+                .then(|| chrono::Utc::now() + chrono::Duration::minutes(deadline_minutes as i64)),
+            eligible_voters: voters,
+        };
+
+        record_message(
+            &caller_agent_id(),
+            b00t_council::Recipient::Channel(proposal.id.clone()),
+            serde_json::json!({"kind": "proposal", "description": description, "proposal": proposal}),
+        );
+
+        let proposal_id = proposal.id.clone();
         let rt = tokio::runtime::Runtime::new()?;
         rt.block_on(async {
             let client = get_nats_client().await?;
             let notification = NotificationMessage::new(
                 "vote",
                 "create",
-                serde_json::json!({"subject": subject, "description": description}),
+                serde_json::json!({"proposal_id": proposal_id, "subject": subject, "description": description}),
             );
             client
                 .publish_notification(&notification)
                 .await
                 .map_err(|e| anyhow::anyhow!("Failed to create vote: {}", e))?;
-            Ok(format!("Vote created: {}", subject))
+            Ok(format!(
+                "Vote created: {} (proposal_id={}) — submit with agent_vote_submit, resolve with agent_vote_tally",
+                subject, proposal_id
+            ))
         })
     }
 }
@@ -601,6 +651,17 @@ impl crate::clap_reflection::McpExecutor for AgentVoteSubmitCommand {
             .and_then(|v| v.as_str())
             .unwrap_or("unknown");
         let vote = params.get("vote").and_then(|v| v.as_str()).unwrap_or("");
+        let reasoning = params
+            .get("reasoning")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+        let voter = caller_agent_id();
+
+        record_message(
+            &voter,
+            b00t_council::Recipient::Channel(proposal_id.to_string()),
+            serde_json::json!({"kind": "vote", "voter": voter, "choice": vote, "reasoning": reasoning}),
+        );
 
         let rt = tokio::runtime::Runtime::new()?;
         rt.block_on(async {
@@ -614,8 +675,116 @@ impl crate::clap_reflection::McpExecutor for AgentVoteSubmitCommand {
                 .publish_notification(&notification)
                 .await
                 .map_err(|e| anyhow::anyhow!("Failed to submit vote: {}", e))?;
-            Ok(format!("Vote submitted for proposal {}", proposal_id))
+            Ok(format!(
+                "Vote submitted for proposal {} — check outcome with agent_vote_tally",
+                proposal_id
+            ))
         })
+    }
+}
+
+/// MCP command for tallying a vote — replays the durable message log for a
+/// proposal's `Channel(proposal_id)` traffic and resolves it via
+/// `b00t_council::tally`. This is the fix for the two stub tools above: a
+/// vote now has an actual, checkable outcome instead of two indistinguishable
+/// NATS notifications.
+#[derive(Parser, Clone)]
+pub struct AgentVoteTallyCommand {
+    #[arg(help = "Proposal ID")]
+    pub proposal_id: String,
+}
+
+impl crate::clap_reflection::McpReflection for AgentVoteTallyCommand {
+    fn mcp_tool_name() -> String {
+        "agent_vote_tally".to_string()
+    }
+    fn command_path() -> Vec<String> {
+        vec![
+            "agent".to_string(),
+            "vote".to_string(),
+            "tally".to_string(),
+        ]
+    }
+}
+
+impl crate::clap_reflection::McpExecutor for AgentVoteTallyCommand {
+    fn execute_mcp_call(
+        params: &std::collections::HashMap<String, serde_json::Value>,
+    ) -> anyhow::Result<String> {
+        let proposal_id = params
+            .get("proposal_id")
+            .and_then(|v| v.as_str())
+            .unwrap_or("unknown");
+
+        let envelopes = message_sink()
+            .replay(&b00t_council::ReplayFilter::channel(proposal_id))
+            .map_err(|e| anyhow::anyhow!("Failed to replay message log: {}", e))?;
+
+        let mut proposal: Option<b00t_council::Proposal<String>> = None;
+        let mut ballots: Vec<(String, b00t_council::Ballot<String>)> = Vec::new();
+
+        for env in &envelopes {
+            let kind = env.body.get("kind").and_then(|v| v.as_str()).unwrap_or("");
+            match kind {
+                "proposal" => {
+                    if let Some(p) = env.body.get("proposal") {
+                        if let Ok(p) = serde_json::from_value::<b00t_council::Proposal<String>>(p.clone()) {
+                            proposal = Some(p);
+                        }
+                    }
+                }
+                "vote" => {
+                    let voter = env
+                        .body
+                        .get("voter")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or(&env.from)
+                        .to_string();
+                    let choice = env.body.get("choice").and_then(|v| v.as_str()).unwrap_or("");
+                    let ballot = if choice.eq_ignore_ascii_case("veto") {
+                        b00t_council::Ballot::Veto { alternative: None }
+                    } else if choice.eq_ignore_ascii_case("abstain") {
+                        b00t_council::Ballot::Abstain
+                    } else {
+                        b00t_council::Ballot::Cast(choice.to_string())
+                    };
+                    ballots.push((voter, ballot));
+                }
+                _ => {}
+            }
+        }
+
+        let Some(proposal) = proposal else {
+            return Ok(format!(
+                "No proposal found for {} — has agent_vote_create been called for it?",
+                proposal_id
+            ));
+        };
+
+        let outcome = b00t_council::tally(&proposal.options, &ballots, &proposal.quorum);
+        let breakdown: std::collections::HashMap<&str, usize> =
+            ballots.iter().fold(std::collections::HashMap::new(), |mut acc, (_, b)| {
+                let key = match b {
+                    b00t_council::Ballot::Cast(o) => o.as_str(),
+                    b00t_council::Ballot::Veto { .. } => "veto",
+                    b00t_council::Ballot::Abstain => "abstain",
+                };
+                *acc.entry(key).or_insert(0) += 1;
+                acc
+            });
+
+        let outcome_str = match &outcome {
+            b00t_council::Outcome::Passed(option) => format!("Passed({option})"),
+            b00t_council::Outcome::Rejected => "Rejected".to_string(),
+            b00t_council::Outcome::Pending => "Pending".to_string(),
+        };
+
+        Ok(format!(
+            "Proposal {} ({}): {outcome_str} — {} ballots cast, breakdown: {breakdown:?}",
+            proposal_id,
+            proposal.subject,
+            ballots.len(),
+        ))
     }
 }
 
@@ -964,6 +1133,12 @@ impl crate::clap_reflection::McpExecutor for AgentNotifyCommand {
             .get("details")
             .map(|v| v.clone())
             .unwrap_or(serde_json::Value::Null);
+
+        record_message(
+            source,
+            b00t_council::Recipient::Broadcast,
+            serde_json::json!({"event_type": event_type, "details": details}),
+        );
 
         let rt = tokio::runtime::Runtime::new()?;
         rt.block_on(async {
@@ -1957,6 +2132,11 @@ pub static TOOL_CATALOG: &[ToolCatalogEntry] = &[
         subcommand: "agent vote submit",
     },
     ToolCatalogEntry {
+        name: "b00t_agent_vote_tally",
+        description: "Resolve a vote's outcome from the durable message log",
+        subcommand: "agent vote tally",
+    },
+    ToolCatalogEntry {
         name: "b00t_session_init",
         description: "Initialize a b00t session",
         subcommand: "session init",
@@ -2380,6 +2560,7 @@ pub fn create_full_mcp_registry() -> McpCommandRegistry {
         .register::<AgentProgressCommand>()
         .register::<AgentVoteCreateCommand>()
         .register::<AgentVoteSubmitCommand>()
+        .register::<AgentVoteTallyCommand>()
         .register::<DelegateDatumCommand>()
         .register::<AgentWaitCommand>()
         .register::<AgentNotifyCommand>()
@@ -2443,6 +2624,61 @@ lazy_static::lazy_static! {
 
 lazy_static::lazy_static! {
     static ref NATS_CLIENT: tokio::sync::Mutex<Option<b00t_chat::ChatClient>> = tokio::sync::Mutex::new(None);
+}
+
+// ┌──────────────────────────────────────────────────────────────────────────────┐
+// │ b00t-council wiring: durable/observable player messages + real vote tally     │
+// └──────────────────────────────────────────────────────────────────────────────┘
+
+/// Durable message/vote log, shared by the agent_message/notify/vote MCP
+/// tools. NATS delivery is unchanged (still fire-and-forget) — this adds the
+/// durable record NATS never provided. Path overridable via
+/// `B00T_MESSAGE_LOG_PATH` (used by tests to avoid writing into a real
+/// `~/.local/share/b00t/messages.jsonl`).
+fn message_sink() -> b00t_council::JsonlSink {
+    match std::env::var_os("B00T_MESSAGE_LOG_PATH") {
+        Some(path) => b00t_council::JsonlSink::at(path),
+        None => b00t_council::JsonlSink::default_location(),
+    }
+}
+
+/// Best-effort identity of whichever process is calling these MCP tools.
+/// None of the agent_message/notify/vote tool params carry an explicit
+/// sender id today, so this is the fallback used to attribute recorded
+/// envelopes and to look up `sender_is_player`.
+fn caller_agent_id() -> String {
+    std::env::var("B00T_AGENT_ID")
+        .or_else(|_| std::env::var("USER"))
+        .unwrap_or_else(|_| "mcp-anonymous".to_string())
+}
+
+/// Record one [`b00t_council::Envelope`] to the durable log. Failures are
+/// observability-only and never fail the caller's MCP tool invocation —
+/// mirrors `b00t-ipc::MessageBus::send`'s non-blocking sink write.
+fn record_message<T: serde::Serialize>(from: &str, to: b00t_council::Recipient, body: T) {
+    let sender_is_player = b00t_cli::commands::crew_handler::is_player(from);
+    let envelope = b00t_council::Envelope::new(from, to, sender_is_player, body);
+    match envelope.to_value_envelope() {
+        Ok(erased) => {
+            if let Err(e) = message_sink().record(&erased) {
+                eprintln!("b00t-mcp: message log record failed: {e:#}");
+            }
+        }
+        Err(e) => eprintln!("b00t-mcp: message log serialize failed: {e:#}"),
+    }
+}
+
+/// `vote_type` (from `AgentVoteCreateCommand`) -> `b00t_council::Quorum`.
+/// `"veto_capable"` matches `b00t_c0re_lib::agent_coordination::VotingType::
+/// VetoCapable`'s naming. Unrecognized/absent types fall back to
+/// `AtLeast(2)`, matching `b00t-ipc::Proposal`'s original default.
+fn quorum_for_vote_type(vote_type: &str) -> b00t_council::Quorum {
+    match vote_type {
+        "unanimous" => b00t_council::Quorum::Unanimous,
+        "majority" | "single_choice" | "ranked_choice" => b00t_council::Quorum::Majority,
+        "veto_capable" => b00t_council::Quorum::LiberumVeto,
+        _ => b00t_council::Quorum::AtLeast(2),
+    }
 }
 
 async fn get_nats_client() -> anyhow::Result<b00t_chat::ChatClient> {

--- a/b00t-mcp/tests/council_wiring_test.rs
+++ b/b00t-mcp/tests/council_wiring_test.rs
@@ -1,0 +1,127 @@
+//! End-to-end check of the b00t-council wiring: agent_vote_create /
+//! agent_vote_submit / agent_vote_tally going from stub NATS pings to a
+//! real, durable, tallyable vote.
+//!
+//! NATS publish is not reachable in a sandboxed test environment, so each
+//! `execute_mcp_call` (which does `record → NATS publish`) is run on its own
+//! thread with a bounded join timeout: a NATS timeout/error is expected and
+//! tolerated here, but the durable record it wrote *before* attempting NATS
+//! is not — `agent_vote_tally` (which never touches NATS) must see it and
+//! resolve a real outcome.
+
+use b00t_mcp::mcp_tools::{AgentVoteCreateCommand, AgentVoteSubmitCommand, AgentVoteTallyCommand};
+use b00t_mcp::clap_reflection::McpExecutor;
+use serde_json::json;
+use std::collections::HashMap;
+use std::time::Duration;
+
+fn call<T: McpExecutor>(params: HashMap<String, serde_json::Value>) -> anyhow::Result<String> {
+    // Bound how long we wait for NATS (unreachable in this sandbox) so a
+    // stalled connect can't hang the test suite.
+    let (tx, rx) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        let _ = tx.send(T::execute_mcp_call(&params));
+    });
+    match rx.recv_timeout(Duration::from_secs(15)) {
+        Ok(result) => result,
+        Err(_) => anyhow::bail!("timed out waiting for NATS (expected without a broker)"),
+    }
+}
+
+fn params(pairs: &[(&str, serde_json::Value)]) -> HashMap<String, serde_json::Value> {
+    pairs
+        .iter()
+        .map(|(k, v)| (k.to_string(), v.clone()))
+        .collect()
+}
+
+#[test]
+fn vote_create_submit_tally_round_trip_is_durable_and_resolves() {
+    let log_path = std::env::temp_dir().join(format!(
+        "b00t-mcp-council-test-{}.jsonl",
+        std::process::id()
+    ));
+    let _ = std::fs::remove_file(&log_path);
+    // SAFETY: single-threaded test process section (no other test in this
+    // binary touches B00T_MESSAGE_LOG_PATH/B00T_AGENT_ID concurrently).
+    unsafe {
+        std::env::set_var("B00T_MESSAGE_LOG_PATH", &log_path);
+    }
+
+    // 1. Create the proposal. NATS publish is expected to fail/timeout here
+    // (no broker) — that's fine, the durable record happens first.
+    let create_result = call::<AgentVoteCreateCommand>(params(&[
+        ("subject", json!("Adopt b00t-council")),
+        ("description", json!("Durable, generic-quorum voting")),
+        ("options", json!(r#"["yes","no"]"#)),
+        ("vote_type", json!("")), // -> default AtLeast(2)
+        ("deadline", json!(0)),
+        ("voters", json!("alice,bob")),
+    ]));
+    let proposal_id = match &create_result {
+        Ok(msg) => msg
+            .split("proposal_id=")
+            .nth(1)
+            .and_then(|s| s.split(')').next())
+            .expect("create response should contain proposal_id=<id>")
+            .to_string(),
+        Err(_) => {
+            // NATS unreachable — recover the id from what was actually recorded.
+            let contents = std::fs::read_to_string(&log_path).expect("log should exist");
+            let first: serde_json::Value =
+                serde_json::from_str(contents.lines().next().expect("one record")).unwrap();
+            match &first["to"] {
+                serde_json::Value::Object(o) => o["Channel"].as_str().unwrap().to_string(),
+                _ => panic!("expected Channel recipient"),
+            }
+        }
+    };
+
+    // 2. Two conflicting-then-agreeing votes from two distinct players.
+    unsafe {
+        std::env::set_var("B00T_AGENT_ID", "alice");
+    }
+    let _ = call::<AgentVoteSubmitCommand>(params(&[
+        ("proposal_id", json!(proposal_id.clone())),
+        ("vote", json!("yes")),
+    ]));
+
+    unsafe {
+        std::env::set_var("B00T_AGENT_ID", "bob");
+    }
+    let _ = call::<AgentVoteSubmitCommand>(params(&[
+        ("proposal_id", json!(proposal_id.clone())),
+        ("vote", json!("yes")),
+    ]));
+
+    // 3. Tally never touches NATS — this must succeed unconditionally and
+    // resolve a real outcome, not a canned string.
+    let tally = call::<AgentVoteTallyCommand>(params(&[(
+        "proposal_id",
+        json!(proposal_id.clone()),
+    )]))
+    .expect("agent_vote_tally must not depend on NATS");
+
+    assert!(
+        tally.contains("Passed(yes)"),
+        "expected the two 'yes' votes to pass under the default AtLeast(2) quorum, got: {tally}"
+    );
+
+    // 4. The log is genuinely observable: 3 envelopes (1 proposal + 2 votes),
+    // each carrying real sender/player attribution.
+    let contents = std::fs::read_to_string(&log_path).unwrap();
+    let lines: Vec<&str> = contents.lines().collect();
+    assert_eq!(lines.len(), 3, "expected proposal + 2 votes recorded, got: {contents}");
+    for line in &lines {
+        let env: serde_json::Value = serde_json::from_str(line).unwrap();
+        assert!(env["id"].is_string());
+        assert!(env["sent_at"].is_string());
+        assert!(env["sender_is_player"].is_boolean());
+    }
+
+    let _ = std::fs::remove_file(&log_path);
+    unsafe {
+        std::env::remove_var("B00T_MESSAGE_LOG_PATH");
+        std::env::remove_var("B00T_AGENT_ID");
+    }
+}


### PR DESCRIPTION
## Summary

The hive currently has 5+ parallel, mostly-disconnected agent-messaging subsystems (Redis `AgentCoordinator`, NATS `b00t-mcp` tools, in-process `b00t-ipc::MessageBus`, dead `orchestrator::agent_messaging`, `HiveTransport`) and none of them keep a durable record of what was sent. The `agent_vote_create`/`agent_vote_submit` MCP tools were pure stubs — fire a NATS notification, return a canned string, no proposal storage, no tally.

This adds `b00t-council`: a generic, minimal-dependency crate providing `Player` identity, a serializable `Envelope<T>` generic over payload type, a `MessageSink` trait (`JsonlSink`/`NoopSink`) for durable/observable message logging, and pluggable-quorum voting (`Majority`/`AtLeast(n)`/`Unanimous`/`LiberumVeto`) via `tally()`. Existing subsystems adopt pieces of it rather than being rewritten:

- `b00t-ipc::Proposal::is_passed`/`is_rejected` now delegate to `tally()` instead of a hardcoded "2 yes votes" check (behavior-preserving: default quorum is `AtLeast(2)`); `MessageBus` gets an optional `MessageSink` hook.
- `b00t-mcp`'s `agent_vote_create`/`agent_vote_submit` build real `Proposal`/`Ballot` data and record it durably; new `agent_vote_tally` tool resolves a real, checkable outcome by replaying the log — the stub-to-real fix. `agent_message`/`agent_notify` also record through the same `JsonlSink`.
- `b00t_c0re_hierarchy::roles::Agent` implements `Player` — the first behavioral use of its previously-dead `is_player` field; `b00t-cli`'s `crew_handler` gains a minimal `pub is_player()` lookup that `b00t-mcp` uses to attribute senders.
- `Quorum::LiberumVeto`: any bare `Veto` only force-rejects under this quorum specifically (previously a global, always-on rule regardless of quorum type) — matches `b00t_c0re_lib::VotingType::VetoCapable`'s naming.

Deliberately **not** touched in this pass (documented as later, non-blocking adopters of the same traits): the Redis `AgentCoordinator` path, dead `orchestrator::agent_messaging`, and the `router.rs`/`HiveTransport` broker abstraction.

## Test plan

- [x] `cargo test -p b00t-council` — 10/10 (Majority/AtLeast(n)/Unanimous/LiberumVeto quorum coverage, envelope round-trip, JSONL sink append+replay)
- [x] `cargo test -p b00t-ipc` — 6/6 unchanged (regression guard — `test_voting`/`test_proposal_lifecycle` still pass after the `tally()` refactor)
- [x] `cargo test -p b00t-mcp --test council_wiring_test` — new integration test drives the real `vote_create → vote_submit ×2 → vote_tally` MCP path end-to-end and confirms a durable, non-canned `Passed(yes)` outcome with 3 attributed envelopes on disk
- [x] `cargo test -p b00t-cli --lib` — 1513 passed, 0 failed, 4 ignored (pre-push gate)
- [x] `cargo check --workspace` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)