### PR TITLE
feat(secrets): add SecretSource::AzureKeyVault

### DIFF
--- a/b00t-cli/src/commands/secret.rs
+++ b/b00t-cli/src/commands/secret.rs
@@ -11,23 +11,40 @@ use clap::Subcommand;
 
 #[derive(Debug, Subcommand)]
 pub enum SecretCommands {
-    #[clap(about = "Resolve a single secret from a file or environment variable and print it to stdout")]
+    #[clap(about = "Resolve a single secret from a file, environment variable, or Azure Key Vault, and print it to stdout")]
     Resolve {
         #[clap(long, help = "Resolve from this file path (whitespace-trimmed)")]
         file: Option<String>,
         #[clap(long, help = "Resolve from this environment variable name")]
         env: Option<String>,
+        #[clap(long, help = "Resolve from this Azure Key Vault name (requires --azure-secret; uses the active `az login` session)", requires = "azure_secret")]
+        azure_vault: Option<String>,
+        #[clap(long, help = "Secret name within --azure-vault", requires = "azure_vault")]
+        azure_secret: Option<String>,
     },
 }
 
 pub fn handle_secret_command(cmd: &SecretCommands) -> Result<()> {
     match cmd {
-        SecretCommands::Resolve { file, env } => {
-            let source = match (file, env) {
-                (Some(path), None) => SecretSource::File { path: path.clone() },
-                (None, Some(name)) => SecretSource::EnvVar { name: name.clone() },
-                (Some(_), Some(_)) => bail!("pass exactly one of --file or --env, not both"),
-                (None, None) => bail!("pass one of --file <path> or --env <name>"),
+        SecretCommands::Resolve {
+            file,
+            env,
+            azure_vault,
+            azure_secret,
+        } => {
+            let source = match (file, env, azure_vault, azure_secret) {
+                (Some(path), None, None, None) => SecretSource::File { path: path.clone() },
+                (None, Some(name), None, None) => SecretSource::EnvVar { name: name.clone() },
+                (None, None, Some(vault), Some(name)) => SecretSource::AzureKeyVault {
+                    vault: vault.clone(),
+                    name: name.clone(),
+                },
+                (None, None, None, None) => {
+                    bail!("pass one of --file <path>, --env <name>, or --azure-vault <vault> --azure-secret <name>")
+                }
+                _ => bail!(
+                    "pass exactly one of --file, --env, or --azure-vault/--azure-secret together, not a mix"
+                ),
             };
             let value = load_secret(&SecretRef {
                 key: "cli-resolve".to_string(),

--- a/b00t-cli/src/pipeline_secrets.rs
+++ b/b00t-cli/src/pipeline_secrets.rs
@@ -33,6 +33,17 @@ pub enum SecretSource {
         /// Human-readable prompt shown to the user.
         description: String,
     },
+    /// Read a secret's value from an Azure Key Vault, via the `az` CLI using
+    /// whatever `az login`/service-principal session is already active on
+    /// this host. Prototype/backup path — see `b00t-azure-cp`'s
+    /// `azure.keyvault_get_secret` MCP tool for the server-side counterpart
+    /// used by agents with no local `az` session.
+    AzureKeyVault {
+        /// Key Vault name (the `xyz` in `https://xyz.vault.azure.net`).
+        vault: String,
+        /// Secret name within the vault.
+        name: String,
+    },
 }
 
 // ── SecretRef ─────────────────────────────────────────────────────────────
@@ -172,6 +183,41 @@ pub fn load_secret(ref_: &SecretRef) -> Result<String> {
             let prompt = format!("{}: ", description);
             rpassword::prompt_password(&prompt)
                 .map_err(|e| anyhow!("failed to read secret from prompt: {}", e))
+        }
+        SecretSource::AzureKeyVault { vault, name } => {
+            let output = std::process::Command::new("az")
+                .args([
+                    "keyvault",
+                    "secret",
+                    "show",
+                    "--vault-name",
+                    vault,
+                    "--name",
+                    name,
+                    "--query",
+                    "value",
+                    "-o",
+                    "tsv",
+                ])
+                .output()
+                .with_context(|| {
+                    format!(
+                        "failed to run `az keyvault secret show` for '{}/{}' — is the az CLI installed and on PATH?",
+                        vault, name
+                    )
+                })?;
+            if !output.status.success() {
+                let stderr = String::from_utf8_lossy(&output.stderr);
+                anyhow::bail!(
+                    "az keyvault secret show failed for '{}/{}': {}",
+                    vault,
+                    name,
+                    stderr.trim()
+                );
+            }
+            let value = String::from_utf8(output.stdout)
+                .with_context(|| format!("az output for '{}/{}' was not valid UTF-8", vault, name))?;
+            Ok(value.trim().to_string())
         }
     }
 }
@@ -521,6 +567,10 @@ mod tests {
             },
             SecretSource::Prompt {
                 description: "Enter token".into(),
+            },
+            SecretSource::AzureKeyVault {
+                vault: "my-vault".into(),
+                name: "my-secret".into(),
             },
         ];
         for v in variants {


### PR DESCRIPTION
## Summary
Stacked on #1073 (needs `b00t-cli/src/commands/secret.rs` to exist first).

- New `SecretSource::AzureKeyVault { vault, name }` in `pipeline_secrets.rs`, resolved via `az keyvault secret show --vault-name <vault> --name <name> --query value -o tsv` using whatever `az login` session is already active on the host.
- Wires into `b00t secret resolve` as `--azure-vault`/`--azure-secret` (clap `requires` enforces both-or-neither), alongside the existing `--file`/`--env`.
- Server-side counterpart to this is `b00t-azure-cp`'s new `azure.keyvault_get_secret` MCP tool (#1074) — that path is for agents talking to the deployed control plane with no local `az` session; this path is for local/script one-shot use.

## Test plan
- [x] `cargo test --lib pipeline_secrets` — 15/15 pass, including the exhaustive `SecretSource` round-trip test extended to cover the new variant
- [x] `b00t secret resolve --azure-vault x` (no `--azure-secret`) → clap `requires` correctly rejects with "required arguments were not provided"
- [x] `b00t secret resolve --file x --env y` → correctly rejected by the mutual-exclusion check
- [x] `b00t secret resolve --env MY_TEST_SECRET` → happy path works
- [x] `b00t secret resolve --azure-vault this-vault-does-not-exist-xyz --azure-secret foo` against the real `az` CLI (this host has an active `az login` session, tenant `promptexecution.com`) → correctly surfaces az's own DNS-resolution error through `load_secret`'s error path, proving the `Command`/args/stdout/stderr wiring end-to-end