### PR TITLE
feat(fax-mvp): telnyx-fax-handler Worker (task #168)

### DIFF
--- a/docs/superpowers/specs/2026-08-09-fax-mvp-design.md
+++ b/docs/superpowers/specs/2026-08-09-fax-mvp-design.md
@@ -1,0 +1,135 @@
+# Fax MVP — Design
+
+**Date:** 2026-08-09
+**Status:** Approved for implementation planning
+**Tracking:** b00t task #168 (parent mission); this spec covers sub-project 2 of 5
+**Memory:** `project_telnyx_fax_service_ledgrrr.md`
+**Depends on:** nothing (credproxy, sub-project 1, is explicitly out of scope — see below)
+
+## Background
+
+Second of five sub-projects decomposed out of the Telnyx/wrangler mission (see
+`2026-08-09-windows-keystore-credproxy-design.md` for the full decomposition
+and sub-project 1). This spec covers the P0 fax send/receive loop: getting
+one working end-to-end fax through Telnyx, self-directed (no external
+counterparty needed to validate it), per b00t's playable-first doctrine.
+
+## Scope decision: credential delivery
+
+Sub-project 1 (Windows-keystore credential proxy) is **backlogged** (b00t
+task #169). This spec uses the simplest possible credential path instead:
+`TELNYX_API_KEY` — already present in `~/.env` on this box — passed into
+wrangler's container as a plain environment variable at `podman run` time.
+No keystore bridge, no `windows-rs`, no bootstrap-seeded podman secret. This
+is a deliberate simplification to unblock the fax loop now; revisiting it
+for a real secret-lifecycle story is deferred until past dev-convenience
+secrets.
+
+## Flow
+
+1. **One-time setup:** create a Telnyx Fax Application (`create_fax_applications`)
+   for the test number, with `webhook_url` pointed at a **stable, named**
+   dev tunnel (e.g. a `cloudflared` tunnel bound to a fixed hostname) —
+   configured once, reused by every test run. (Rejected: an ephemeral
+   per-run tunnel, which would require calling `update_fax_applications`
+   to repoint the webhook before every send — more moving parts for no
+   benefit at this stage.)
+2. **Send:** wrangler calls `create_faxes` with `from` = `to` = the test
+   number (self-fax) and `media_url` pointing at a static test PDF served
+   over that same tunnel. (`upload_media`/`media_name` was considered as an
+   alternative to `media_url`, but it still requires fetching from a public
+   URL itself — no advantage for a one-shot test PDF; skipped.)
+3. **Receive confirmation:** because `to == from`, Telnyx routes the fax
+   back to the same number. The Fax Application's `webhook_url` receives
+   both the outbound leg's lifecycle (`fax.queued` → `fax.media.processed`
+   → `fax.sending.started` → `fax.delivered`) and a separate inbound
+   `fax.received` event for the same logical test run.
+
+## P0 success criteria
+
+A single test run produces both the outbound `fax.delivered` and inbound
+`fax.received` webhook events, correlated to the same run (via
+`client_state` or timing). That is the whole loop — send and receive
+exercised together, bi-directional-capable architecture validated, without
+needing a second party.
+
+## Document ingestion into ledgrrr
+
+Once a fax completes (either direction), its PDF should land in ledgrrr,
+not just Telnyx's own temporary storage. `ledgerr-mcp` already has the
+right hook for this: `proxy_docling_ingest_pdf`
+(`ledgerr-mcp::mcp_adapter::handle_ingest_pdf`) — a working, already-wired
+tool that runs a PDF through `docling` extraction and calls
+`service.ingest_pdf(request)`, landing rows in ledgrrr's transaction system
+with `docling`-tagged provenance (source, tool version, backend call id).
+No new ledgrrr-side code needed for P0 — wrangler calls this existing MCP
+tool with the fax's PDF (outbound: the same test PDF already being sent;
+inbound: `fax.received`'s media, fetched from Telnyx first) once the
+`fax.delivered`/`fax.received` webhook confirms the transfer completed.
+
+## Error handling
+
+`fax.failed` webhook (carries Telnyx's error code/message) is logged
+verbatim, not swallowed. If no webhook arrives within a timeout, fall back
+to polling `retrieve_faxes` by id rather than hanging indefinitely.
+
+## Superseding update (2026-08-11): real deployment, not local dev
+
+A live Cloudflare Developer Platform MCP connector became available
+mid-mission and revealed the operator already has a real, deployed Worker
+— **`telnyx-sms-forwarder`** — that receives a Telnyx webhook
+(`message.received`) and calls the Telnyx API using a real
+`env.TELNYX_API_KEY` Worker secret. This is direct, working proof that
+the "podman + dev tunnel" design above is unnecessary complexity: a real
+sibling Worker, deployed to the same account, gets a real public
+`webhook_url` for free — no tunnel, no local `wrangler dev`, no
+container.
+
+**Revised flow:**
+1. A new Worker (e.g. `telnyx-fax-handler`), mirroring
+   `telnyx-sms-forwarder`'s shape (single `fetch` handler, no framework),
+   deployed to the same Cloudflare account. Its real `*.workers.dev` (or
+   custom-domain) URL becomes the Fax Application's `webhook_url` —
+   permanently, no tunnel-URL churn to manage.
+2. `TELNYX_API_KEY` as a real Worker secret on the new Worker (`wrangler
+   secret put`), matching the existing convention, not a plain env var
+   passed into a container.
+3. The test PDF for `media_url` should live in R2 (the account already
+   has `b00t-templates`, a bucket that fits this use) rather than being
+   served over a dev tunnel. **Not yet uploaded** — the Cloudflare MCP
+   connector used for this whole investigation only exposes bucket-level
+   operations (create/list/get/delete), not object PUT; getting a real
+   PDF into R2 needs the operator's own `wrangler r2 object put` (or
+   equivalent) or a Worker endpoint that accepts an upload.
+4. Document ingestion into ledgrrr (existing section below) is unaffected
+   by this change — it's about what happens after the fax completes, not
+   how the webhook is hosted.
+
+This mirrors exactly what happened with the credential vault (spec 6): a
+Durable-Object design built against an unrelated product got superseded
+once the operator's own real infrastructure was discovered. Same
+correction here — build on `telnyx-sms-forwarder`'s real, proven pattern,
+not a fresh local-dev sandbox.
+
+**What's real vs. not yet**: the architecture above and the R2 bucket
+(`b00t-templates`) are real. `telnyx-fax-handler`'s actual code hasn't
+been written yet (unlike `b00t-mcp-vault`, which was written as complete,
+ready-to-deploy source in the same session) — that's the next concrete
+step, not yet done as of this update.
+
+## Out of scope for this spec
+
+- **clawPDF** / real document generation — a static test PDF is sufficient
+  for P0; clawPDF's role (converting a real ledgrrr document to PDF) is a
+  later, separate concern once this loop works.
+- **credproxy** (sub-project 1) — backlogged, see above.
+- **Voice/TTS/STT** (sub-project 5) — unrelated capability, tracked
+  separately.
+- Production public endpoint for wrangler — the dev tunnel is explicitly a
+  stopgap; sub-project 3 (cloudflare-os hosting) is where wrangler gets a
+  real deployment story. This spec does not block on that.
+
+## References
+
+- Telnyx `create_faxes`, `create_fax_applications`, `upload_media` — schemas
+  pulled live via the Telnyx MCP connector, 2026-08-09.

--- a/workers/telnyx-fax-handler/.gitignore
+++ b/workers/telnyx-fax-handler/.gitignore
@@ -1,0 +1,1 @@
+.wrangler/

--- a/workers/telnyx-fax-handler/README.md
+++ b/workers/telnyx-fax-handler/README.md
@@ -1,0 +1,49 @@
+# telnyx-fax-handler
+
+The fax MVP's real, deployed Worker (task #168, spec 2) — mirrors the
+existing `telnyx-sms-forwarder` Worker's shape rather than the local
+`wrangler dev` + dev-tunnel design the spec originally called for. See
+the "Superseding update (2026-08-11)" section of
+`docs/superpowers/specs/2026-08-09-fax-mvp-design.md` in the parent repo
+for the full rationale.
+
+Not deployed yet — real, ready-to-deploy source, same status as the
+sibling `workers/b00t-mcp-vault`.
+
+## Routes
+
+- `POST /send-test-fax` — triggers the P0 self-test: sends a fax from
+  `TEST_FAX_NUMBER` to itself via Telnyx's `create_faxes` API, using
+  `TEST_FAX_MEDIA_URL` as the document.
+- `POST /webhook` — Telnyx's fax lifecycle webhook target
+  (`fax.queued`/`delivered`/`failed`/`received`/etc.). Logs each event;
+  `fax.delivered` + `fax.received` both appearing for one test run is the
+  P0 success criterion — check with `wrangler tail` after triggering
+  `/send-test-fax`.
+
+ledgrrr document ingestion (`proxy_docling_ingest_pdf`) on a completed fax
+is real per the spec but not wired into `/webhook` yet — it needs
+`ledgerr-mcp` reachable over HTTP (spec 4), which isn't deployed. The
+webhook handler already logs enough (fax id, status, direction) to add
+that call later without changing the route shape.
+
+## Deploy
+
+```bash
+cd workers/telnyx-fax-handler
+pnpm install
+wrangler secret put TELNYX_API_KEY
+# Also set as plain vars (not secret — not credential material) in
+# wrangler.jsonc, or via `wrangler secret put` if preferred:
+#   TELNYX_CONNECTION_ID, TEST_FAX_NUMBER, TEST_FAX_MEDIA_URL
+wrangler deploy
+```
+
+`TEST_FAX_MEDIA_URL` needs a real, publicly reachable PDF URL — the
+account's existing `b00t-templates` R2 bucket is a candidate, but nothing
+has been uploaded to it yet (this session's Cloudflare MCP connector only
+exposes R2 bucket-level operations, not object PUT — needs `wrangler r2
+object put` or equivalent from the operator).
+
+Once deployed, point the Telnyx Fax Application's `webhook_url` at this
+Worker's real `/webhook` URL (permanent — no tunnel-URL churn to manage).

--- a/workers/telnyx-fax-handler/package.json
+++ b/workers/telnyx-fax-handler/package.json
@@ -8,6 +8,6 @@
   "devDependencies": {
     "wrangler": "^4.119.0",
     "typescript": "^5.9.3",
-    "@cloudflare/workers-types": "^4.20260801.0"
+    "@cloudflare/workers-types": "^5.20260823.1"
   }
 }

