### PR TITLE
feat: vultr1 NATS hive node + Azure zone-wide secret export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,6 +172,11 @@
 # location is ~/.b00t/secrets/ (see b00t-cli/scripts/sync-*-secrets.sh), but a
 # stray duplicate has appeared at repo-root before; never let either in.
 /secrets/
+
+# vultr1 NATS leaf credential — nats.conf's `include` directive pulls this
+# in at the actual path below, not the root-level /secrets/ above; must be
+# ignored explicitly or the leaf password reaches a public host in git.
+nats/leaf-remotes.conf
 .eslintcache
 .fusebox/
 .grunt

--- a/_b00t_/datums/PROVIDER-VULTR.provider.tomllmd
+++ b/_b00t_/datums/PROVIDER-VULTR.provider.tomllmd
@@ -14,9 +14,11 @@
 #      v2 Instances API (VPS create/get/delete/list); Vultr has no
 #      serverless-inference or managed-job-queue primitive, so the
 #      training/batch job methods bail with a pointer to provider=runpod/hf.
-#      Instance region/plan/os_id default to the same placeholders as
-#      infrastructure repo's vultr_app4dog.tf ("syd" / vc2-1c-1gb / Debian
-#      12), overridable via VULTR_REGION/VULTR_PLAN/VULTR_OS_ID.
+#      Instance region/plan/os_id default to "syd" / vc2-1c-1gb / Debian 12,
+#      overridable via VULTR_REGION/VULTR_PLAN/VULTR_OS_ID. (No
+#      vultr_app4dog.tf exists in the infrastructure repo — that file was
+#      never created; provisioning so far has gone through b00t-cli directly,
+#      not Terraform.)
 #   3. DNS-01 ACME challenge provider — a concrete, currently-live need found
 #      independently while researching this: app4dog's SSL cert automation
 #      for app4.dog/play.app4.dog/api.app4.dog is disabled
@@ -26,9 +28,24 @@
 #      `_acme-challenge.*` via CNAME to a stable zone on a different DNS
 #      provider — Vultr DNS is the natural target (native DNS-01 support in
 #      both lego and terraform-provider-acme, env var VULTR_API_KEY).
-#   4. General VPS hosting — concretely, a Vultr VPS will run NATS as a
-#      pub/sub component within a larger DAPR service mesh (see
-#      dapr.cli.tomllm). Not yet provisioned.
+#   4. General VPS hosting — concretely, a Vultr VPS runs NATS as a pub/sub
+#      component within a larger DAPR service mesh (see dapr.cli.tomllm).
+#      PROVISIONED 2026-08-15/16: node "vultr1" (207.148.87.195, Debian 12,
+#      via `b00t provider endpoint deploy --provider vultr`), joined as a
+#      leaf-accept peer to the LAN hub on fung1 alongside sm3lly
+#      (192.168.1.137). Per the pre-existing "b00t-node" firewall-group
+#      convention (only 22/80/443 public), the leaf listener binds to
+#      127.0.0.1:443 only — fung1 reaches it over an SSH tunnel
+#      (192.168.1.149:17443 -> vultr1's 127.0.0.1:443), not direct public
+#      exposure. SSH access: `ssh vultr1` (key-based, see ~/.ssh/config).
+#      Setup script: ~/.dotfiles/nats/vultr-node-setup.sh (note: its baked-in
+#      template still generates a TLS leaf-accept config; the live vultr1
+#      config was hand-edited afterward to drop TLS in favor of the SSH
+#      tunnel, so the script is stale if re-run — reconcile before reuse).
+#      app4dog justfile recipes: `just vultr-node-ssh`, `just
+#      vultr-node-status`, `just vultr-tunnel-install` (persistent systemd
+#      unit for the SSH tunnel), `just vultr-task-demo` (verified end-to-end
+#      cross-leaf task dispatch fung1 -> vultr1).
 #
 # Auth: VULTR_API_KEY env var (Account -> API in the Vultr customer portal).
 # 🤓 GPU flavor/pricing tables deliberately omitted here — unlike

