### PR TITLE
fix(ci): checkout submodules in build-release.yml

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -70,6 +70,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ needs.resolve-release.outputs.tag }}
+          submodules: recursive
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
## Summary
Every run of `build-release.yml` has failed since it was added — its only historical run (v0.8.4, 2026-06-23) failed on all 5 build targets with the same root cause: `actions/checkout@v4` doesn't recurse submodules by default, so `vendor/l3dg3rr` (containing `crates/b00t-reflect-types`, a workspace member referenced from the root `Cargo.toml`) was missing at build time:

```
error: failed to load manifest for workspace member `.../b00t-cli`
Caused by: failed to load manifest for dependency `b00t-reflect-types`
Caused by: failed to read `.../vendor/l3dg3rr/crates/b00t-reflect-types/Cargo.toml`
Caused by: No such file or directory (os error 2)
```

Fix: add `submodules: recursive` to the checkout step.

Found while looking for a working `b00t-x86_64-unknown-linux-gnu.tar.gz` release asset to provision a Vultr VPS from (`PromptExecution/infrastructure`, in progress) — none exists yet since this was broken from the start. Cutting a new release tag to actually produce one is a separate step, not done here.

## Test plan
- [x] Root-caused via `gh run view --log-failed` on the only historical run
- [ ] Not re-run here (requires publishing a real GitHub Release, which triggers this workflow) — next release cut will be the real test