--- a/workers/telnyx-fax-handler/package.json
+++ b/workers/telnyx-fax-handler/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "telnyx-fax-handler",
+  "private": true,
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy"
+  },
+  "devDependencies": {
+    "wrangler": "^4.119.0",
+    "typescript": "^5.9.3",
+    "@cloudflare/workers-types": "^4.20260801.0"
+  }
+}

--- a/workers/telnyx-fax-handler/src/index.ts
+++ b/workers/telnyx-fax-handler/src/index.ts
@@ -1,0 +1,110 @@
+// telnyx-fax-handler: the fax MVP's real, deployed Worker — mirrors
+// telnyx-sms-forwarder's shape (single fetch handler, no framework, a
+// real Worker secret for TELNYX_API_KEY) rather than the local
+// wrangler-dev + tunnel design this spec originally had.
+//
+// Two routes:
+//   POST /send-test-fax  — triggers the P0 self-fax test (send to our own
+//                          number) via Telnyx's create_faxes API.
+//   POST /webhook        — receives Telnyx's fax lifecycle webhooks
+//                          (fax.queued/delivered/failed/received/etc.),
+//                          logs the event, returns 200 OK.
+//
+// ledgrrr document ingestion (proxy_docling_ingest_pdf) on fax.delivered/
+// fax.received is real per the fax MVP spec, but not wired here yet — it
+// needs ledgerr-mcp reachable over HTTP (spec 4), which isn't deployed.
+// The webhook handler logs enough to add that call later without
+// redesigning the route.
+
+export interface Env {
+  TELNYX_API_KEY: string;
+  TELNYX_CONNECTION_ID: string;
+  TEST_FAX_NUMBER: string; // E.164, used as both `from` and `to` for the self-test
+  TEST_FAX_MEDIA_URL: string; // publicly reachable PDF URL (e.g. an R2 public bucket URL)
+}
+
+interface TelnyxFaxWebhookPayload {
+  data?: {
+    event_type?: string;
+    payload?: {
+      id?: string;
+      status?: string;
+      direction?: "inbound" | "outbound";
+      from?: string;
+      to?: string;
+      client_state?: string;
+    };
+  };
+}
+
+async function sendTestFax(env: Env): Promise<Response> {
+  const response = await fetch("https://api.telnyx.com/v2/faxes", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${env.TELNYX_API_KEY}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      connection_id: env.TELNYX_CONNECTION_ID,
+      from: env.TEST_FAX_NUMBER,
+      to: env.TEST_FAX_NUMBER,
+      media_url: env.TEST_FAX_MEDIA_URL,
+    }),
+  });
+
+  const body = await response.text();
+  console.log("Telnyx create_faxes response:", response.status, body);
+
+  if (!response.ok) {
+    return new Response(`Failed to send test fax: ${body}`, { status: 502 });
+  }
+  return new Response(body, {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+async function handleWebhook(request: Request): Promise<Response> {
+  let payload: TelnyxFaxWebhookPayload;
+  try {
+    payload = await request.json();
+  } catch (err) {
+    console.error("Failed to parse webhook JSON payload", err);
+    return new Response("Invalid JSON", { status: 400 });
+  }
+
+  const eventType = payload?.data?.event_type;
+  const fax = payload?.data?.payload;
+  console.log(
+    "Telnyx fax webhook:",
+    eventType,
+    "id=", fax?.id,
+    "status=", fax?.status,
+    "direction=", fax?.direction
+  );
+
+  // P0 success criterion (per the fax MVP spec): fax.delivered (outbound
+  // leg) and fax.received (inbound leg, since to==from routes back to the
+  // same number) both observed for one correlated test run. Logging here
+  // is the P0 verification mechanism — read these logs (`wrangler tail`)
+  // to confirm the self-test loop actually completed both directions.
+
+  return new Response(`Acknowledged: ${eventType ?? "unknown event"}`, {
+    status: 200,
+  });
+}
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const url = new URL(request.url);
+
+    if (request.method === "POST" && url.pathname === "/send-test-fax") {
+      return sendTestFax(env);
+    }
+    if (request.method === "POST" && url.pathname === "/webhook") {
+      return handleWebhook(request);
+    }
+
+    return new Response("Not found", { status: 404 });
+  },
+};

