### PR TITLE
fix(ci): pass --repo to gh release download in verify job

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -170,7 +170,9 @@ jobs:
       - name: Download release artifact
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release download "${{ needs.resolve-release.outputs.tag }}" --pattern "b00t-x86_64-unknown-linux-gnu.tar.gz"
+        # Same class of bug as upload-assets (#1087): no checkout in this
+        # job, so gh has no local git repo to infer --repo from.
+        run: gh release download "${{ needs.resolve-release.outputs.tag }}" --pattern "b00t-x86_64-unknown-linux-gnu.tar.gz" --repo "${{ github.repository }}"
 
       - name: Verify extracted binaries
         shell: bash


### PR DESCRIPTION
## Summary
Same bug class as #1087, in the sibling `verify` job: no `actions/checkout` step, so `gh release download` has no local git context and fails with `fatal: not a git repository`.

Confirmed in run [31583410584](https://github.com/elasticdotventures/_b00t_/actions/runs/31583410584) — `upload-assets` succeeded (the `b00t-x86_64-unknown-linux-gnu.tar.gz` asset is live on `v0.10.4`), but `verify` still failed on this.

## Test plan
- [ ] Re-run `workflow_dispatch` against `v0.10.4` after merge; confirm the `verify` job downloads and extracts the bundle successfully this time.