### PR TITLE
feat(azure-cp): add Key Vault secret tool + fix pre-push bin-only bug

### DIFF
--- a/_b00t_/hooks/pre-push
+++ b/_b00t_/hooks/pre-push
@@ -154,8 +154,33 @@ for p in "${SELECTED[@]}"; do
   [ "$p" = "b00t-cli" ] && { git submodule update --init vendor/ledgrrr vendor/runpod-sdk vendor/embed-anything-b00t 2>/dev/null || true; break; }
 done
 
-# Single invocation: Cargo dedups compilation across selected packages.
-if ! cargo test --lib --quiet $(printf -- '-p %s ' "${SELECTED[@]}") 2>&1; then
+# `--lib` errors ("no library targets found") on any selected package that is
+# bin-only (e.g. b00t-azure-cp), even when other selected packages do have a
+# lib target — cargo validates the requested target-kind per -p, not just
+# somewhere-in-the-selection. Split the selection accordingly: lib-having
+# packages keep the fast/scoped `--lib` (unit tests only, no doctests/
+# integration tests); bin-only packages run under `--bins` instead (covers
+# any inline #[test] in their main.rs, and is a no-op — not an error — for
+# packages with zero bin targets).
+LIB_PKGS=()
+BIN_ONLY_PKGS=()
+for p in "${SELECTED[@]}"; do
+  if jq -e --arg p "$p" '.packages[] | select(.name == $p) | .targets[] | select(.kind[] == "lib")' <<<"$META" >/dev/null 2>&1; then
+    LIB_PKGS+=("$p")
+  else
+    BIN_ONLY_PKGS+=("$p")
+  fi
+done
+
+FAILED=0
+if [ "${#LIB_PKGS[@]}" -gt 0 ]; then
+  cargo test --lib --quiet $(printf -- '-p %s ' "${LIB_PKGS[@]}") 2>&1 || FAILED=1
+fi
+if [ "${#BIN_ONLY_PKGS[@]}" -gt 0 ]; then
+  cargo test --bins --quiet $(printf -- '-p %s ' "${BIN_ONLY_PKGS[@]}") 2>&1 || FAILED=1
+fi
+
+if [ "$FAILED" -eq 1 ]; then
   echo "🚫 pre-push: tests failed — push blocked" >&2
   exit 1
 fi

--- a/b00t-azure-cp/src/main.rs
+++ b/b00t-azure-cp/src/main.rs
@@ -1,11 +1,12 @@
 //! b00t Azure Control Plane — MCP server for on-demand ACI compute.
 //!
-//! Exposes five MCP tools:
-//!   azure.provision_aci  — spin up an ACI container, return endpoint_url + lease_id
-//!   azure.deprovision    — tear down by lease_id
-//!   azure.heartbeat      — renew lease TTL
-//!   azure.list_leases    — active resources + TTLs
-//!   azure.cost_estimate  — current-month spend for the control plane RG
+//! Exposes six MCP tools:
+//!   azure.provision_aci        — spin up an ACI container, return endpoint_url + lease_id
+//!   azure.deprovision          — tear down by lease_id
+//!   azure.heartbeat            — renew lease TTL
+//!   azure.list_leases          — active resources + TTLs
+//!   azure.cost_estimate        — current-month spend for the control plane RG
+//!   azure.keyvault_get_secret  — fetch a secret by (vault_name, secret_name)
 //!
 //! Lease state stored in Azure Table Storage (b00tLeases table).
 //! Background watchdog tears down leases where expires_at < now().
@@ -154,6 +155,17 @@ struct HeartbeatInput {
     /// New TTL from now in minutes. Defaults to server-configured default.
     #[serde(default)]
     ttl_minutes: Option<i64>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct KeyvaultGetSecretInput {
+    /// Key Vault name (the `xyz` in `https://xyz.vault.azure.net`), not the full URL.
+    vault_name: String,
+    /// Secret name within the vault.
+    secret_name: String,
+    /// Specific version to fetch. Defaults to the latest enabled version.
+    #[serde(default)]
+    version: Option<String>,
 }
 
 // ---------------------------------------------------------------------------
@@ -654,6 +666,78 @@ impl AzureCpServer {
                         .map_err(|e| McpError::internal_error(e.to_string(), None))?,
                 ]))
             }
