### PR TITLE
docs(#910): learn-topic knowledge map — ufo-types canonical pointers

### DIFF
--- a/_b00t_/learn/b00t-datums.md
+++ b/_b00t_/learn/b00t-datums.md
@@ -1,2 +1,5 @@
 ---
 datum key shadowing: scan_datums_recursive dedups by key with rank .tomllmd>.tomllm>.toml — assimilate writes <topic>.cli.toml siblings that silently lose to handwritten datums/<topic>.cli.tomllm; assimilate should detect+merge existing keys, not mint duplicates
+
+---
+canonical types: ufo-types::stereotype (UfoStereotype) — DatumType stereotype/implies() hierarchy now belongs to the crate, not hand-rolled shapes here.

--- a/_b00t_/learn/b00t.md
+++ b/_b00t_/learn/b00t.md
@@ -19,6 +19,9 @@ governance gate architecture: 3-return gates (Allow/Deny/Hook) with Eisenhower 4
 compound-engineering parity: b00t covers 80% of everyinc/compound-engineering-plugin workflow via skills+CLI+MCP. Gaps: doc-review skill, ideate command, time-windowed health. b00t strengths CE lacks: typed pipelines, WASM codegen, twin simulation, container stack. Architecture is Rust CLI vs TS plugin — complementary not competitive.
 
 ---
+canonical types: ufo-types::dare (DaredProposal, OodaStateMachine, OodaPhase, OodaGuards) — OODA state-change workflow types now belong to the crate, not hand-rolled shapes here.
+
+---
 shortcut tokens: Prefer idiomatic command words like sh over symbolic or terse aliases; avoids bash history expansion and ambiguous short-code semantics.
 
 ---

--- a/_b00t_/learn/blessing-manifest.md
+++ b/_b00t_/learn/blessing-manifest.md
@@ -1,2 +1,5 @@
 ---
 role datums need depends_on BEFORE testing manifest — empty required block is the symptom; fix: add depends_on to *.role.toml then re-run b00t blessing --manifest
+
+---
+canonical types: ufo-types::capability (AgentCapability, CapabilityDomain, Task) + ufo-types::stereotype (Stereotyped) — agent identity/capability introspection now belongs to the crate, not hand-rolled shapes here.

--- a/_b00t_/learn/datum-generator.md
+++ b/_b00t_/learn/datum-generator.md
@@ -1,2 +1,5 @@
 ---
 datum-generator: man page section 3 (library functions) incorrectly generates type=cli datums — guard with: man -f <cmd> | grep -v '(3)' or check man page section before classifying as cli
+
+---
+canonical types: ufo-types::stereotype (UfoStereotype) — DatumType stereotype/implies() hierarchy now belongs to the crate, not hand-rolled shapes here.

--- a/_b00t_/learn/datum.md
+++ b/_b00t_/learn/datum.md
@@ -1,2 +1,5 @@
 ---
 STOP-SEQUENCES: Stop sequences in input do NOT cause models to stop reading — they are only checked against output tokens. Created datum documenting 12 model families, tokenization analysis, and experiment protocol for Issue #96.
+
+---
+canonical types: ufo-types::stereotype (UfoStereotype) — DatumType stereotype/implies() hierarchy now belongs to the crate, not hand-rolled shapes here.

--- a/_b00t_/learn/desired-state-2026-07.md
+++ b/_b00t_/learn/desired-state-2026-07.md
@@ -25,6 +25,7 @@
 - **Governance**: Auto-selection by confidence. Operator approval for mutations.
 - **Ralph loop**: Agent REPL outer-loop for autonomous execution.
 - **Ooda as Plan subtype**: Not a Skill. Teal rectangle (Tool class).
+- **Canonical types**: `ufo-types::dare` (DaredProposal, OodaStateMachine, OodaPhase, OodaGuards) — OODA state-change workflow types now belong to the crate, not hand-rolled shapes here.
 
 ## Build / Deploy
 - **b00t-buildd**: Background daemon watches git diff, maps files→crates, auto-builds. Auto-restarts b00t-admin.

--- a/_b00t_/learn/exec-guards.md
+++ b/_b00t_/learn/exec-guards.md
@@ -1,2 +1,5 @@
 ---
 Run b00t guard list FIRST when b00t exec blocks unexpectedly — junk session guards (single-char patterns) match: Run b00t guard list FIRST when b00t exec blocks unexpectedly — junk session guards (single-char patterns) match everything; clean with b00t guard remove <pattern> <!-- salvaged:no_colon -->
+
+---
+canonical types: ufo-types::satisfies (Satisfies<C>, SatisfiesResult, Disposition, EvidenceBridge) — constraint evaluation outcomes now belong to the crate, not hand-rolled shapes here.

--- a/_b00t_/learn/guard-system.md
+++ b/_b00t_/learn/guard-system.md
@@ -1,2 +1,5 @@
 ---
 state persistence: Guard violation counters should use append-mode JSONL (OpenOptions::append) instead of rewriting whole file. Each violation appends one line: {\"pattern\": \"$name\", \"count\": $n}. Compaction merges duplicates via just guard-compact. Weekly cron job prevents unbounded growth. Use best-effort IO — never let persistence failure block command execution.
+
+---
+canonical types: ufo-types::satisfies (Satisfies<C>, SatisfiesResult, Disposition, EvidenceBridge) — constraint evaluation outcomes now belong to the crate, not hand-rolled shapes here.

--- a/_b00t_/learn/karpathy.md
+++ b/_b00t_/learn/karpathy.md
@@ -1,2 +1,5 @@
 ---
 deepwiki=autoresearch=karpathy: pattern where agent recursively reads source material BEFORE acting. Key: a sm0l reviewer model reads retrieved doc and answers RELEVANT|SKIP:<reason>. Gate fires between Orient and Act in OODA. Without it: retrieval is keyword-match, agent acts on wrong context. In b00t: use grok ask as the sm0l reviewer. Never skip the reviewer gate just because retrieval returned a result.
+
+---
+canonical types: ufo-types::dare (DaredProposal, OodaStateMachine, OodaPhase, OodaGuards) — OODA state-change workflow types now belong to the crate, not hand-rolled shapes here.

--- a/_b00t_/learn/session-2026-06-29.md
+++ b/_b00t_/learn/session-2026-06-29.md
@@ -25,3 +25,6 @@
 - **crates.io**: `blessed` v0.1.0, `b00t` v0.1.0 placeholder published. `b00t-cli`/`b00t-mcp` need workspace deps versioned first.
 - **npm**: `b00t-cli` available, needs NPM_TOKEN.
 - **PyPI**: `b00t` available (HTTP 200 is misleading — check JSON for `message: "Not Found"`). Use `p00ty` as fallback.
+
+## Canonical Types
+- **canonical types**: `ufo-types::capability` (AgentCapability, CapabilityDomain, Task) + `ufo-types::stereotype` (Stereotyped) — agent identity/capability introspection now belongs to the crate, not hand-rolled shapes here.

--- a/_b00t_/learn/whoami-agent-flag.md
+++ b/_b00t_/learn/whoami-agent-flag.md
@@ -1,2 +1,5 @@
 ---
 b00t whoami --agent=operator fails - 'unexpected argument --agent' in installed binary. Use: b00t whoami --agent=operator fails - 'unexpected argument --agent' in installed binary. Use --role=operator instead. Branch task/learn-role-agent-flag is implementing this. Dogfood lesson: always verify flag availability before using. <!-- salvaged:topic_overflow -->
+
+---
+canonical types: ufo-types::capability (AgentCapability, CapabilityDomain, Task) + ufo-types::stereotype (Stereotyped) — agent identity/capability introspection now belongs to the crate, not hand-rolled shapes here.

--- a/_b00t_/learn/whoami-role-resolution.md
+++ b/_b00t_/learn/whoami-role-resolution.md
@@ -1,2 +1,5 @@
 ---
 b00t whoami --role=reviewer reports role: reviewer in --json output but renders AGENTS/--role=worker.md content in the markdown text output instead of AGENTS/--role=reviewer.md (confirmed correct on disk, 147 lines, header 'Reviewer Role Supplement'). Role name resolves correctly for JSON metadata but the AGENTS/ file loader picks the wrong file. Repro: diff <(b00t whoami --role=reviewer | tail -100) AGENTS/--role=reviewer.md
+
+---
+canonical types: ufo-types::capability (AgentCapability, CapabilityDomain, Task) + ufo-types::stereotype (Stereotyped) — agent identity/capability introspection now belongs to the crate, not hand-rolled shapes here.

--- a/_b00t_/learn/whoami.md
+++ b/_b00t_/learn/whoami.md
@@ -1,2 +1,5 @@
 ---
 b00t whoami in a Claude Code session double-pays ~2.4k tokens: harness already injects CLAUDE.md, whoami echoes identical boilerplate. Needs --suffix-only mode (emit session context + role summary only) or CLAUDE_CODE env detection
+
+---
+canonical types: ufo-types::capability (AgentCapability, CapabilityDomain, Task) + ufo-types::stereotype (Stereotyped) — agent identity/capability introspection now belongs to the crate, not hand-rolled shapes here.


### PR DESCRIPTION
Closes #910

## Summary

Adds a one-line "canonical types: `ufo-types::<module>`" pointer to each learn-topic file identified in #910's triage (Hive Maintenance Report comment) as hand-rolling concepts that `ufo-types` (github.com/PromptExecution/ufo-types, pinned `tag = "v0.10.2"` in workspace `Cargo.toml`) now canonically hosts.

| Learn topic family | Files | Points to |
|---|---|---|
| `whoami*`, `session`, `blessing-manifest` (agent identity + capability introspection) | `whoami.md`, `whoami-agent-flag.md`, `whoami-role-resolution.md`, `session-2026-06-29.md`, `blessing-manifest.md` | `ufo-types::capability` (AgentCapability, CapabilityDomain, Task) + `ufo-types::stereotype` (Stereotyped) |
| `b00t-datums`, `datum`, `datum-generator` (DatumType stereotypes) | `b00t-datums.md`, `datum.md`, `datum-generator.md` | `ufo-types::stereotype` (UfoStereotype) |
| `guard-system`, `exec-guards` (constraint evaluation outcomes) | `guard-system.md`, `exec-guards.md` | `ufo-types::satisfies` (Satisfies<C>, SatisfiesResult, Disposition, EvidenceBridge) |
| OODA references | `b00t.md`, `karpathy.md`, `desired-state-2026-07.md` | `ufo-types::dare` (DaredProposal, OodaStateMachine, OodaPhase, OodaGuards) |

13 files, one line each (2 use a markdown-header style consistent with those files' existing structure instead of the LFMF `---` delimiter).

## Verification

Module/type names were checked against the actual `ufo-types` source at the pinned tag, not invented:

```
$ gh api repos/PromptExecution/ufo-types/contents/src?ref=v0.10.2 --jq '.[].name'
capability.rs  dare.rs  iso.rs  lib.rs  satisfies.rs  stereotype.rs

$ gh api repos/PromptExecution/ufo-types/contents/src/lib.rs?ref=v0.10.2 --jq '.content' | base64 -d | grep '^pub mod'
pub mod capability; pub mod dare; pub mod iso; pub mod satisfies; pub mod stereotype;
```

Per-module type names (`AgentCapability`, `UfoStereotype`, `Satisfies<C>`, `DaredProposal`, etc.) confirmed via `grep '^pub (struct|enum|trait)'` on each source file at the pinned tag.

No doc-lint/validate recipe exists in the justfile for this repo; confirmed instead via `git diff` (clean, minimal, one addition per file) and `git grep -c "canonical types" _b00t_/learn/` (13 files hit). No submodules (`integrations/`, `plantuml-server`) touched.

## Test plan

- [x] `git diff --stat` — 13 files changed, 37 insertions, 0 deletions
- [x] `git grep` confirms pointer present in all target files
- [x] No submodule paths modified
- [x] ufo-types module/type names verified against pinned tag `v0.10.2` source, not invented

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014pJVpfaPYPZFgRtMh9AXG8