### PR TITLE
fix(ci): pass --repo to gh release upload

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -156,7 +156,11 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          gh release upload "${{ needs.resolve-release.outputs.tag }}" dist/* --clobber
+          # This job has no actions/checkout step (it only needs the built
+          # artifacts, not the source tree), so `gh` has no local git repo to
+          # infer --repo from and fails with "not a git repository" without
+          # this flag being explicit (confirmed failure, run 31565030616).
+          gh release upload "${{ needs.resolve-release.outputs.tag }}" dist/* --clobber --repo "${{ github.repository }}"
 
   verify:
     name: Verify x86_64 Linux release bundle


### PR DESCRIPTION
## Summary
- The `upload-assets` job in `build-release.yml` has no `actions/checkout` step (it only needs downloaded build artifacts), so `gh release upload` has no local git context to infer the target repo from and fails with `fatal: not a git repository`.
- Confirmed failing: run [31565030616](https://github.com/elasticdotventures/_b00t_/actions/runs/31565030616), triggered while chasing down a `b00t-x86_64-unknown-linux-gnu.tar.gz` release asset for `PromptExecution/infrastructure#91` (Vultr NATS node).
- Fix: pass `--repo "${{ github.repository }}"` explicitly.

## Test plan
- [ ] Re-run `workflow_dispatch` against `v0.10.4` after merge; confirm `Upload release assets` succeeds and `b00t-x86_64-unknown-linux-gnu.tar.gz` appears on the release.