### PR TITLE
fix(ci): unblock Linux release assets from macOS-only build failures

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -16,6 +16,11 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
+  # macos-latest runners hit a libgit2 SSL trust error fetching nested
+  # submodules (e.g. b00t-c0re-lib -> zvec -> arrow -> arrow-testing) —
+  # cargo's own error suggests this exact fix. Linux runners aren't
+  # affected, but setting it globally is harmless there too.
+  CARGO_NET_GIT_FETCH_WITH_CLI: true
 
 jobs:
   resolve-release:
@@ -45,6 +50,11 @@ jobs:
     name: Build ${{ matrix.target }}
     needs: resolve-release
     runs-on: ${{ matrix.os }}
+    # macOS legs are not required for this release's actual consumers
+    # (Vultr cloud-init only needs x86_64-unknown-linux-gnu); don't let a
+    # macOS-only toolchain/dependency issue block upload-assets from
+    # publishing the Linux targets that did succeed.
+    continue-on-error: ${{ matrix.os == 'macos-latest' }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary
- v0.10.4's release run showed both macOS matrix legs (`x86_64-apple-darwin`, `aarch64-apple-darwin`) fail while all three Linux legs succeeded — root cause is a libgit2 SSL trust error on macOS runners fetching a nested submodule chain (`b00t-c0re-lib` -> `zvec` -> `arrow` -> `arrow-testing`), unrelated to this repo's own code.
- `CARGO_NET_GIT_FETCH_WITH_CLI=true` works around it by using the system `git` CLI for fetches instead of libgit2 — this is cargo's own suggested fix, printed in the error output.
- `continue-on-error: true` on the macOS matrix legs so `upload-assets` isn't blocked when only macOS fails — the Linux targets are the actual release consumers.

## Test plan
- [ ] Re-run `workflow_dispatch` (or cut a new tag) and confirm `upload-assets`/`verify` now run and macOS no longer hard-blocks the pipeline