### PR TITLE
fix(PiExecutor): pass task as positional arg, not stdin

### DIFF
--- a/_b00t_/ralph/ralph/executors.py
+++ b/_b00t_/ralph/ralph/executors.py
@@ -292,6 +292,9 @@ class PiExecutor:
     Invokes pi in non-interactive (-p) mode against the local ch0nky slot
     via llama-cpp provider. Requires pi installed and local inference running
     on the OpenAI-compatible endpoint configured in ~/.pi/agent/models.json.
+
+    pi takes the task as a trailing positional argument, not stdin
+    (`pi [options] [@files...] [messages...]` per `pi --help`).
     """
 
     prompt_path: Path
@@ -317,8 +320,8 @@ class PiExecutor:
         ]
         if self.extra_args:
             command.extend(self.extra_args.split())
-        # pi reads task from stdin when -p flag is set
-        return _run_subprocess(tuple(command), input_text=prompt_text, cwd=cwd_value)
+        command.append(prompt_text)
+        return _run_subprocess(tuple(command), input_text=None, cwd=cwd_value)
 
 
 __all__ = [


### PR DESCRIPTION
## Summary
- `pi`'s own `--help` documents messages as a trailing positional argument (`pi [options] [@files...] [messages...]`), not stdin. `PiExecutor` was passing the prompt via stdin, which `pi` does not read in `-p` mode.
- Supersedes stale branch `task/47-rustfmt-post-edit-hook` (7+ weeks old), which fixed the same real bug but also incorrectly swapped `provider="llama-cpp"` → `"openai"` and added a `--base-url` flag that doesn't exist on the current `pi` CLI.
- Verified `provider="llama-cpp"` is correct as-is: `~/.pi/agent/models.json` registers it as a legitimate custom provider pointing at `localhost:8001/v1` — not a typo for a built-in provider name. `--base-url` was checked against `pi --help` directly and doesn't exist (only `AZURE_OPENAI_BASE_URL` exists, Azure-specific).
- This PR touches only the actual bug (stdin → positional arg); the other 3 files the stale branch touched are left untouched since their changes were part of the incorrect provider/base-url fix.

## Test plan
- [x] `python3 -c "import ast; ast.parse(...)"` — syntax verified
- [x] Confirmed `pi`'s documented CLI interface takes messages positionally (`pi --help`)
- [ ] Full functional run against a live `ch0nky` local-inference backend — not possible in this environment right now (`localhost:8001` is down), left for the next person who has that backend running

🤖 Generated with [Claude Code](https://claude.com/claude-code)