### PR TITLE
fix(pre-push): block force-push to main, not just force-delete

### DIFF
--- a/_b00t_/hooks/pre-push
+++ b/_b00t_/hooks/pre-push
@@ -37,6 +37,13 @@ while read LOCAL_REF LOCAL_SHA REMOTE_REF REMOTE_SHA; do
     echo "🚫 pre-push: force-delete of main is BLOCKED" >&2
     exit 1
   fi
+
+  if [[ "$REMOTE_REF" == "refs/heads/main" && "$REMOTE_SHA" != "0000000000000000000000000000000000000000" ]]; then
+    if ! git merge-base --is-ancestor "$REMOTE_SHA" "$LOCAL_SHA" 2>/dev/null; then
+      echo "🚫 pre-push: force-push to main is BLOCKED (not a fast-forward)" >&2
+      exit 1
+    fi
+  fi
   REMOTE_TIP="$REMOTE_SHA"
 done
 


### PR DESCRIPTION
## Summary
- The pre-push hook only checked `LOCAL_SHA==zeros` (branch deletion) for `main`. A force-push (non-fast-forward, non-zero SHAs on both sides) passed through unblocked at the local-hook level — only server-side GitHub branch protection, if configured, was actually stopping it.
- Adds a `git merge-base --is-ancestor` check: if the remote's current tip isn't an ancestor of the new local HEAD for `refs/heads/main`, the push would rewrite history and is blocked.
- Rebuilt fresh against the current hook (substantially rewritten — reverse-dependency-closure test selection — since stale branch `task/77-hooks-evaluation`, 7+ weeks old, first identified this gap; that branch's diff no longer applies).

## Known issue surfaced (unrelated, separate from this fix)
Pushing this branch hit `~/.cargo/config.toml`'s `rustc-wrapper = "b00t-rustc-wrapper.sh"` — that script doesn't exist anywhere on `PATH` or in the repo, so the hook's own conservative full-gate (`cargo test -p b00t-cli`, triggered because this diff touches `_b00t_/hooks/*`) can't run at all right now, for any change. Pushed with `--no-verify` (explicit operator authorization) since this blocker predates and is unrelated to this fix. Worth a separate issue — flagging here rather than filing one unprompted.

## Test plan
- [x] `bash -n` — hook syntax verified
- [x] Isolated scratch-repo test of the merge-base logic itself: a genuine fast-forward (remote SHA ancestor of new local HEAD) → allowed; divergent/rewritten history (remote SHA not an ancestor) → correctly blocked
- [ ] Full hook-installed test (real `git push --force` against a disposable local bare remote) — blocked by sandbox restrictions on `--force`, not attempted; only the underlying git logic was directly verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)