### PR TITLE
fix(chat): flush NATS publishes so `chat send --transport nats` actually sends

### DIFF
--- a/b00t-lib-chat/src/transport.rs
+++ b/b00t-lib-chat/src/transport.rs
@@ -328,6 +328,17 @@ impl RealNatsTransport {
         format!("b00t.chat.{}.{}", msg.channel, msg.sender)
     }
 
+    /// `client.flush()`, bounded the same way every other flush in this file
+    /// already is (`ensure_connected`'s liveness probe: 1s; the reconnect
+    /// heartbeat: 2s) so a degraded connection fails fast instead of hanging
+    /// a foreground CLI command indefinitely.
+    async fn flush_with_timeout(client: &async_nats::Client) -> ChatResult<()> {
+        tokio::time::timeout(std::time::Duration::from_secs(1), client.flush())
+            .await
+            .map_err(|_| ChatError::Other("NATS flush timed out after 1s".to_string()))?
+            .map_err(|e| ChatError::Other(format!("NATS flush failed: {}", e)))
+    }
+
     async fn send(&self, message: &ChatMessage) -> ChatResult<()> {
         let client = self.ensure_connected().await?;
         let subject = Self::chat_subject(message);
@@ -341,10 +352,7 @@ impl RealNatsTransport {
         // before that buffer is ever flushed to the socket, so the message
         // never actually reaches the server despite Ok(()) being returned.
         // Flush explicitly so send() only succeeds once the server has it.
-        client
-            .flush()
-            .await
-            .map_err(|e| ChatError::Other(format!("NATS flush failed: {}", e)))?;
+        Self::flush_with_timeout(&client).await?;
         debug!("NATS published to {}", subject);
         Ok(())
     }
@@ -357,10 +365,7 @@ impl RealNatsTransport {
             .publish(subject.clone(), payload.into())
             .await
             .map_err(|e| ChatError::Other(format!("NATS task publish failed: {}", e)))?;
-        client
-            .flush()
-            .await
-            .map_err(|e| ChatError::Other(format!("NATS flush failed: {}", e)))?;
+        Self::flush_with_timeout(&client).await?;
         info!(
             "Task {} dispatched to {} via NATS",
             task.task_id, task.to_agent
@@ -397,6 +402,15 @@ impl RealNatsTransport {
         Ok(rx)
     }
 
+    // Note: also used by long-lived callers (e.g. bridge.rs's notification_loop
+    // forwarding a child process's stdout line-by-line) where the old buffered
+    // publish() was a throughput advantage (many messages coalesced into fewer
+    // socket flushes). The added flush is a local TCP-buffer flush, not a
+    // server-ACK round-trip, so the per-message cost is expected to be small —
+    // but if a hot loop's notification volume ever grows enough for this to
+    // matter, split into a fire-and-forget variant for that caller rather than
+    // removing the flush here (this method's correctness for one-shot callers
+    // like `chat send` depends on it).
     async fn publish_notification(&self, notification: &NotificationMessage) -> ChatResult<()> {
         let client = self.ensure_connected().await?;
         let subject = notification.subject();
@@ -405,10 +419,7 @@ impl RealNatsTransport {
             .publish(subject.clone(), payload.into())
             .await
             .map_err(|e| ChatError::Other(format!("NATS notify publish failed: {}", e)))?;
-        client
-            .flush()
-            .await
-            .map_err(|e| ChatError::Other(format!("NATS flush failed: {}", e)))?;
+        Self::flush_with_timeout(&client).await?;
         debug!("NATS notification published to {}", subject);
         Ok(())
     }
@@ -447,10 +458,7 @@ impl RealNatsTransport {
             .publish(subject.to_string(), payload.to_vec().into())
             .await
             .map_err(|e| ChatError::Other(format!("NATS raw publish failed: {}", e)))?;
-        client
-            .flush()
-            .await
-            .map_err(|e| ChatError::Other(format!("NATS flush failed: {}", e)))?;
+        Self::flush_with_timeout(&client).await?;
         debug!("NATS raw published to {}", subject);
         Ok(())
     }

--- a/b00t-lib-chat/src/transport.rs
+++ b/b00t-lib-chat/src/transport.rs
@@ -336,6 +336,15 @@ impl RealNatsTransport {
             .publish(subject.clone(), payload.into())
             .await
             .map_err(|e| ChatError::Other(format!("NATS publish failed: {}", e)))?;
+        // publish() only enqueues the frame on the client's internal write
+        // buffer; a short-lived CLI process can exit (dropping the runtime)
+        // before that buffer is ever flushed to the socket, so the message
+        // never actually reaches the server despite Ok(()) being returned.
+        // Flush explicitly so send() only succeeds once the server has it.
+        client
+            .flush()
+            .await
+            .map_err(|e| ChatError::Other(format!("NATS flush failed: {}", e)))?;
         debug!("NATS published to {}", subject);
         Ok(())
     }
@@ -348,6 +357,10 @@ impl RealNatsTransport {
             .publish(subject.clone(), payload.into())
             .await
             .map_err(|e| ChatError::Other(format!("NATS task publish failed: {}", e)))?;
+        client
+            .flush()
+            .await
+            .map_err(|e| ChatError::Other(format!("NATS flush failed: {}", e)))?;
         info!(
             "Task {} dispatched to {} via NATS",
             task.task_id, task.to_agent
@@ -392,6 +405,10 @@ impl RealNatsTransport {
             .publish(subject.clone(), payload.into())
             .await
             .map_err(|e| ChatError::Other(format!("NATS notify publish failed: {}", e)))?;
+        client
+            .flush()
+            .await
+            .map_err(|e| ChatError::Other(format!("NATS flush failed: {}", e)))?;
         debug!("NATS notification published to {}", subject);
         Ok(())
     }
@@ -430,6 +447,10 @@ impl RealNatsTransport {
             .publish(subject.to_string(), payload.to_vec().into())
             .await
             .map_err(|e| ChatError::Other(format!("NATS raw publish failed: {}", e)))?;
+        client
+            .flush()
+            .await
+            .map_err(|e| ChatError::Other(format!("NATS flush failed: {}", e)))?;
         debug!("NATS raw published to {}", subject);
         Ok(())
     }

--- a/b00t-lib-chat/tests/nats_integration.rs
+++ b/b00t-lib-chat/tests/nats_integration.rs
@@ -86,4 +86,51 @@ mod nats_integration {
             Err(_) => panic!("Task receive timed out — is NATS running?"),
         }
     }
+
+    /// Regression test for the flush-after-publish fix (client.publish() alone
+    /// enqueues a frame on the client's write buffer without waiting for it to
+    /// reach the socket, so a short-lived process's runtime can drop before the
+    /// buffered frame is ever written -- send() would return Ok(()) while the
+    /// message silently never landed). Asserts the server's own in_msgs counter
+    /// actually increments after send() returns, via the monitoring HTTP API
+    /// (`http_port` on nats-server, typically :8222) -- the same signal used to
+    /// manually verify this fix originally.
+    #[tokio::test]
+    #[ignore] // requires running NATS server with monitoring enabled (-m 8222)
+    async fn test_nats_send_actually_reaches_server() {
+        let monitor_url =
+            std::env::var("B00T_NATS_MONITOR_URL").unwrap_or_else(|_| "http://localhost:8222".into());
+
+        async fn in_msgs(monitor_url: &str) -> u64 {
+            let varz: serde_json::Value = reqwest::get(format!("{monitor_url}/varz"))
+                .await
+                .expect("GET /varz — is NATS monitoring enabled? (-m 8222)")
+                .json()
+                .await
+                .expect("parse /varz JSON");
+            varz["in_msgs"].as_u64().expect("in_msgs field present")
+        }
+
+        let client = ChatClient::nats(
+            Some("nats://localhost:4222".into()),
+            std::env::var("B00T_HIVE_NATS_USER").ok(),
+            std::env::var("B00T_HIVE_NATS_PASSWORD").ok(),
+        )
+        .expect("create NATS client");
+
+        let before = in_msgs(&monitor_url).await;
+
+        let msg = ChatMessage::new("test.channel", "fung1", "flush regression probe");
+        client.send(&msg).await.expect("send should succeed");
+
+        // Give the server a moment to account the message server-side.
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+        let after = in_msgs(&monitor_url).await;
+
+        assert!(
+            after > before,
+            "in_msgs did not increase after send() returned (before={before}, after={after}) \
+             -- the published message never reached the server, exactly the bug this fix closes"
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- `RealNatsTransport::send()` and 3 sibling methods (`send_task`, `publish_notification`, `send_raw`) in `b00t-lib-chat/src/transport.rs` called `async_nats::Client::publish()` without a following `.flush()`.
- `publish()` only enqueues the PUB frame on the client's internal write buffer; it does not wait for the bytes to reach the socket. In a short-lived CLI process, the tokio runtime drops as soon as `main()` returns, so the buffered frame was frequently discarded before the background I/O task ever wrote it out.
- The connect handshake completes eagerly and unconditionally, so `total_connections` on the NATS server always incremented — but the message itself silently never landed, so `in_msgs` stayed flat. `b00t chat send --transport nats` printed a success line regardless.

## Fix
Added `client.flush().await` immediately after each `.publish()` call in all four `RealNatsTransport` methods, mapped to `ChatError::Other` on failure.

## Fixed per code review
- **Timeout**: the four new `flush()` calls are now bounded by a 1s timeout (`flush_with_timeout`, a shared helper), matching this file's own established pattern (`ensure_connected`'s liveness probe: 1s; the reconnect heartbeat: 2s) — an unbounded flush risked hanging the foreground `chat send` CLI command indefinitely on a degraded connection.
- **Documented tradeoff**: `publish_notification`/`send_raw` are also used by long-lived callers (`bridge.rs`'s `notification_loop`, `b00t-mcp`'s MCP server process) where the old buffered `publish()` was a throughput advantage. Added an inline comment on `publish_notification` explaining the tradeoff (the flush is a local TCP-buffer flush, not a server-ACK round-trip, so expected per-message cost is small) rather than silently changing shared-method behavior without comment.
- **Regression test**: added `test_nats_send_actually_reaches_server`, an `#[ignore]`d integration test (matching the existing live-NATS-required pattern in `nats_integration.rs`) asserting the NATS server's own `in_msgs` counter increments after `send()` returns, via its monitoring HTTP API — closing the "no test crosses the actual defect class" gap the review found.

## Test plan
- [x] Live A/B against a real running `nats-server`: fixed binary reliably increments `in_msgs` by 1 per `chat send`; pre-fix binary reproduces the exact original symptom (connects, `in_msgs` unchanged).
- [x] Full `cargo test -p b00t-cli --lib` gate: 1539 passed, 0 failed.
- [x] Confirmed the installed `b00t`/`b00t-cli` binary picks up the fix and used it for real inter-host agent coordination (not just a synthetic test).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>