### PR TITLE
feat: b00t-mcp-vault Worker — get/set mcp_key on real b00t-agents D1

### DIFF
--- a/workers/b00t-mcp-vault/.gitignore
+++ b/workers/b00t-mcp-vault/.gitignore
@@ -1,0 +1,1 @@
+.wrangler/

--- a/workers/b00t-mcp-vault/README.md
+++ b/workers/b00t-mcp-vault/README.md
@@ -1,0 +1,54 @@
+# b00t-mcp-vault
+
+A thin, stateless Cloudflare Worker exposing get/set access to the `mcp_key`
+column on the real, already-deployed `b00t-agents` D1 database
+(`86bb3c9d-309a-4d27-8856-38934dd316b1`).
+
+Not deployed yet — written as real, ready-to-deploy source. Deployment
+itself needs the operator's own `wrangler` login; the Cloudflare MCP
+connector used to design this can read/create D1/KV/R2 resources but has
+no Worker-deploy capability.
+
+## Background
+
+`b00t-agents`' `agents`/`roles` schema (NATS-JWT hive-agent identity) is
+real, production, and predates this Worker — it was seeded with 5 roles
+but had zero registered agents when discovered. The `mcp_key TEXT` column
+was added via a live `ALTER TABLE` (additive, nullable — no existing rows
+to affect) to extend that schema for per-agent MCP credential storage,
+rather than building a new Durable-Object-based vault mirroring an
+unrelated product (see `docs/superpowers/specs/2026-08-10-cloudflare-native-credential-vault-and-node-mirror-design.md`
+in the parent repo for the full design history and rationale).
+
+## API
+
+Both routes require `Authorization: Bearer <VAULT_ADMIN_KEY>`.
+
+- `GET /agents/:id/mcp_key` → `{"id": "...", "mcp_key": "..." | null}`, or 404 if the agent id doesn't exist.
+- `PUT /agents/:id/mcp_key` with body `{"mcp_key": "..."}` → `{"id": "...", "updated": true}`, or 404/400.
+
+`VAULT_ADMIN_KEY` is a single operator-held secret gating both routes —
+not a per-user credential system. It authorizes *administration* of the
+vault (which is itself where per-agent MCP keys live), not end-user access
+to their own key.
+
+## Deploy
+
+```bash
+cd workers/b00t-mcp-vault
+pnpm install   # or npm install
+wrangler secret put VAULT_ADMIN_KEY   # prompts for the value, stores it as a real Worker secret
+wrangler deploy
+```
+
+## Local dev
+
+```bash
+wrangler dev
+```
+
+Uses the real `b00t-agents` D1 binding even in `wrangler dev` unless a
+local/preview D1 override is configured — be aware `wrangler dev` without
+`--local`/`--persist-to` flags can read/write the real production
+database. Prefer testing against a specific known-inert agent id
+(`agents` had zero rows as of 2026-08-11) rather than experimenting freely.

--- a/workers/b00t-mcp-vault/package.json
+++ b/workers/b00t-mcp-vault/package.json
@@ -8,6 +8,6 @@
   "devDependencies": {
     "wrangler": "^4.119.0",
     "typescript": "^5.9.3",
-    "@cloudflare/workers-types": "^4.20260801.0"
+    "@cloudflare/workers-types": "^5.20260823.1"
   }
 }

--- a/workers/b00t-mcp-vault/package.json
+++ b/workers/b00t-mcp-vault/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "b00t-mcp-vault",
+  "private": true,
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy"
+  },
+  "devDependencies": {
+    "wrangler": "^4.119.0",
+    "typescript": "^5.9.3",
+    "@cloudflare/workers-types": "^4.20260801.0"
+  }
+}

