### PR TITLE
docs(datum): update flexo-mms MCP datums with live-verified ports

### DIFF
--- a/_b00t_/flexo-mms-layer1-mcp.mcp.toml
+++ b/_b00t_/flexo-mms-layer1-mcp.mcp.toml
@@ -22,15 +22,23 @@ auto_digest = true
 # Transport: FastMCP streamable-HTTP, server listens on 0.0.0.0:8000.
 #
 # REQUIRES A RUNNING FLEXO MMS BACKEND -- this MCP server is a thin proxy,
-# not the model store itself. No Flexo instance is deployed in this
-# environment yet. Real reference stack (open-mbee/flexo-mms-deployment,
-# docker-compose/docker-compose.yml, verified 2026-08-22): openldap ->
-# quad-store (Apache Jena Fuseki, port 3030) -> minio (9000) -> auth-service
-# (8082) -> store-service (8081) -> layer1-service (8080, this is MMS_URL).
-# Standing that stack up is a real infra decision (5 containers, ports,
-# credentials) -- do it deliberately, not as a side effect of this datum.
+# not the model store itself. Deployed and verified end-to-end 2026-08-22:
+# openldap -> quad-store (Apache Jena Fuseki, host port 3030) -> minio (host
+# 9010, remapped from 9000 due to a local port conflict) -> auth-service
+# (host 8092, remapped from 8082, same reason) -> store-service (8081) ->
+# layer1-service (8080, this is MMS_URL, unmapped/default). Real SPARQL
+# COUNT query against quad-server's /ds/sparql returned real results; a real
+# MCP `initialize` handshake against this server (built from
+# open-mbee/flexo-mms-layer1-mcp's own Dockerfile) succeeded end-to-end
+# through layer1-service into the live quadstore. Two of the six containers
+# (quad-server, and this MCP server itself) needed to run outside
+# podman-compose on this host: quad-server hit a JDK cgroup-metrics NullPointerException
+# under rootless podman (Fuseki's Prometheus metrics init calls
+# jdk.internal.platform.Container.metrics(), which NPEs without --cgroupns=host --
+# a flag podman-compose 1.5.0 has no compose-key for), and this MCP server's
+# default host port 8000 was already bound by an unrelated local process.
 [[b00t.mcp.httpstream]]
-url = "http://127.0.0.1:8000/mcp"
+url = "http://127.0.0.1:8010/mcp"
 transport = "httpstream"
 priority = 0
 requires = ["docker"]

--- a/_b00t_/flexo-mms-sysmlv2-mcp.mcp.toml
+++ b/_b00t_/flexo-mms-sysmlv2-mcp.mcp.toml
@@ -21,8 +21,16 @@ auto_digest = true
 # depends_on flexo-mms-layer1-mcp: SYSMLV2_URL is the SysML v2-conformant
 # facade Flexo exposes on TOP OF the same layer1-service backend --
 # there's one Flexo deployment underneath both MCP servers, not two.
+#
+# Deployed and verified end-to-end 2026-08-22, same live backend as
+# flexo-mms-layer1-mcp. A real MCP `initialize` handshake against this
+# server (built from open-mbee/flexo-mms-sysmlv2-mcp's own Dockerfile)
+# returned serverInfo "SysMLv2 API". Port 8001 (this datum's original
+# default) was already bound by an unrelated local powermcp container on
+# this host, so this deployment used 8011 instead -- same
+# already-bound-by-something-else pattern as flexo-mms-layer1-mcp's 8000.
 [[b00t.mcp.httpstream]]
-url = "http://127.0.0.1:8001/mcp"
+url = "http://127.0.0.1:8011/mcp"
 transport = "httpstream"
 priority = 0
 requires = ["docker"]


### PR DESCRIPTION
## Summary
- Deployed the real open-mbee/flexo-mms-deployment docker-compose stack (openldap, Fuseki quad-store, minio, auth-service, store-service, layer1-service) locally.
- Built and ran both real upstream MCP servers (flexo-mms-layer1-mcp, flexo-mms-sysmlv2-mcp) from their own Dockerfiles against that live backend.
- Verified with a real SPARQL COUNT query against the quadstore and real MCP `initialize` handshakes against both servers.
- Updated each datum's `url` to the port actually used, after several host port conflicts (8000, 8001, 9000, 8082) with unrelated local processes forced remaps.

## Notes
- quad-server (Apache Jena Fuseki) hits a JDK cgroup-metrics NullPointerException under rootless podman unless run with `--cgroupns=host`; podman-compose 1.5.0 has no compose-file key for this, so that one container runs outside compose on this host.

## Test plan
- [x] Real SPARQL query against quad-server returned a valid result set
- [x] MCP `initialize` handshake against flexo-mms-layer1-mcp returned serverInfo "MMS Flexo Layer 1 Service"
- [x] MCP `initialize` handshake against flexo-mms-sysmlv2-mcp returned serverInfo "SysMLv2 API"