### PR TITLE
fix(ci): skip unrelated emoji-path submodule in build-release.yml

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -70,7 +70,23 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ needs.resolve-release.outputs.tag }}
-          submodules: recursive
+          submodules: false
+
+      - name: Checkout submodules (excluding unrelated non-Rust submodules)
+        shell: bash
+        run: |
+          set -euo pipefail
+          # python.🐍/DALLE2-pytorch is a Python ML repo, not a Cargo
+          # workspace member (confirmed: absent from root Cargo.toml) — and
+          # its emoji path hits a real actions/checkout + git bug on hosted
+          # runners: `git submodule update --init --recursive` errors with
+          # `ENOENT .../. git/modules/python.🐍/DALLE2-pytorch/config`
+          # (first release attempt after the #1082 recursive-submodule fix,
+          # 2026-08-11). Deactivating it lets everything else — including
+          # vendor/l3dg3rr, the actual submodule this workflow needs —
+          # init normally.
+          git config submodule."python.🐍/DALLE2-pytorch".active false
+          git submodule update --init --recursive
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
## Summary
v0.10.3's release build (first attempt after #1082's recursive-submodule fix) got past the original `vendor/l3dg3rr` issue but failed on all 5 targets at the submodule-checkout step itself:

\`\`\`
ENOENT: no such file or directory, open '.../.git/modules/python.🐍/DALLE2-pytorch/config'
\`\`\`

`python.🐍/DALLE2-pytorch` is a Python ML repo submodule, not a Cargo workspace member (confirmed absent from root `Cargo.toml`) — not needed for this build. Its emoji path appears to trip a real git/`actions-checkout` bug on hosted runners.

Fix: split the single `submodules: recursive` checkout into an explicit checkout (`submodules: false`) + a `git submodule update --init --recursive` step that deactivates just this one submodule first, so everything else — including `vendor/l3dg3rr`, the actual submodule this workflow needs — still inits normally.

## Test plan
- [x] Confirmed `python.🐍/DALLE2-pytorch` is the only non-ASCII submodule path in `.gitmodules` (no other lurking instances)
- [x] Verified locally that `git config submodule."python.🐍/DALLE2-pytorch".active false` is accepted without quoting/escaping issues
- [ ] The ENOENT itself is runner-specific and can only be confirmed by a real run — next release attempt (v0.10.3, in progress) is the real test