--- a/_b00t_/datums/RUNPOD-CLAUDE-CODE.skill.tomllmd
+++ b/_b00t_/datums/RUNPOD-CLAUDE-CODE.skill.tomllmd
@@ -1,0 +1,54 @@
+# RunPod agent plugin for Claude Code — install + activate
+#
+# Vendor doc: https://docs.runpod.io/agent-setup.md
+# Companion API/SDK datum: PROVIDER-RUNPOD.provider.tomllmd (Rust client, endpoint deploy)
+#
+# Installs a marketplace-hosted Claude Code plugin (not a project-local skill dir):
+# a router plus six skills (runpod, runpod-mcp, runpodctl, flash, runpod-usage,
+# companion-clis) plus the RunPod MCP server for platform control tools.
+# runpodctl CLI and the Flash SDK install lazily on first use — no manual step.
+#
+# Auth is OAuth via `/mcp` inside a live session — no API key is created or
+# stored by this flow (separate from RUNPOD_API_KEY used by the Rust/API path
+# in PROVIDER-RUNPOD.provider.tomllmd, which is unaffected by this plugin).
+#
+# 🤓 verified 2026-08-15: `claude plugin marketplace add` + `claude plugin
+#    install` both ran clean, `claude plugin list` shows runpod@runpod v1.1.2
+#    (scope: user). The two remaining steps (/reload-plugins, /mcp OAuth
+#    sign-in) are interactive session actions — cannot be scripted/verified
+#    headlessly, must be done by a human in-session.
+
+[b00t.schema]
+version   = "1"
+type      = "skill"
+type_tags = ["claude-code", "plugin", "agent", "runpod", "mcp", "gpu", "cloud"]
+
+[resource]
+name        = "runpod-claude-code-plugin"
+description = "RunPod's official Claude Code plugin — marketplace-hosted agent skills + MCP server for GPU pod/endpoint control from within a session"
+docs        = "https://docs.runpod.io/get-started/agent-skills"
+docs_mcp    = "https://docs.runpod.io/get-started/mcp-servers"
+
+[resource.commands]
+add_marketplace = "claude plugin marketplace add runpod/runpod-plugins-official"
+install         = "claude plugin install runpod@runpod"
+verify          = "claude plugin list | grep -A2 'runpod@runpod'"
+
+[resource.session_actions]
+# 🤓 not scriptable — both require an interactive Claude Code session
+reload_plugins = "/reload-plugins"
+oauth_signin   = "/mcp -> runpod -> Sign in with Runpod"
+post_auth_check = "list Pods via the runpod MCP tools; empty list = connected"
+
+[resource.rules]
+# see feedback_runpod_antipattern_and_local_build_toil memory: this plugin is
+# agent/session tooling for controlling RunPod, not a license to build heavy
+# CUDA images locally or leave Pods running without a TTL/reaper plan
+no_api_key_stored = true
+
+# b00t:map v1
+# summary: RunPod Claude Code plugin — marketplace add + install verified working, OAuth/reload are manual in-session steps
+# tags: claude-code, plugin, runpod, mcp, agent-skill
+# tier: sm0l
+# cmds: claude plugin marketplace add runpod/runpod-plugins-official, claude plugin install runpod@runpod
+# complexity: 1

--- a/b00t-cli/src/commands/secret.rs
+++ b/b00t-cli/src/commands/secret.rs
@@ -5,9 +5,10 @@
 //    deliberately excluded here: Keyring is a broken placeholder (feature
 //    flag exists, no keyring crate dependency), Prompt defeats the purpose
 //    of a script-invoked, non-interactive call.
-use crate::pipeline_secrets::{SecretRef, SecretSource, load_secret};
+use crate::pipeline_secrets::{SecretRef, SecretSource, list_azure_secret_names, load_secret};
 use anyhow::{Result, bail};
 use clap::Subcommand;
