### PR TITLE
fix(glama): update icon URL to existing asset

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "homepage": "https://github.com/elasticdotventures/_b00t_",
   "repository": "https://github.com/elasticdotventures/_b00t_",
-  "icon": "https://raw.githubusercontent.com/elasticdotventures/_b00t_/main/_b00t_/assets/b00t-icon.png",
+  "icon": "https://raw.githubusercontent.com/elasticdotventures/_b00t_/main/b00t-vscode/icons/b00t.png",
   "keywords": ["agent", "rust", "datum", "mcp", "hive", "ooda", "autonomous"],
   "category": "Development Tools",
   "server": {


### PR DESCRIPTION
## Summary
- glama.json's icon URL points to `_b00t_/assets/b00t-icon.png`, which doesn't exist on main (confirmed 404 via `git cat-file -e`). `b00t-vscode/icons/b00t.png` exists and is the correct asset.
- Cherry-picked from stale branch `task/69-marketplace-listing` (7+ weeks old), which also removed a duplicate `diffy` dependency — that part is dropped here since main has already deduped it independently (only one `diffy` line exists in `b00t-cli/Cargo.toml` now).

## Test plan
- [x] `git cat-file -e origin/main:_b00t_/assets/b00t-icon.png` → confirms missing (old URL)
- [x] `git cat-file -e origin/main:b00t-vscode/icons/b00t.png` → confirms exists (new URL)

🤖 Generated with [Claude Code](https://claude.com/claude-code)