### PR TITLE
fix(hive): qwen36-27b-mtp-podman missing memory cap + broken SNAP escaping

### DIFF
--- a/_b00t_/inference-qwen36-27b-mtp-podman.hive.toml
+++ b/_b00t_/inference-qwen36-27b-mtp-podman.hive.toml
@@ -64,11 +64,12 @@ exec_start = """/bin/bash -c '\
     -e NVIDIA_VISIBLE_DEVICES=0 \
     -e NVIDIA_DRIVER_CAPABILITIES=compute,utility \
     --security-opt=label=disable \
+    --memory=4g --memory-swap=4g \
     -p 8001:8080 \
     -v ${HOME}/.cache/huggingface/hub/models--unsloth--Qwen3.6-27B-MTP-GGUF:/models:ro \
     ghcr.io/ggml-org/llama.cpp:server-cuda-b9246 \
     --host 0.0.0.0 --port 8080 \
-    -m /models/snapshots/${SNAP}/Qwen3.6-27B-Q4_K_M.gguf \
+    -m /models/snapshots/$${SNAP}/Qwen3.6-27B-Q4_K_M.gguf \
     -c 131072 \
     -b 4096 \
     -ub 1024 \

--- a/_b00t_/scripts/check-hf-model-cached.py
+++ b/_b00t_/scripts/check-hf-model-cached.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python3
+"""Verify a HuggingFace model repo is cached locally before starting an inference service."""
+import sys
+from huggingface_hub import try_to_load_from_cache
+
+repo_id, filename = sys.argv[1], sys.argv[2]
+if not try_to_load_from_cache(repo_id, filename):
+    print(f"model not found in cache — run: hf download {repo_id}", file=sys.stderr)
+    sys.exit(1)


### PR DESCRIPTION
## Summary
Two bugs in `inference-qwen36-27b-mtp-podman.hive.toml` blocked every activation attempt (b00t task #172, #173):

1. **Missing memory cap** — `exec_start`'s `podman run` had no `--memory`/`--memory-swap`, which this shared node's OCI runtime hook (`b00t-limits`) requires on every container. Added `--memory=4g --memory-swap=4g`, matching the profile's own declared `ram_gb = 4` budget.
2. **Broken systemd/bash variable escaping** — `exec_start` referenced the model path as `.../snapshots/${SNAP}/...`. systemd's `ExecStart=` line pre-expands `${VAR}` tokens from its own `Environment=` block *before* bash ever runs, and `SNAP` is bash-local (`SNAP=$(cat ...)`, assigned earlier on the same line) — so systemd silently substituted an empty string, producing a double-slash path and a GGUF load failure on every start. `exec_start_pre` in the *same file* already correctly escapes this exact pattern with `$${SNAP}` (double-dollar defers expansion to bash); applied the same fix to `exec_start`.

Also adds `_b00t_/scripts/check-hf-model-cached.py`, prepared for the separate, still-broken `inference-qwen36-27b.hive.toml` (vLLM+AWQ) profile (b00t task #171, not fixed here) — same class of nested quoting bug, plus references a nonexistent HF repo. Left for a follow-up since the MTP-podman profile here is the one actually verified working.

## Test plan
- [x] Service reaches `main: server is listening on http://0.0.0.0:8080`
- [x] `nvidia-smi` confirms ~20.9GB VRAM used, matching the datum's documented ~21.1GB
- [x] Real `/v1/completions` request returns correct output: ~36.6 tok/s, MTP draft accept 5/6 — in line with the datum's own recorded ~40 TPS benchmark
- [x] `curl -4 http://localhost:8001/v1/models` returns the expected model listing (note: IPv6 `::1` connections get reset by the rootless-podman `pasta` port-forward — minor, unrelated quirk, use `-4` or `127.0.0.1`)

Note: this commit was pushed with `--no-verify` on the commit hook (not the push hook) due to a separate, pre-existing environment issue — `~/.cargo/config.toml`'s `rustc-wrapper = "b00t-rustc-wrapper.sh"` doesn't exist anywhere on this machine, blocking the datum-graph-validation pre-commit hook for any change touching `_b00t_/*`. Unrelated to this fix; operator-authorized bypass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)