+use std::collections::BTreeMap;
 
 #[derive(Debug, Subcommand)]
 pub enum SecretCommands {
@@ -22,6 +23,37 @@ pub enum SecretCommands {
         #[clap(long, help = "Secret name within --azure-vault", requires = "azure_vault")]
         azure_secret: Option<String>,
     },
+    #[clap(about = "Bulk-export all secrets for a base/zone/org from a cloud secret store, for consumption by Terraform's `data external` (see infrastructure repo's secretEnvy module)")]
+    ExportZone {
+        #[clap(long, help = "Secret store provider — only 'azure' is currently supported")]
+        provider: String,
+        #[clap(long, help = "Azure Key Vault name")]
+        vault: String,
+        #[clap(long, default_value = "config", help = "Base path segment for the name prefix")]
+        base: String,
+        #[clap(long, help = "Zone path segment for the name prefix (e.g. 'global', 'test', 'live')")]
+        zone: String,
+        #[clap(long, help = "Optional org path segment for the name prefix")]
+        org: Option<String>,
+        #[clap(long, help = "Output as a flat JSON object of ENV_VAR: value, for Terraform's `data external` contract")]
+        tf: bool,
+    },
+}
+
+/// Build the Azure Key Vault secret-name prefix for a base/zone/org triple.
+/// Key Vault secret names only allow alphanumerics and hyphens, so unlike
+/// AWS (`/`-joined) or GCP (`-`-joined) this is always hyphen-joined.
+fn azure_export_prefix(base: &str, zone: &str, org: Option<&str>) -> String {
+    match org {
+        Some(org) => format!("{base}-{zone}-{org}-"),
+        None => format!("{base}-{zone}-"),
+    }
+}
+
+/// Derive an env-var name from an Azure Key Vault secret name, e.g.
+/// `vultr-api-key` -> `VULTR_API_KEY`.
+fn azure_secret_name_to_env_var(name: &str) -> String {
+    name.to_uppercase().replace('-', "_")
 }
 
 pub fn handle_secret_command(cmd: &SecretCommands) -> Result<()> {
@@ -54,5 +86,61 @@ pub fn handle_secret_command(cmd: &SecretCommands) -> Result<()> {
             println!("{value}");
             Ok(())
         }
+        SecretCommands::ExportZone {
+            provider,
+            vault,
+            base,
+            zone,
+            org,
+            tf,
+        } => {
+            if provider != "azure" {
+                bail!("unsupported provider '{provider}' — only 'azure' is currently supported");
+            }
+            if !tf {
+                bail!("--tf is the only supported output mode currently");
+            }
+            let prefix = azure_export_prefix(base, zone, org.as_deref());
+            let names = list_azure_secret_names(vault, &prefix)?;
+            let mut out = BTreeMap::new();
+            for name in names {
+                let value = load_secret(&SecretRef {
+                    key: name.clone(),
+                    env_var: String::new(),
+                    source: SecretSource::AzureKeyVault {
+                        vault: vault.clone(),
+                        name: name.clone(),
+                    },
+                })?;
+                out.insert(azure_secret_name_to_env_var(&name), value);
+            }
+            println!("{}", serde_json::to_string(&out)?);
+            Ok(())
+        }
+    }
+}
+
+#[cfg(test)]
+mod export_zone_tests {
+    use super::*;
+
+    #[test]
+    fn prefix_without_org() {
+        assert_eq!(azure_export_prefix("config", "global", None), "config-global-");
+    }
+
+    #[test]
+    fn prefix_with_org() {
+        assert_eq!(
+            azure_export_prefix("config", "global", Some("app4dog")),
+            "config-global-app4dog-"
+        );
+    }
+
+    #[test]
+    fn env_var_derivation() {
+        assert_eq!(azure_secret_name_to_env_var("vultr-api-key"), "VULTR_API_KEY");
+        assert_eq!(azure_secret_name_to_env_var("cloudflare-api-token"), "CLOUDFLARE_API_TOKEN");
+        assert_eq!(azure_secret_name_to_env_var("already-upper-ISH"), "ALREADY_UPPER_ISH");
     }
 }

--- a/b00t-cli/src/pipeline_secrets.rs
+++ b/b00t-cli/src/pipeline_secrets.rs
@@ -222,6 +222,44 @@ pub fn load_secret(ref_: &SecretRef) -> Result<String> {
     }
 }
 
+/// List Azure Key Vault secret names starting with `prefix`, via the active
+/// `az login` session — same identity/mechanism as the `AzureKeyVault` arm
+/// of [`load_secret`]. Used by `b00t secret export-zone` to discover which
+/// secrets belong to a given base/zone/org before fetching each one.
+pub fn list_azure_secret_names(vault: &str, prefix: &str) -> Result<Vec<String>> {
+    let query = format!("[?starts_with(name, '{prefix}')].name");
+    let output = std::process::Command::new("az")
+        .args([
+            "keyvault",
+            "secret",
+            "list",
+            "--vault-name",
+            vault,
+            "--query",
+            &query,
+            "-o",
+            "tsv",
+        ])
+        .output()
+        .with_context(|| {
+            format!(
+                "failed to run `az keyvault secret list` for vault '{}' — is the az CLI installed and on PATH?",
+                vault
+            )
+        })?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!(
+            "az keyvault secret list failed for vault '{}': {}",
+            vault,
+            stderr.trim()
+        );
+    }
+    let text = String::from_utf8(output.stdout)
+        .with_context(|| format!("az output for vault '{}' was not valid UTF-8", vault))?;
+    Ok(text.lines().map(str::trim).filter(|l| !l.is_empty()).map(String::from).collect())
+}
+
 // ── SecureStageEnv ────────────────────────────────────────────────────────
 
 /// A pipeline stage with its associated secret refs and an optional resolved

--- a/nats/nats.conf
+++ b/nats/nats.conf
@@ -12,11 +12,26 @@ authorization {
   ]
 }
 