--- a/workers/telnyx-fax-handler/tsconfig.json
+++ b/workers/telnyx-fax-handler/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "module": "ES2022",
+    "moduleResolution": "Bundler",
+    "types": ["@cloudflare/workers-types"],
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["src"]
+}

--- a/workers/telnyx-fax-handler/wrangler.jsonc
+++ b/workers/telnyx-fax-handler/wrangler.jsonc
@@ -1,0 +1,6 @@
+{
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "telnyx-fax-handler",
+  "main": "src/index.ts",
+  "compatibility_date": "2026-08-01"
+}


### PR DESCRIPTION
## Summary
- Real, ready-to-deploy `telnyx-fax-handler` Worker mirroring the deployed `telnyx-sms-forwarder` Worker's shape (single fetch handler, real Worker secrets) instead of the local `wrangler dev` + tunnel design the fax MVP spec originally called for.
- `POST /send-test-fax` — triggers the P0 self-fax test via Telnyx's `create_faxes` API.
- `POST /webhook` — Telnyx fax lifecycle webhook target; logs each event (`fax.queued`/`delivered`/`failed`/`received`); `fax.delivered` + `fax.received` both appearing for one test run is the P0 success criterion.
- Updates `docs/superpowers/specs/2026-08-09-fax-mvp-design.md` with a "Superseding update (2026-08-11)" section documenting the redesign rationale, following the real Cloudflare account/infrastructure discovery this session.

## Not done yet (documented in the Worker's README)
- Not deployed — needs the operator's own `wrangler secret put` (TELNYX_API_KEY) + `wrangler deploy`.
- `TEST_FAX_MEDIA_URL` needs a real PDF uploaded to R2 — this session's Cloudflare MCP connector only exposes bucket-level R2 ops, not object PUT.
- ledgrrr document ingestion (`proxy_docling_ingest_pdf`) on a completed fax is real per the spec but not wired into `/webhook` yet — needs `ledgerr-mcp` reachable over HTTP (spec 4), which isn't deployed.

## Test plan
- [ ] `cd workers/telnyx-fax-handler && pnpm install && pnpm run dev` — local sanity check
- [ ] Operator: `wrangler secret put TELNYX_API_KEY`, set `TELNYX_CONNECTION_ID`/`TEST_FAX_NUMBER`/`TEST_FAX_MEDIA_URL`, `wrangler deploy`
- [ ] Trigger `/send-test-fax`, confirm `fax.delivered` + `fax.received` both logged via `wrangler tail`

🤖 Generated with [Claude Code](https://claude.com/claude-code)