### PR TITLE
chore: bump workspace version to 0.10.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1376,7 +1376,7 @@ version = "0.1.0"
 
 [[package]]
 name = "b00t-admin"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "axum 0.8.9",
  "b00t-c0re-lib",
@@ -1399,7 +1399,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-ast"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "anyhow",
  "clap",
@@ -1415,7 +1415,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-azure-cp"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -1439,7 +1439,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-bouncer"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1453,7 +1453,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-c0re-a2a"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "chrono",
  "serde",
@@ -1466,7 +1466,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-c0re-gov"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "async-trait",
  "b00t-c0re-lib",
@@ -1483,7 +1483,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-c0re-hierarchy"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "b00t-c0re-gov",
  "b00t-c0re-role",
@@ -1497,7 +1497,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-c0re-lib"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -1552,7 +1552,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-c0re-role"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "serde",
  "serde_json",
@@ -1568,7 +1568,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-candle-serve"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "anyhow",
  "candle-core 0.11.0",
@@ -1581,7 +1581,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-chat"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "anyhow",
  "arrow",
@@ -1624,7 +1624,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-cli"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "anyhow",
  "apalis",
@@ -1723,7 +1723,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-council"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1734,7 +1734,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-datum-core"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1746,7 +1746,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-embed"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1767,7 +1767,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-embed-serve"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -1780,7 +1780,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-grok"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "anyhow",
  "async-openai",
@@ -1799,7 +1799,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-ipc"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -1820,7 +1820,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-isometric-wasm"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "b00t-l3dg3rr-viz",
  "serde_json",
@@ -1829,7 +1829,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-l3dg3rr-viz"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "blake3",
  "kasuari",
@@ -1840,7 +1840,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-lsp"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "anyhow",
  "b00t-datum-core",
@@ -1854,7 +1854,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-mcp"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -1899,7 +1899,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-mermaid-wasm"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "mermaid-rs-renderer",
  "wasm-bindgen",
@@ -1907,7 +1907,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-pyverse"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "anyhow",
  "b00t-c0re-lib",
@@ -1922,11 +1922,11 @@ dependencies = [
 
 [[package]]
 name = "b00t-reflect-types"
-version = "0.10.4"
+version = "0.10.5"
 
 [[package]]
 name = "b00t-stt-serve"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -1939,7 +1939,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-ui-wasm"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "dioxus",
  "dioxus-web",
@@ -1956,7 +1956,7 @@ dependencies = [
 
 [[package]]
 name = "b00t-zellij"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "b00t-c0re-lib",
  "chrono",
@@ -2531,7 +2531,7 @@ dependencies = [
 
 [[package]]
 name = "capability-forge"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -7235,7 +7235,7 @@ dependencies = [
 
 [[package]]
 name = "k0mmand3r"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "decimal-rs",
  "indexmap 2.14.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ resolver = "2"
 [workspace.package]
 # 🤓 Version management centralized in b00t-c0re-lib
 # All workspace crates inherit from the single source of truth
-version = "0.10.4"
+version = "0.10.5"
 edition = "2024"
 authors = ["Brian Horakh <brian@promptexecution.com>"]
 license = "MIT"


### PR DESCRIPTION
Bumps the workspace version so a new release build actually includes today's 5 merges (capability-forge #1091, build fix #1070, scopestore datum #1090, role taxonomy unification #1096, vultr1/Azure export #1092) — v0.10.4 predates all of them. Needed to get a b00t-x86_64-unknown-linux-gnu.tar.gz release asset containing capability-forge, which unblocks infrastructure PR #98's Vultr node cloud-init wiring.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016BdzsGNf8qazBCNMjVue1x