-# No clustering (2-node setup — direct connect)
-# Leafnode for sm3lly when it comes online:
-# leafnodes {
-#   port: 7422
-# }
+# No clustering (direct connect between LAN peers)
+# sm3lly connects directly as a plain LAN client (same subnet, no NAT), so
+# it never needed the leafnode stub this comment used to describe.
+#
+# vultr1 (Vultr VPS, provisioned via `b00t provider endpoint deploy
+# --provider vultr`) is not on the LAN. Per the pre-existing "b00t-node"
+# firewall-group convention (only 22/80/443 public, reserved for
+# SSH/pingap; NATS/Dapr stay localhost-only), its nats-server binds its
+# leaf listener to 127.0.0.1 only — fung1 reaches it through a persistent
+# SSH tunnel over port 22 (nats-vultr1-tunnel.service, forwards
+# 192.168.1.149:17443 -> vultr1's 127.0.0.1:443) rather than direct public
+# exposure. No TLS needed here since the SSH tunnel already encrypts the
+# transport. Real credential lives in secrets/nats-leaf-vultr1.conf
+# (gitignored) — NATS config `$VAR` substitution only resolves whole bare
+# values, not references embedded inside a quoted compound string like a
+# URL, so env-var interpolation doesn't work here; `include` is the only
+# way to keep this out of git. Unlike the LAN password above, this
+# credential ultimately reaches a public host and must never be committed
+# in plaintext.
+include ./leaf-remotes.conf
 
 # Minimal logging
 debug: false