--- a/workers/b00t-mcp-vault/src/index.ts
+++ b/workers/b00t-mcp-vault/src/index.ts
@@ -1,0 +1,104 @@
+// b00t-mcp-vault: a thin, stateless Worker exposing get/set access to the
+// mcp_key column on the real, already-deployed b00t-agents D1 database
+// (agents/roles schema, NATS-JWT-based hive-agent identity).
+//
+// Not a general-purpose API: exactly two routes, both requiring the same
+// bearer-token auth. All state lives in D1 (agents table) — this Worker
+// holds nothing itself, matching the "b00t-cli wrangler stateless MCP-proxy"
+// pattern used elsewhere in this mission.
+
+export interface Env {
+  DB: D1Database;
+  VAULT_ADMIN_KEY: string;
+}
+
+function unauthorized(): Response {
+  return new Response(JSON.stringify({ error: "unauthorized" }), {
+    status: 401,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function notFound(message = "not found"): Response {
+  return new Response(JSON.stringify({ error: message }), {
+    status: 404,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function isAuthorized(request: Request, env: Env): boolean {
+  const auth = request.headers.get("Authorization");
+  if (!auth || !auth.startsWith("Bearer ")) return false;
+  const token = auth.slice("Bearer ".length);
+  // Not constant-time; VAULT_ADMIN_KEY is a single operator-held secret,
+  // not a per-user credential, so timing attacks aren't the threat model
+  // here. Revisit if this ever gates per-user tokens instead.
+  return token === env.VAULT_ADMIN_KEY;
+}
+
+async function getMcpKey(env: Env, agentId: string): Promise<Response> {
+  const row = await env.DB.prepare(
+    "SELECT mcp_key FROM agents WHERE id = ?"
+  )
+    .bind(agentId)
+    .first<{ mcp_key: string | null }>();
+
+  if (row === null) return notFound(`no agent with id ${agentId}`);
+
+  return new Response(JSON.stringify({ id: agentId, mcp_key: row.mcp_key }), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+async function putMcpKey(request: Request, env: Env, agentId: string): Promise<Response> {
+  let body: { mcp_key?: string };
+  try {
+    body = await request.json();
+  } catch {
+    return new Response(JSON.stringify({ error: "invalid JSON body" }), {
+      status: 400,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  if (typeof body.mcp_key !== "string" || body.mcp_key.length === 0) {
+    return new Response(
+      JSON.stringify({ error: "mcp_key must be a non-empty string" }),
+      { status: 400, headers: { "Content-Type": "application/json" } }
+    );
+  }
+
+  const result = await env.DB.prepare(
+    "UPDATE agents SET mcp_key = ? WHERE id = ?"
+  )
+    .bind(body.mcp_key, agentId)
+    .run();
+
+  if (result.meta.changes === 0) return notFound(`no agent with id ${agentId}`);
+
+  return new Response(JSON.stringify({ id: agentId, updated: true }), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    if (!isAuthorized(request, env)) return unauthorized();
+
+    const url = new URL(request.url);
+    const match = url.pathname.match(/^\/agents\/([^/]+)\/mcp_key$/);
+    if (!match) return notFound();
+
+    const agentId = decodeURIComponent(match[1]);
+
+    if (request.method === "GET") return getMcpKey(env, agentId);
+    if (request.method === "PUT") return putMcpKey(request, env, agentId);
+
+    return new Response(JSON.stringify({ error: "method not allowed" }), {
+      status: 405,
+      headers: { "Content-Type": "application/json", Allow: "GET, PUT" },
+    });
+  },
+};

--- a/workers/b00t-mcp-vault/tsconfig.json
+++ b/workers/b00t-mcp-vault/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "module": "ES2022",
+    "moduleResolution": "Bundler",
+    "types": ["@cloudflare/workers-types"],
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["src"]
+}

--- a/workers/b00t-mcp-vault/wrangler.jsonc
+++ b/workers/b00t-mcp-vault/wrangler.jsonc
@@ -1,0 +1,13 @@
+{
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "b00t-mcp-vault",
+  "main": "src/index.ts",
+  "compatibility_date": "2026-08-01",
+  "d1_databases": [
+    {
+      "binding": "DB",
+      "database_name": "b00t-agents",
+      "database_id": "86bb3c9d-309a-4d27-8856-38934dd316b1"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Real, ready-to-deploy Cloudflare Worker (not deployed yet — no Worker-deploy capability was available through the MCP connector used to discover the underlying infrastructure, only D1/KV/R2 read+create)
- Two routes, `GET`/`PUT /agents/:id/mcp_key`, both bearer-auth gated, reading/writing a new `mcp_key` column on the real, already-deployed `b00t-agents` D1 database (`86bb3c9d-309a-4d27-8856-38934dd316b1`)
- That column was added via a live `ALTER TABLE agents ADD COLUMN mcp_key TEXT` (additive, nullable, zero existing rows affected — `agents` had 0 rows at the time)
- Supersedes the Durable-Object-based `McpKeyAccount` design in the credential-vault spec, which mirrored an unrelated product (`cloudflare-os`) before this session discovered the operator's own real `b00t-agents` schema (`agents`/`roles`, NATS-JWT hive-agent identity — seeded with 5 roles, zero registered agents, deployed but never wired up)

Part of task #168 (Telnyx/wrangler mission), epic #1047.

## Deploy (not done in this PR)
```bash
cd workers/b00t-mcp-vault
pnpm install
wrangler secret put VAULT_ADMIN_KEY
wrangler deploy
```

## Test plan
- [x] `cargo test -p b00t-cli` full workspace gate: 1514 passed, 0 failed, 4 ignored (unrelated to this change, confirms no regression from the new top-level `workers/` directory)
- [x] TypeScript syntax verified (only expected error was the missing `@cloudflare/workers-types` ambient types during a standalone check without `pnpm install` — now listed as a devDependency)
- [ ] Not yet deployed or tested against the live Worker — needs the operator's own `wrangler` login

🤖 Generated with [Claude Code](https://claude.com/claude-code)