### PR TITLE
test(#893): ScopeStore BDD end-to-end test suite + CONOPS doc

### DIFF
--- a/b00t-c0re-gov/tests/scope_store_bdd_test.rs
+++ b/b00t-c0re-gov/tests/scope_store_bdd_test.rs
@@ -1,0 +1,500 @@
+//! BDD-style end-to-end test suite for ScopeStore (issue #893, §8 checklist
+//! items: "BDD: discovery chain across >=2 providers in a synthetic
+//! submodule tree" plus general end-to-end coverage of get/set, chain
+//! traversal, credential guard, and audit logging).
+//!
+//! Exercises the full user-facing seam through a real backend
+//! (`RedbScopeStore`, not the in-memory test double `scope_chain_view.rs`'s
+//! own unit tests use) assembled into a `ScopeChainView`, end-to-end:
+//! get/set, repo -> node -> global chain resolution, the credential guard
+//! (#899), audit logging (#900), and discovery-chain traversal (#898) across
+//! a synthetic submodule tree.
+//!
+//! This crate has no cucumber/gherkin dependency (checked: no BDD framework
+//! is used anywhere else in this repo either), so "BDD-style" here follows
+//! the project's existing convention (see `scope_chain_view.rs`'s own test
+//! names): one `mod` per Feature, one `#[test]` per Scenario, each with
+//! Given/When/Then comments -- structured narrative over plain `#[test]`,
+//! not a literal feature-file framework.
+
+use b00t_c0re_gov::discovery::walk_lazy_chain;
+use b00t_c0re_gov::errors::ScopeError;
+use b00t_c0re_gov::redb_scope_store::RedbScopeStore;
+use b00t_c0re_gov::scope_audit::AuditLogger;
+use b00t_c0re_gov::scope_chain_view::{Queryable, ScopeChainView};
+use b00t_c0re_gov::scope_store::{ScopeId, ScopeStore};
+use serde_json::json;
+use tempfile::TempDir;
+
+/// Test fixture: a real repo -> node -> global chain, each backed by its
+/// own `RedbScopeStore` file inside a fresh tempdir -- mirrors how a real
+/// caller assembles a chain (three independent files, not three in-memory
+/// HashMaps), so this suite proves the actual backend interacts correctly
+/// with `ScopeChainView`'s resolution/guard/audit logic, not just the
+/// resolution algorithm in isolation.
+struct Fixture {
+    _dir: TempDir, // keeps the tempdir alive for the fixture's lifetime
+}
+
+impl Fixture {
+    fn chain(repo: &str, node: &str) -> (Self, ScopeChainView) {
+        let dir = TempDir::new().unwrap();
+        let repo_store = RedbScopeStore::open(
+            dir.path().join("repo.redb"),
+            ScopeId::Repo(repo.to_string()),
+            Some(ScopeId::Node(node.to_string())),
+        )
+        .unwrap();
+        let node_store = RedbScopeStore::open(
+            dir.path().join("node.redb"),
+            ScopeId::Node(node.to_string()),
+            Some(ScopeId::Global),
+        )
+        .unwrap();
+        let global_store =
+            RedbScopeStore::open(dir.path().join("global.redb"), ScopeId::Global, None).unwrap();
+
+        let chain = ScopeChainView::new(vec![
+            Box::new(repo_store) as Box<dyn ScopeStore>,
+            Box::new(node_store),
+            Box::new(global_store),
+        ]);
+
+        (Self { _dir: dir }, chain)
+    }
+}
+
+// ---------------------------------------------------------------------
+// Feature: get/set within a scope chain
+// ---------------------------------------------------------------------
+mod get_set {
+    use super::*;
+
+    #[test]
+    fn scenario_set_then_get_round_trips_the_same_value() {
+        // Given a fresh repo -> node -> global chain
+        let (_fx, mut chain) = Fixture::chain("myrepo", "myhost");
+
+        // When a value is set at an explicit scope
+        chain
+            .set_raw(&ScopeId::Global, "greeting", json!("hello"))
+            .unwrap();
+
+        // Then reading the same key returns exactly what was written
+        assert_eq!(chain.get_raw("greeting").unwrap(), Some(json!("hello")));
+    }
+
+    #[test]
+    fn scenario_get_on_a_never_set_key_returns_none_not_an_error() {
+        // Given an empty chain
+        let (_fx, chain) = Fixture::chain("myrepo", "myhost");
+
+        // When reading a key nobody ever wrote
+        let result = chain.get_raw("nope").unwrap();
+
+        // Then the caller sees an absence, not an error
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn scenario_set_persists_in_the_targeted_backend_file() {
+        // Given a chain whose repo scope is backed by a real redb file
+        let (_fx, mut chain) = Fixture::chain("myrepo", "myhost");
+
+        // When a value is written to the repo scope specifically
+        chain
+            .set_raw(&ScopeId::Repo("myrepo".into()), "k", json!(42))
+            .unwrap();
+
+        // Then the resolving scope for that key is the repo scope, not a
+        // fallback -- proving the write landed in the real backend file
+        // ScopeChainView routed it to, not a shared in-memory map.
+        assert_eq!(
+            chain.resolving_scope("k").unwrap(),
+            Some(&ScopeId::Repo("myrepo".into()))
+        );
+    }
+}
+
+// ---------------------------------------------------------------------
+// Feature: repo -> node -> global chain resolution
+// ---------------------------------------------------------------------
+mod chain_traversal {
+    use super::*;
+
+    #[test]
+    fn scenario_most_specific_scope_wins_when_all_three_have_the_key() {
+        // Given all three scopes have set the same key to different values
+        let (_fx, mut chain) = Fixture::chain("myrepo", "myhost");
+        chain
+            .set_raw(&ScopeId::Global, "k", json!("global"))
+            .unwrap();
+        chain
+            .set_raw(&ScopeId::Node("myhost".into()), "k", json!("node"))
+            .unwrap();
+        chain
+            .set_raw(&ScopeId::Repo("myrepo".into()), "k", json!("repo"))
+            .unwrap();
+
+        // When reading through the chain
+        let value = chain.get_raw("k").unwrap();
+
+        // Then the most-specific (repo) value wins
+        assert_eq!(value, Some(json!("repo")));
+    }
+
+    #[test]
+    fn scenario_falls_back_to_global_when_repo_and_node_are_silent() {
+        // Given only the global scope has the key
+        let (_fx, mut chain) = Fixture::chain("myrepo", "myhost");
+        chain
+            .set_raw(&ScopeId::Global, "k", json!("global-default"))
+            .unwrap();
+
+        // When reading through the full chain
+        let value = chain.get_raw("k").unwrap();
+
+        // Then resolution falls through to global
+        assert_eq!(value, Some(json!("global-default")));
+    }
+
+    #[test]
+    fn scenario_writes_never_implicitly_shadow_a_more_specific_scope() {
+        // Given a value already set at the node scope
+        let (_fx, mut chain) = Fixture::chain("myrepo", "myhost");
+        chain
+            .set_raw(&ScopeId::Node("myhost".into()), "k", json!("node-value"))
+            .unwrap();
+
+        // When a *different* write explicitly targets global (not repo/node)
+        chain
+            .set_raw(&ScopeId::Global, "k", json!("global-value"))
+            .unwrap();
+
+        // Then the node-scope value still wins on read -- global's write did
+        // not silently clobber a more specific scope, because
+        // ScopeChainView has no "write to whichever scope is closest"
+        // method: the caller had to say exactly which scope to write.
+        assert_eq!(chain.get_raw("k").unwrap(), Some(json!("node-value")));
+    }
+
+    #[test]
+    fn scenario_writing_to_a_scope_outside_the_chain_is_rejected() {
+        // Given a chain scoped to "myrepo"
+        let (_fx, mut chain) = Fixture::chain("myrepo", "myhost");
+
+        // When a caller tries to target a repo that isn't part of this chain
+        let err = chain
+            .set_raw(&ScopeId::Repo("some-other-repo".into()), "k", json!(1))
+            .unwrap_err();
+
+        // Then the write is rejected outright, not silently redirected
+        assert!(matches!(err, ScopeError::InvalidScopeId(_)));
+    }
+
+    #[test]
+    fn scenario_jsonpath_query_reaches_into_a_resolved_nested_document() {
+        // Given a JSON document stored under one key
+        let (_fx, mut chain) = Fixture::chain("myrepo", "myhost");
+        chain
+            .set_raw(
+                &ScopeId::Global,
+                "config",
+                json!({"b00t": {"name": "widget", "tags": ["a", "b"]}}),
+            )
+            .unwrap();
+
+        // When querying into it with a JSONPath expression
+        let matches = chain.query("config", "$.b00t.name").unwrap();
+
+        // Then the query resolves the key through the chain first, then
+        // evaluates the path against the resolved value
+        assert_eq!(matches, vec![json!("widget")]);
+    }
+
+    #[test]
+    fn scenario_query_on_a_key_missing_everywhere_returns_empty_not_error() {
+        // Given an empty chain
+        let (_fx, chain) = Fixture::chain("myrepo", "myhost");
+
+        // When querying a key that was never set anywhere
+        let matches = chain.query("nope", "$.anything").unwrap();
+
+        // Then the result is an empty match set, not an error
+        assert_eq!(matches, Vec::<serde_json::Value>::new());
+    }
+}
+
+// ---------------------------------------------------------------------
+// Feature: credential guard (#899) -- rejected at every scope
+// ---------------------------------------------------------------------
+mod credential_guard {
+    use super::*;
+
+    #[test]
+    fn scenario_credential_shaped_key_is_rejected_at_every_scope_in_the_chain() {
+        // Given a chain with all three scopes available as write targets
+        for target in [
+            ScopeId::Repo("myrepo".into()),
+            ScopeId::Node("myhost".into()),
+            ScopeId::Global,
+        ] {
+            let (_fx, mut chain) = Fixture::chain("myrepo", "myhost");
+
+            // When a caller tries to write a credential-shaped key to any of them
+            let err = chain
+                .set_raw(
+                    &target,
+                    "openai.credential",
+                    json!("sk-should-never-land-here"),
+                )
+                .unwrap_err();
+
+            // Then the write is rejected before it ever reaches the backend
+            // -- "at every scope", not just repo-scope (#899's reframing).
+            assert!(
+                matches!(err, ScopeError::WriteRejected(_)),
+                "expected WriteRejected for {target:?}, got {err:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn scenario_rejected_credential_write_never_touches_the_backend() {
+        // Given a chain
+        let (_fx, mut chain) = Fixture::chain("myrepo", "myhost");
+
+        // When a credential-shaped write is attempted and rejected
+        let _ = chain
+            .set_raw(&ScopeId::Global, "aws.credentials", json!("secret"))
+            .unwrap_err();
+
+        // Then no value was actually persisted -- a read finds nothing
+        assert_eq!(chain.get_raw("aws.credentials").unwrap(), None);
+    }
+
+    #[test]
+    fn scenario_ordinary_keys_are_unaffected_by_the_guard() {
+        // Given a chain
+        let (_fx, mut chain) = Fixture::chain("myrepo", "myhost");
+
+        // When writing a key that merely mentions credentials in its name,
+        // not in the guarded ".credential"/".credentials" suffix shape
+        chain
+            .set_raw(&ScopeId::Global, "openai.cli", json!("gpt-5"))
+            .unwrap();
+
+        // Then it's written normally
+        assert_eq!(chain.get_raw("openai.cli").unwrap(), Some(json!("gpt-5")));
+    }
+}
+
+// ---------------------------------------------------------------------
+// Feature: audit logging (#900) -- boundaries_crossed, not a boolean
+// ---------------------------------------------------------------------
+mod audit_logging {
+    use super::*;
+
+    #[test]
+    fn scenario_audited_read_records_every_boundary_crossed_before_the_hit() {
+        // Given a chain where only the global scope holds the key
+        let (_fx, mut chain) = Fixture::chain("myrepo", "myhost");
+        chain.set_raw(&ScopeId::Global, "k", json!("v")).unwrap();
+        let audit_dir = TempDir::new().unwrap();
+        let logger = AuditLogger::open(audit_dir.path().join("audit.jsonl"));
+
+        // When reading through the chain with auditing enabled
+        let result = chain.get_raw_with_audit("k", &logger).unwrap();
+
+        // Then the value resolves correctly...
+        assert_eq!(result, Some(json!("v")));
+
+        // ...and the audit trail shows both boundaries crossed
+        // (repo->node, node->global) on the way to the global hit.
+        let events = logger.read_all().unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].boundaries_crossed.len(), 2);
+        assert_eq!(events[0].resolved_at, Some(ScopeId::Global));
+    }
+
+    #[test]
+    fn scenario_audited_read_hit_on_the_most_specific_scope_crosses_nothing() {
+        // Given a chain where the repo scope (most specific) has the key
+        let (_fx, mut chain) = Fixture::chain("myrepo", "myhost");
+        chain
+            .set_raw(&ScopeId::Repo("myrepo".into()), "k", json!("v"))
+            .unwrap();
+        let audit_dir = TempDir::new().unwrap();
+        let logger = AuditLogger::open(audit_dir.path().join("audit.jsonl"));
+
+        // When reading with auditing enabled
+        chain.get_raw_with_audit("k", &logger).unwrap();
+
+        // Then zero boundaries were crossed, and that zero is itself
+        // recorded -- not indistinguishable from "never checked" (#900).
+        let events = logger.read_all().unwrap();
+        assert_eq!(events.len(), 1);
+        assert!(events[0].boundaries_crossed.is_empty());
+        assert_eq!(
+            events[0].resolved_at,
+            Some(ScopeId::Repo("myrepo".into()))
+        );
+    }
+
+    #[test]
+    fn scenario_audit_log_survives_multiple_reads_across_reopened_loggers() {
+        // Given a chain with a value set, and two separate reads
+        let (_fx, mut chain) = Fixture::chain("myrepo", "myhost");
+        chain
+            .set_raw(&ScopeId::Node("myhost".into()), "k", json!("v"))
+            .unwrap();
+        let audit_dir = TempDir::new().unwrap();
+        let audit_path = audit_dir.path().join("audit.jsonl");
+
+        // When two reads happen through two separately-opened loggers
+        // pointed at the same file (simulating two agent processes sharing
+        // one scope root's audit log)
+        {
+            let logger = AuditLogger::open(&audit_path);
+            chain.get_raw_with_audit("k", &logger).unwrap();
+        }
+        {
+            let logger = AuditLogger::open(&audit_path);
+            chain.get_raw_with_audit("missing-key", &logger).unwrap();
+        }
+
+        // Then both events are present, in order, in the shared append-only
+        // log -- nothing was truncated or overwritten by the second open.
+        let logger = AuditLogger::open(&audit_path);
+        let events = logger.read_all().unwrap();
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0].key, "k");
+        assert_eq!(events[1].key, "missing-key");
+    }
+}
+
+// ---------------------------------------------------------------------
+// Feature: discovery chain (#898) across a synthetic submodule tree --
+// #893 §8's explicit outstanding checklist item: "BDD: discovery chain
+// across >=2 providers in a synthetic submodule tree".
+// ---------------------------------------------------------------------
+mod discovery_chain {
+    use super::*;
+    use std::collections::HashMap;
+
+    /// Synthetic submodule tree: each entry maps a repo id to the parent
+    /// repo(s) its `$.b00t.manifest` publishes -- mirrors #893's "each
+    /// discovery unlocks the next" walk, reusing `discovery::walk_lazy_chain`
+    /// (the same generic walker `blessing --manifest` uses) rather than a
+    /// second hand-rolled graph walk.
+    fn submodule_manifest() -> HashMap<String, Vec<String>> {
+        let mut m = HashMap::new();
+        m.insert("app".to_string(), vec!["vendor-lib".to_string()]);
+        m.insert("vendor-lib".to_string(), vec!["monorepo".to_string()]);
+        m.insert("monorepo".to_string(), vec![]); // top of the submodule tree
+        m
+    }
+
+    #[test]
+    fn scenario_discovery_walk_orders_repos_most_specific_first() {
+        // Given a synthetic 3-level submodule tree (app -> vendor-lib -> monorepo)
+        let manifest = submodule_manifest();
+
+        // When walking the discovery chain starting from the innermost
+        // checked-out repo ("app")
+        let order = walk_lazy_chain(["app".to_string()], 10, |id| {
+            manifest.get(id).cloned().unwrap_or_default()
+        });
+
+        // Then discovery visits most-specific (app) first, walking outward
+        // toward the submodule root -- exactly the order ScopeChainView
+        // needs for most-specific-wins resolution.
+        assert_eq!(
+            order,
+            vec![
+                "app".to_string(),
+                "vendor-lib".to_string(),
+                "monorepo".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn scenario_two_or_more_discovered_providers_assemble_into_a_working_chain() {
+        // Given a discovery walk across >= 2 providers (app, vendor-lib,
+        // monorepo -- three, comfortably over the >=2 bar from #893's own
+        // checklist wording)
+        let manifest = submodule_manifest();
+        let order = walk_lazy_chain(["app".to_string()], 10, |id| {
+            manifest.get(id).cloned().unwrap_or_default()
+        });
+        assert!(order.len() >= 2, "fixture must exercise >=2 providers");
+
+        let dir = TempDir::new().unwrap();
+        let mut stores: Vec<Box<dyn ScopeStore>> = Vec::new();
+        for (i, repo_id) in order.iter().enumerate() {
+            let parent = order.get(i + 1).map(|p| ScopeId::Repo(p.clone()));
+            let store = RedbScopeStore::open(
+                dir.path().join(format!("{repo_id}.redb")),
+                ScopeId::Repo(repo_id.clone()),
+                parent,
+            )
+            .unwrap();
+            stores.push(Box::new(store));
+        }
+        let mut chain = ScopeChainView::new(stores);
+
+        // When each discovered provider writes its own value for the same key
+        for repo_id in &order {
+            chain
+                .set_raw(
+                    &ScopeId::Repo(repo_id.clone()),
+                    "shared-key",
+                    json!(repo_id),
+                )
+                .unwrap();
+        }
+
+        // Then resolution honors discovery order: the innermost ("app")
+        // provider wins, exactly like the non-discovery chain tests above.
+        assert_eq!(chain.get_raw("shared-key").unwrap(), Some(json!("app")));
+        assert_eq!(
+            chain.resolving_scope("shared-key").unwrap(),
+            Some(&ScopeId::Repo("app".to_string()))
+        );
+    }
+
+    #[test]
+    fn scenario_diamond_shaped_submodule_graph_visits_each_provider_once() {
+        // Given a diamond: a leaf depends on two submodules that share a
+        // common ancestor (a realistic shape -- two vendored libs sharing
+        // one upstream submodule)
+        let mut manifest = HashMap::new();
+        manifest.insert(
+            "leaf".to_string(),
+            vec!["lib-a".to_string(), "lib-b".to_string()],
+        );
+        manifest.insert("lib-a".to_string(), vec!["shared-upstream".to_string()]);
+        manifest.insert("lib-b".to_string(), vec!["shared-upstream".to_string()]);
+        manifest.insert("shared-upstream".to_string(), vec![]);
+
+        // When discovering from the leaf
+        let order = walk_lazy_chain(["leaf".to_string()], 10, |id| {
+            manifest.get(id).cloned().unwrap_or_default()
+        });
+
+        // Then the shared ancestor is discovered exactly once, not twice,
+        // and every provider in the diamond appears (4 total: leaf, lib-a,
+        // lib-b, shared-upstream) -- a real submodule graph can easily be a
+        // diamond, and re-visiting shared-upstream twice would double-count
+        // it in the eventual scope chain.
+        assert_eq!(order.len(), 4);
+        assert_eq!(
+            order
+                .iter()
+                .filter(|id| id.as_str() == "shared-upstream")
+                .count(),
+            1
+        );
+    }
+}

--- a/docs/architecture/SCOPESTORE_CONOPS.md
+++ b/docs/architecture/SCOPESTORE_CONOPS.md
@@ -1,0 +1,199 @@
+# CONOPS: ScopeStore — concept of operations
+
+**Status**: Living doc (not an ADR — describes intended usage, not a decision record)
+**Related**: _b00t_ issue #893 (ScopeStore umbrella), `SCOPESTORE_CONCURRENCY_ADR.md`
+(backend consistency guarantees), `b00t-c0re-gov/src/scope_store.rs`,
+`scope_chain_view.rs`, `redb_scope_store.rs`, `redis_scope_store.rs`,
+`discovery.rs`, `scope_credential_guard.rs`, `scope_audit.rs`
+
+## What problem this solves
+
+Before ScopeStore, "where does this piece of config/state live" had no single
+answer in b00t: some things belonged to one repo, some to one machine, some
+were meant to be shared across every agent everywhere — and each of those had
+its own bespoke storage path, with no consistent precedence rule when the
+same logical key existed at more than one level.
+
+ScopeStore gives that problem exactly one abstraction: a **repo → node →
+global** scope chain, one flat get/set contract per scope
+(`ScopeStore::get_raw`/`set_raw`), and one JSONPath query layer
+(`Queryable::query`) that sits above whichever chain of scopes a caller
+assembles. The storage backend (`RedbScopeStore` today, `RedisScopeStore`
+tomorrow) is invisible above that seam — callers write against the trait, not
+against redb or redis directly.
+
+## The mental model
+
+Think of a `ScopeChainView` as a **most-specific-first override stack**, not
+a merge:
+
+```
+repo scope    (most specific — "this repository's own setting")
+  ↓ falls back to
+node scope    (this machine's default, shared across every repo on it)
+  ↓ falls back to
+global scope  (the one shared default, if nothing more specific exists)
+```
+
+A **read** (`get_raw`) walks the stack top-down and returns the first hit —
+whichever scope answers first wins, and nothing below it is even inspected
+once a hit is found. There is no merging of partial values across scopes: if
+repo-scope has the key, node-scope and global-scope's values for that same
+key are invisible for that read, full stop.
+
+A **write** (`set_raw`) always names its target scope explicitly. There is no
+`set(key, value)` that means "write to whichever scope is closest" — every
+call site says `set_raw(&ScopeId::Repo("myrepo"), key, value)` or
+`&ScopeId::Node(...)` or `&ScopeId::Global`. This is deliberate: silent
+shadowing (a well-meaning write that only takes effect once a more specific
+scope's copy is deleted) is exactly the kind of "why didn't my config change
+anything" bug this design refuses to allow. If you want to override a value,
+you write to the more specific scope that's currently winning — you don't
+write blindly and hope.
+
+## Scope stereotypes — what belongs where
+
+| Scope | Identity | Typical contents | Backend (today) |
+|---|---|---|---|
+| `Repo(id)` | opaque key, e.g. `sha256(remote_url)`; one per repo *and* one per submodule boundary (never flattened into a parent) | repo-specific overrides: feature flags for this project, per-repo skill config | `RedbScopeStore` @ `.b00t/store.redb` |
+| `Node(hostname)` | hostname | machine-local defaults shared by every repo/agent on this box | `RedbScopeStore` @ `$XDG_CONFIG_HOME/b00t` |
+| `Global` | singleton, no identity needed | fleet-wide defaults meant to apply everywhere unless overridden | `RedbScopeStore` today; redis (`RedisScopeStore`) is the intended v2 for a genuinely shared/distributed global scope |
+
+Skills, souls, and feature-flag datums are the common case that legitimately
+lives at all three levels with fallback (a skill's default at global, a
+per-machine override at node, a per-repo pin at repo). **Credentials are the
+explicit exception**: `scope_credential_guard.rs` rejects any write whose key
+matches the `.credential`/`.credentials` datum-type suffix, at *every* scope,
+unconditionally. ScopeStore is not a secrets store. If you're tempted to
+write a token or API key through `set_raw`, don't — see "What ScopeStore
+deliberately does not do," below.
+
+## Common patterns
+
+### 1. Read a config value with sensible fallback
+
+```rust
+let value = chain.get_raw("some.setting")?;
+// Some(v) if any scope in the chain had it, most-specific wins.
+// None if nobody in the chain ever set it — not an error.
+```
+
+This is the default pattern for "give me the effective value of X for this
+agent, on this machine, in this repo, right now."
+
+### 2. Override at the most specific scope that makes sense
+
+```rust
+// Pin a setting for just this repo, leaving node/global defaults alone
+// for every other repo on this machine.
+chain.set_raw(&ScopeId::Repo(repo_id), "some.setting", json!("repo-specific-value"))?;
+```
+
+Because writes are always explicit-target, this is also how you *remove* an
+override in spirit: write the desired value back to the scope you actually
+want it to live in, rather than relying on any implicit precedence at write
+time.
+
+### 3. Reach into a stored JSON document with JSONPath
+
+A scope's stored value can be an arbitrary JSON document, not just a scalar.
+`Queryable::query` resolves the key through the chain first (most-specific
+wins, same as `get_raw`), then evaluates a JSONPath expression against
+whatever was found:
+
+```rust
+// config resolved at whichever scope has it, then $.b00t.name extracted
+let matches = chain.query("config", "$.b00t.name")?;
+```
+
+Empty (`Vec::new()`), not an error, when the key isn't set anywhere in the
+chain — a query against nothing is a valid, uninteresting answer, not a
+failure.
+
+### 4. Know *why* a read resolved where it did (audited reads)
+
+For any read where provenance matters — debugging "why is this repo picking
+up the global default instead of what I thought was a node-level
+override," or a compliance/audit trail — use `get_raw_with_audit` instead of
+`get_raw`:
+
+```rust
+let logger = AuditLogger::open(scope_root.join("audit.jsonl"));
+let value = chain.get_raw_with_audit("some.setting", &logger)?;
+```
+
+Every scope checked-and-missed on the way to the hit (or every scope checked,
+if the key wasn't found anywhere) is appended to `logger` as one JSON line —
+an ordered `boundaries_crossed[from, to, direction]` list, not a boolean. A
+hit on the very first (most-specific) scope logs zero crossings, and that
+zero is itself meaningful (distinguishable from "this key was never audited
+at all"). Use `get_raw` for the hot path where you don't need provenance;
+reach for `get_raw_with_audit` when you do.
+
+### 5. Assemble a chain via discovery instead of hand-wiring it
+
+For the common case of "walk from wherever I am (the current repo/submodule)
+out to node and global, picking up every intermediate submodule boundary
+along the way," don't hand-assemble the `Vec<Box<dyn ScopeStore>>` — use
+`discovery::walk_lazy_chain` starting from the innermost scope, expanding
+each node via its `$.b00t.manifest`:
+
+```rust
+let order = walk_lazy_chain([innermost_repo_id], max_depth, |id| {
+    // look up id's parent(s) from its published manifest
+});
+// order is already most-specific-first; open one ScopeStore per entry
+// and hand the Vec to ScopeChainView::new.
+```
+
+The walker is cycle-guarded and depth-capped, so a malformed or cyclic
+submodule graph terminates instead of looping forever, and a graph deeper
+than your cap is truncated (not rejected) — the boundary node is still
+recorded, its own children just aren't expanded further.
+
+## What ScopeStore deliberately does not do
+
+- **It is not a secrets store.** `scope_credential_guard.rs` rejects
+  credential-shaped keys at every scope. Use the reference/delivery pattern
+  from `_b00t_/learn/managing-secrets.md` (Infisical/Teller/SOPS/vals at
+  delivery time) or `datum_credential.rs`'s dedicated OS-keyring-wrapped
+  storage — outside ScopeStore entirely — if a local encrypted copy is
+  genuinely required.
+- **It does not merge values across scopes.** Most-specific-wins is a
+  full-value override, not a deep merge of partial JSON documents. If two
+  scopes each set half of a config object, only one half is ever visible at
+  a time (whichever scope's copy resolves).
+- **It does not guess a write target.** No API exists that infers "the
+  closest scope" for a write. Every `set_raw` call names its scope.
+- **It does not (yet) give any cross-process concurrency guarantee stronger
+  than what the backend itself provides.** See
+  `SCOPESTORE_CONCURRENCY_ADR.md` for exactly what `RedbScopeStore` (OS file
+  lock, fails fast on a second writer) and `RedisScopeStore` (no lock,
+  last-write-wins, no ordering signal) each actually guarantee today, and
+  why porting concurrency assumptions from one backend to the other is
+  unsafe. A generation-token mechanism for cross-query read consistency is
+  tracked as its own follow-up (#897) and is explicitly not built yet.
+
+## Where the ergonomics are still evolving
+
+`ScopeStore`/`ScopeChainView`'s current shape is deliberately narrow: flat
+`get_raw`/`set_raw` plus the `Queryable` bridge. A path-addressed `Writable`
+trait (`set_path`, writing into a nested location inside a stored document
+rather than only replacing the whole value at a key) has been proposed
+separately (issue #895) as an ergonomic layer on top of this same seam —
+check `b00t-c0re-gov/src/scope_chain_view.rs`'s current state before
+assuming it exists; as of this writing it is tracked but not necessarily
+merged. This CONOPS describes the `get_raw`/`set_raw`/`query` contract that
+is definitely in the tree today.
+
+## Quick reference: which method for which job
+
+| I want to... | Use |
+|---|---|
+| Read the effective value of a key, fallback included | `ScopeChainView::get_raw` |
+| Read the effective value *and* know which scope it resolved at | `ScopeChainView::get_raw` + `resolving_scope`, or `get_raw_with_audit` if you also want it persisted |
+| Write/override a value at a specific scope | `ScopeChainView::set_raw(&target_scope, key, value)` |
+| Reach into a nested field of a stored JSON document | `Queryable::query(key, jsonpath)` |
+| Get an audit trail of exactly which scopes were checked | `get_raw_with_audit` + `AuditLogger::read_all` |
+| Build a chain from a repo's actual submodule tree | `discovery::walk_lazy_chain` starting from the innermost scope |
+| Store a secret/token | Don't — see "What ScopeStore deliberately does not do" |


### PR DESCRIPTION
Closes #893

Per the triage investigation on #893, ScopeStore's Phase 1 core already shipped in commit `ab873545` (`scope_store.rs`, `scope_chain_view.rs`, `redb_scope_store.rs`, `redis_scope_store.rs`, `discovery.rs`, `scope_credential_guard.rs`, `scope_audit.rs`, all with embedded unit tests), and `docs/architecture/SCOPESTORE_CONCURRENCY_ADR.md` (Accepted) already answers #902's concurrency question. Of the issue's §8 checklist, two items remained: a BDD-style end-to-end test suite and a CONOPS doc. This PR adds both.

## What's here

- `b00t-c0re-gov/tests/scope_store_bdd_test.rs` — 18 Given/When/Then-style scenarios grouped into 5 Features, exercised against the **real `RedbScopeStore` backend** (not the in-memory test double `scope_chain_view.rs`'s own unit tests use):
  - `get_set` — round-trip, absence-is-not-an-error, write lands in the targeted backend file
  - `chain_traversal` — most-specific-wins, fallback, no-implicit-shadow-on-write, out-of-chain write rejection, JSONPath query
  - `credential_guard` — credential-shaped keys rejected at every scope (#899), rejected writes never touch the backend, ordinary keys unaffected
  - `audit_logging` — boundaries_crossed recorded correctly (#900), zero-crossing hit still logged, log survives multiple reopened-logger reads
  - `discovery_chain` — #893's explicit outstanding item, "BDD: discovery chain across >=2 providers in a synthetic submodule tree": linear 3-repo chain assembled from `discovery::walk_lazy_chain` output into a working `ScopeChainView`, plus a diamond-shaped submodule graph proving shared ancestors are visited once
- `docs/architecture/SCOPESTORE_CONOPS.md` — mental model (most-specific-first override stack, not a merge), scope stereotype table (repo/node/global), 5 common usage patterns with code, what ScopeStore deliberately does not do (not a secrets store, no cross-scope merge, no implicit write target, no stronger-than-backend concurrency guarantee), and a quick-reference table of which method to use for which job. Matches the existing ADR's location and style.

No source files under `b00t-c0re-gov/src/` were touched — this is test + docs only, on top of the already-shipped seam.

## Test Plan
- [x] `cargo check -p b00t-c0re-gov` — clean compile
- [x] `cargo test -p b00t-c0re-gov` — **155 passed, 0 failed** (137 pre-existing + 18 new BDD scenarios + e2e/ring/scheduler/store integration tests + 1 doctest)

https://claude.ai/code/session_014pJVpfaPYPZFgRtMh9AXG8