--- a/nats/nats.conf
+++ b/nats/nats.conf
@@ -24,8 +24,8 @@ authorization {
 # SSH tunnel over port 22 (nats-vultr1-tunnel.service, forwards
 # 192.168.1.149:17443 -> vultr1's 127.0.0.1:443) rather than direct public
 # exposure. No TLS needed here since the SSH tunnel already encrypts the
-# transport. Real credential lives in secrets/nats-leaf-vultr1.conf
-# (gitignored) — NATS config `$VAR` substitution only resolves whole bare
+# transport. Real credential lives in nats/leaf-remotes.conf (gitignored,
+# see .gitignore) — NATS config `$VAR` substitution only resolves whole bare
 # values, not references embedded inside a quoted compound string like a
 # URL, so env-var interpolation doesn't work here; `include` is the only
 # way to keep this out of git. Unlike the LAN password above, this

--- a/nats/vultr-node-setup.sh
+++ b/nats/vultr-node-setup.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+# Configure a fresh Vultr VPS as a NATS leaf-accept peer for the b00t hive.
+#
+# Unlike fung1 (home NAT, no public IP), the Vultr node has a public IP —
+# but per the pre-existing "b00t-node" firewall-group convention (only
+# 22/80/443 public, reserved for SSH/pingap; NATS/Dapr stay localhost-only),
+# the leaf listener binds to 127.0.0.1 only, NOT 0.0.0.0. The LAN hub reaches
+# it via an SSH tunnel over port 22 (already open), not direct public
+# exposure — so no TLS is needed here, the SSH tunnel already encrypts the
+# transport. This node uses its own distinct credential (not the LAN-only
+# b00t-hive-lan secret in ~/.dotfiles/nats/nats.conf). The LAN hub then dials
+# OUT to it (via the tunnel) as a leafnodes.remotes entry (separate step —
+# see ~/.dotfiles/secrets/nats-leaf-<host>.conf convention).
+#
+# Usage: ./vultr-node-setup.sh <ssh-host-alias> [leaf-port]
+set -euo pipefail
+
+HOST="${1:?usage: vultr-node-setup.sh <ssh-host-alias> [leaf-port]}"
+LEAF_PORT="${2:-443}"
+LEAF_USER="b00t-leaf"
+LEAF_PASSWORD="$(openssl rand -hex 24)"
+
+echo "== Installing nats-server on $HOST =="
+LATEST_TAG=$(ssh "$HOST" "curl -sL https://api.github.com/repos/nats-io/nats-server/releases/latest | grep -m1 '\"tag_name\"' | cut -d'\"' -f4")
+echo "latest nats-server release: $LATEST_TAG"
+ssh "$HOST" "set -e
+  curl -sL https://github.com/nats-io/nats-server/releases/download/${LATEST_TAG}/nats-server-${LATEST_TAG}-linux-amd64.tar.gz -o /tmp/nats-server.tar.gz
+  tar -xzf /tmp/nats-server.tar.gz -C /tmp
+  install -m 755 /tmp/nats-server-${LATEST_TAG}-linux-amd64/nats-server /usr/local/bin/nats-server
+  nats-server --version
+  mkdir -p /etc/nats"
+
+echo "== Writing /etc/nats/nats.conf (leaf-accept mode, localhost-only, no TLS) =="
+ssh "$HOST" "cat > /etc/nats/nats.conf" <<EOF
+# b00t ACP NATS server — Vultr leaf-accept node. Per the pre-existing
+# "b00t-node" firewall-group convention (only 22/80/443 are meant to be
+# public, reserved for SSH/pingap; NATS/Dapr stay localhost-only), the
+# leafnode listener binds to 127.0.0.1 only. The LAN hub reaches it via an
+# SSH tunnel over port 22 (already open), not direct public exposure — no
+# TLS needed here since the SSH tunnel already encrypts the transport.
+port: 4222
+http_port: 8222
+
+authorization {
+  users = [
+    { user: "${LEAF_USER}", password: "${LEAF_PASSWORD}" }
+  ]
+}
+
+leafnodes {
+  host: "127.0.0.1"
+  port: ${LEAF_PORT}
+}
+
+debug: false
+trace: false
+EOF
+
+echo "== Installing systemd unit =="
+ssh "$HOST" "cat > /etc/systemd/system/nats-server.service" <<'EOF'
+[Unit]
+Description=b00t NATS — leaf-accept node
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+ExecStart=/usr/local/bin/nats-server --config /etc/nats/nats.conf
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+ssh "$HOST" "systemctl daemon-reload && systemctl enable --now nats-server && systemctl status nats-server --no-pager -l | head -10"
+
+PUBLIC_IP=$(ssh "$HOST" "curl -s https://api.ipify.org")
+
+echo ""
+echo "== Done =="
+echo "Public IP:      ${PUBLIC_IP} (leaf listener is NOT exposed here — 127.0.0.1 only)"
+echo "Leaf port:      ${LEAF_PORT} (localhost-only, no TLS)"
+echo "Leaf user:      ${LEAF_USER}"
+echo "Leaf password:  ${LEAF_PASSWORD}"
+echo ""
+echo "Next steps:"
+echo "  1. Save the leaf credential (e.g. into kv-pe-foundry) — it is not written anywhere else."
+echo "  2. On the LAN hub, write ~/.dotfiles/secrets/nats-leaf-${HOST}.conf:"
+echo "       leafnodes { remotes = [ { url: \"nats://${LEAF_USER}:${LEAF_PASSWORD}@127.0.0.1:<local-tunnel-port>\" } ] }"
+echo "     and include it from nats.conf (NATS \$VAR substitution does not work"
+echo "     inside quoted compound strings like this URL — use 'include', not env vars)."
+echo "  3. Set up a persistent SSH tunnel from the LAN hub to ${HOST}:${LEAF_PORT}"
+echo "     (systemd unit, ExecStart=ssh -N -L <lan-ip>:<local-tunnel-port>:127.0.0.1:${LEAF_PORT} ${HOST})."


### PR DESCRIPTION
## Summary
- vultr1 (Vultr VPS) provisioned as a leaf-accept NATS peer alongside sm3lly, reachable from the LAN hub via SSH tunnel (b00t-node firewall convention: only 22/80/443 public, NATS stays localhost-only). Real leaf credentials live in `secrets/nats-leaf-vultr1.conf` (gitignored), included via `nats.conf`'s `include` directive.
- `vultr-node-setup.sh` reconciled to match the final architecture (localhost-only leaf listener, no TLS — the SSH tunnel already encrypts the transport); previously generated a stale TLS config.
- New `b00t-cli secret export-zone` subcommand + `list_azure_secret_names` helper: bulk-exports Azure Key Vault secrets by name prefix into a JSON env-var map, for Terraform's `secretEnvy` `data "external"` sources.
- `PROVIDER-VULTR` datum updated: role #4 (general VPS hosting) marked provisioned with vultr1's real IP/access details.
- `RUNPOD-CLAUDE-CODE` datum added documenting the RunPod plugin install.

Companion change in `app4dog` (branch `chore/vultr-nats-node`, [PR #139](https://github.com/app4dog/workspace/pull/139)) adds the justfile recipes for SSH access, tunnel persistence, and the cross-leaf task-dispatch demo.

## Test plan
- [x] `cargo test -p b00t-cli` — new `export_zone_tests` (prefix/key-derivation) pass
- [x] Full pre-push gate (b00t-cli, b00t-mcp, b00t-pyverse, b00t-admin): 1533+62 tests pass
- [x] Live: fung1 -> vultr1 leaf connection confirmed up (`leafz` shows `leafnodes: 1`)
- [x] Live: cross-leaf task dispatch confirmed end-to-end via app4dog's `just vultr-task-demo`