### PR TITLE
chore: bump workspace version to 0.10.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1376,7 +1376,7 @@ version = "0.1.0"
 
 [[package]]
 name = "b00t-admin"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "axum 0.8.9",
  "b00t-c0re-lib",
@@ -1399,7 +1399,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-ast"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "anyhow",
  "clap",
@@ -1415,7 +1415,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-azure-cp"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -1439,7 +1439,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-bouncer"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1453,7 +1453,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-c0re-a2a"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "chrono",
  "serde",
@@ -1466,7 +1466,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-c0re-gov"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "async-trait",
  "b00t-c0re-lib",
@@ -1483,7 +1483,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-c0re-hierarchy"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "b00t-c0re-gov",
  "b00t-council",
@@ -1496,7 +1496,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-c0re-lib"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -1558,7 +1558,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-candle-serve"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "anyhow",
  "candle-core 0.11.0",
@@ -1571,7 +1571,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-chat"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "anyhow",
  "arrow",
@@ -1614,7 +1614,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-cli"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "anyhow",
  "apalis",
@@ -1711,7 +1711,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-council"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1722,7 +1722,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-datum-core"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1734,7 +1734,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-embed"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1755,7 +1755,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-embed-serve"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -1768,7 +1768,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-grok"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "anyhow",
  "async-openai",
@@ -1787,7 +1787,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-ipc"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -1808,7 +1808,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-isometric-wasm"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "b00t-l3dg3rr-viz",
  "serde_json",
@@ -1817,7 +1817,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-l3dg3rr-viz"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "blake3",
  "kasuari",
@@ -1828,7 +1828,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-lsp"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "anyhow",
  "b00t-datum-core",
@@ -1842,7 +1842,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-mcp"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -1887,7 +1887,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-mermaid-wasm"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "mermaid-rs-renderer",
  "wasm-bindgen",
@@ -1895,7 +1895,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-pyverse"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "anyhow",
  "b00t-c0re-lib",
@@ -1910,11 +1910,11 @@ dependencies = [
 
 [[package]]
 name = "b00t-reflect-types"
-version = "0.10.3"
+version = "0.10.4"
 
 [[package]]
 name = "b00t-stt-serve"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -1927,7 +1927,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-ui-wasm"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "dioxus",
  "dioxus-web",
@@ -1944,7 +1944,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-zellij"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "b00t-c0re-lib",
  "chrono",
@@ -7208,7 +7208,7 @@ dependencies = [
 
 [[package]]
 name = "k0mmand3r"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "decimal-rs",
  "indexmap 2.14.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ resolver = "2"
 [workspace.package]
 # 🤓 Version management centralized in b00t-c0re-lib
 # All workspace crates inherit from the single source of truth
-version = "0.10.3"
+version = "0.10.4"
 edition = "2024"
 authors = ["Brian Horakh <brian@promptexecution.com>"]
 license = "MIT"

--- a/b00t-cli/src/runtime_sandbox.rs
+++ b/b00t-cli/src/runtime_sandbox.rs
@@ -24,6 +24,7 @@ use std::ffi::CString;
 /// `evaluate_gates`/`GatePreconditions` elsewhere) — needed to resolve
 /// relative `file` gates. Pass whatever `path` was used to resolve the
 /// runtime datum in the first place.
+#[cfg(target_os = "linux")]
 pub fn spawn_sandboxed(
     config: &RuntimeConfig,
     passthrough_args: &[String],
@@ -146,7 +147,9 @@ pub fn spawn_sandboxed(
 }
 
 // ── Child-only functions — async-signal-safe (no heap, no format, no alloc) ──
+// Linux-only: unshare(2)/mount(2)/prctl(2) below don't exist in macOS's libc.
 
+#[cfg(target_os = "linux")]
 fn child_sandbox(
     iso: &Option<IsolationConfig>,
     cwd: Option<&std::ffi::CStr>,
@@ -182,6 +185,7 @@ fn child_sandbox(
     Ok(())
 }
 
+#[cfg(target_os = "linux")]
 fn child_enter_namespaces(iso: &IsolationConfig) -> Result<(), u8> {
     let mut ns_flags = libc::CLONE_NEWNS;
 
@@ -204,6 +208,7 @@ fn child_enter_namespaces(iso: &IsolationConfig) -> Result<(), u8> {
     Ok(())
 }
 
+#[cfg(target_os = "linux")]
 fn child_mount_root() -> Result<(), u8> {
     if unsafe {
         libc::mount(
@@ -220,6 +225,7 @@ fn child_mount_root() -> Result<(), u8> {
     Ok(())
 }
 
+#[cfg(target_os = "linux")]
 fn child_apply_mounts(mounts: &[crate::MountEntry]) -> Result<(), u8> {
     for mnt in mounts {
         let src = CString::new(mnt.src.as_str()).map_err(|_| 4u8)?;
@@ -261,6 +267,7 @@ fn child_apply_mounts(mounts: &[crate::MountEntry]) -> Result<(), u8> {
     Ok(())
 }
 
+#[cfg(target_os = "linux")]
 fn child_bind_mount(
     src: &[u8],
     dest: &CString,
@@ -368,6 +375,7 @@ static ALL_CAPS: &[(&str, u32)] = &[
     ("CAP_CHECKPOINT_RESTORE", CAP_CHECKPOINT_RESTORE),
 ];
 
+#[cfg(target_os = "linux")]
 fn child_drop_capabilities(iso: &IsolationConfig) {
     let retain: std::collections::HashSet<&str> = iso
         .caps_retain
@@ -382,6 +390,21 @@ fn child_drop_capabilities(iso: &IsolationConfig) {
             }
         }
     }
+}
+
+/// Non-Linux stub — the real implementation forks and uses unshare(2)/
+/// mount(2)/prctl(2), none of which exist outside Linux. `resolve_binary`
+/// below stays portable/unguarded since the test suite exercises it on
+/// every platform independent of sandboxing support.
+#[cfg(not(target_os = "linux"))]
+pub fn spawn_sandboxed(
+    _config: &RuntimeConfig,
+    _passthrough_args: &[String],
+    _datum_path: &str,
+) -> Result<i32> {
+    bail!(
+        "sandboxed runtime execution requires Linux (namespace isolation via unshare(2)/mount(2)/prctl(2)); unsupported on this platform"
+    )
 }
 
 /// Resolve a binary name to an absolute path (searches PATH).


### PR DESCRIPTION
v0.10.3 was tagged before three same-day CI/code fixes (#1082-#1084) were merged, and `workflow_dispatch` re-runs of `build-release.yml` against an existing tag check out that tag's pinned commit, not current main — so re-running against v0.10.3 kept building the pre-fix code. Cutting 0.10.4 instead of force-moving v0.10.3 (no consumers of v0.10.3 exist yet — zero release assets were ever successfully produced from it).