+        }
+    }
+
+    /// Fetch a secret's value from an Azure Key Vault by (vault_name, secret_name).
+    ///
+    /// Uses the same managed-identity credential as every other tool on this
+    /// server — the identity needs the "Key Vault Secrets User" role (or
+    /// equivalent access policy) on the target vault. This is the
+    /// server-side counterpart to `b00t secret resolve --azure-vault/--azure-secret`
+    /// in b00t-cli, which instead shells out to `az keyvault secret show`
+    /// using the developer's own `az login` session — that path is for local,
+    /// one-shot CLI/script use; this tool is for agents talking to the
+    /// deployed control plane, where no local `az` session exists.
+    #[tool(name = "azure.keyvault_get_secret")]
+    async fn keyvault_get_secret(
+        &self,
+        input: Parameters<KeyvaultGetSecretInput>,
+    ) -> Result<CallToolResult, McpError> {
+        let input = input.0;
+
+        let path = match &input.version {
+            Some(v) => format!("secrets/{}/{}", input.secret_name, v),
+            None => format!("secrets/{}", input.secret_name),
+        };
+        let url = format!(
+            "https://{}.vault.azure.net/{}?api-version=7.4",
+            input.vault_name, path
+        );
+
+        let token = self
+            .credential
+            .get_token(&["https://vault.azure.net/.default"])
+            .await
+            .map_err(|e| McpError::internal_error(format!("credential error: {e}"), None))?;
+
+        let resp = self
+            .http_client
+            .get(&url)
+            .bearer_auth(token.token.secret())
+            .send()
+            .await
+            .map_err(|e| McpError::internal_error(format!("keyvault request failed: {e}"), None))?;
+
+        if resp.status().is_success() {
+            let body: serde_json::Value = resp
+                .json()
+                .await
+                .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+            let value = body.get("value").and_then(|v| v.as_str()).ok_or_else(|| {
+                McpError::internal_error("keyvault response had no 'value' field", None)
+            })?;
+            {
+                let _mjson = serde_json::json!({
+                    "vault_name": input.vault_name,
+                    "secret_name": input.secret_name,
+                    "value": value,
+                });
+                Ok(CallToolResult::success(vec![
+                    Content::json(_mjson)
+                        .map_err(|e| McpError::internal_error(e.to_string(), None))?,
+                ]))
+            }
+        } else {
+            let status = resp.status();
+            let text = resp.text().await.unwrap_or_default();
+            Err(McpError::internal_error(
+                format!(
+                    "keyvault get_secret failed: HTTP {} for '{}/{}': {}",
+                    status, input.vault_name, input.secret_name, text
+                ),
+                None,
+            ))
         }
     }
 }


### PR DESCRIPTION
## Summary
- Adds `azure.keyvault_get_secret` as a sixth MCP tool on the existing `b00t-azure-cp` control-plane server (alongside provision_aci/deprovision/heartbeat/list_leases/cost_estimate), following `cost_estimate`'s exact pattern: reuse the server's existing `AppServiceManagedIdentityCredential` to get a `vault.azure.net`-scoped token, call the Key Vault REST API directly via the shared `reqwest` client.
- This is the server-side counterpart to the forthcoming `b00t secret resolve --azure-vault/--azure-secret` in b00t-cli (separate PR), which instead shells out to `az keyvault secret show` using the developer's own `az login` session for local/script use.
- Fixes a real bug in `_b00t_/hooks/pre-push` found while validating this change: `cargo test --lib -p <pkg>` errors ("no library targets found") for any `-p` package that's bin-only, even when other selected packages in the same invocation have a lib target — the check is per-package. This blocked every push touching `b00t-azure-cp` (`[[bin]]`-only) regardless of correctness. Fixed by splitting the selected-package set: `--lib` for lib-having packages, `--bins` for bin-only ones.

## Test plan
- [x] `cargo build -p b00t-azure-cp` — clean
- [x] Verified the hook fix's classification logic directly against `cargo metadata` (b00t-azure-cp → bin-only, b00t-cli → has-lib)
- [x] Full pre-push gate (hook change → conservative full b00t-cli test run, 1517 tests) — green
- [ ] Live Key Vault call not exercised here (needs a deployed control plane + a vault with the identity granted "Key Vault Secrets User" — out of scope for this PR)