### PR TITLE
feat: vendor voidaliot/sysml-v2-docs as a b00t reference skill

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -118,3 +118,6 @@
 [submodule "vendor/linkml-b00t"]
 	path = vendor/linkml-b00t
 	url = https://github.com/linkml/linkml.git
+[submodule "vendor/sysml-v2-docs"]
+	path = vendor/sysml-v2-docs
+	url = https://github.com/voidaliot/sysml-v2-docs.git

--- a/_b00t_/sysml-v2-docs.skill.toml
+++ b/_b00t_/sysml-v2-docs.skill.toml
@@ -1,0 +1,56 @@
+[b00t]
+name = "sysml-v2-docs"
+type = "skill"
+type_tags = ["reference"]
+hint = "SysML v2.0 / KerML 1.0 / API-Services 1.0 knowledge base, vendored verbatim for agent-authored .sysml/.kerml modeling"
+keywords = ["sysml", "sysml2", "kerml", "systems-modeling", "omg-spec", "requirements", "verification", "modeling-language"]
+
+[b00t.learn]
+content = """
+`vendor/sysml-v2-docs` is a full-text markdown knowledge base derived from the
+formally adopted OMG SysML v2.0 (July 2025) / KerML 1.0 / Systems Modeling API
+& Services 1.0 specifications, plus the Pilot Implementation reference. It was
+purpose-built for AI-agent consumption (voidaliot/sysml-v2-docs upstream) and
+vendored here as a git submodule so any b00t agent can load it without a
+network fetch. Small corpus: ~512K, 21 files, mostly markdown.
+
+Layout:
+  vendor/sysml-v2-docs/language/    — the language itself, 01-overview.md through
+                                       11-graphical-notation.md + GLOSSARY.md.
+                                       04-definition-vs-usage.md is the core
+                                       paradigm; read it before anything else.
+  vendor/sysml-v2-docs/ai-agents/   — guidance written specifically for coding
+                                       agents: 01-modeling-guide.md (intent →
+                                       SysML), 02-prompting-rules.md (hard
+                                       invariants), 03-common-patterns.md
+                                       (reusable templates), 04-validation-
+                                       checklist.md (run BEFORE returning code).
+  vendor/sysml-v2-docs/examples/    — flashlight.sysml (minimal end-to-end),
+                                       vehicle-skeleton.sysml (larger model).
+
+When asked to author or review `.sysml`/`.kerml` files, or to evaluate SysML v2
+tooling (parsers, LSPs, validators): read `ai-agents/01-modeling-guide.md` and
+`ai-agents/04-validation-checklist.md` first, then `language/04-definition-vs-
+usage.md` for the Definition-vs-Usage split that trips up most naive output.
+Prefer this vendored copy over re-deriving SysML v2 syntax from model memory —
+the spec changed substantially from SysML v1 and stale pretraining knowledge
+is a known failure mode here.
+
+If the OMG publishes a spec revision that contradicts this corpus, the OMG
+spec PDF (https://www.omg.org/spec/SysML/2.0/) is authoritative — this vendor
+copy is a convenience cache, not the source of truth. Update via:
+  cd vendor/sysml-v2-docs && git fetch && git checkout <ref>
+then commit the updated submodule pointer in the parent repo, matching the
+`vendor/agentsea-skillpacks` precedent already used in this repo.
+
+Originally surfaced by the ledgrrr SysML v2 tooling survey (PromptExecution/
+ledgrrr#180) as zero-risk/high-value regardless of which SysML tooling
+direction ledgrrr ultimately picks.
+"""
+
+# b00t:map v1
+# summary: vendored SysML v2/KerML/API-Services markdown spec corpus for agent-authored .sysml modeling
+# tags: reference, sysml, kerml, modeling, omg-spec
+# tier: sm0l
+# cmds: b00t learn sysml-v2-docs
+# complexity: 2


### PR DESCRIPTION
## What

Vendors `vendor/sysml-v2-docs` (git submodule, matching the
`vendor/agentsea-skillpacks` precedent) — the OMG SysML v2.0/KerML 1.0/
API-Services 1.0 spec rendered as agent-consumable markdown, plus two
runnable `.sysml` examples (~512K, 21 files).

Adds `_b00t_/sysml-v2-docs.skill.toml` describing the corpus, its layout,
and when to load it (authoring/reviewing `.sysml`/`.kerml`, evaluating
SysML v2 tooling).

Surfaced by the ledgrrr SysML v2 tooling survey
([`PromptExecution/ledgrrr#180`](https://github.com/PromptExecution/ledgrrr/pull/180))
as zero-risk/high-value regardless of which SysML direction ledgrrr
ultimately picks — this session ended up using `sysml-v2-parser` (a
different, separate crate) directly rather than this corpus, but the docs
are still useful reference material for anyone authoring/reviewing SysML
v2 text by hand (see the emitter fixes in
[`PromptExecution/ledgrrr#197`](https://github.com/PromptExecution/ledgrrr/pull/197)).

## Verification

- `cargo test` (full workspace pre-push suite): 1530 passed, 4 ignored, 0
  failed.