### PR TITLE
docs(b00t-cli): document DatumType::McpServer as reserved (#1094)

### DIFF
--- a/b00t-cli/src/datum_types.rs
+++ b/b00t-cli/src/datum_types.rs
@@ -48,6 +48,21 @@ pub enum DatumType {
     Polyseme,
     Runtime,
     Training,
+    /// **Reserved — not yet implemented.** No `McpServerDatum` struct exists, and this
+    /// variant is not wired into `main.rs` dispatch. It is declared as a UFO `SubKind`
+    /// of `Mcp` (see `ufo_stereotype()` below) to hold a structural distinction between
+    /// a local MCP config (`Mcp`) and a deployed remote MCP server (`McpServer`) — a
+    /// distinction the codebase doesn't build out yet.
+    ///
+    /// The intended path to actually implement this is *not* a standalone
+    /// `McpServerDatum` struct: per the 2026-08-16 app4dog-workspace decision, `McpDatum`
+    /// (see `datum_mcp.rs`) is expected to gain a `deploy_targets` field instead, folding
+    /// "deployed remote server" into the existing `Mcp` datum rather than forking a
+    /// parallel type. Do not build a separate `McpServerDatum` without revisiting that
+    /// decision first.
+    ///
+    /// Kept (not removed) per the resolution of issue #1094 — see that issue for the
+    /// full investigation and the removal-vs-keep discussion.
     McpServer,
     Schema,
     Hook,


### PR DESCRIPTION
Closes #1094.

## Decision
Keep `DatumType::McpServer` rather than remove it, per operator decision — but document it clearly as reserved/not-yet-implemented so it doesn't get rediscovered as a mystery stub again.

## Change
Single doc comment on the `McpServer` variant declaration (`b00t-cli/src/datum_types.rs`), explaining:
- No `McpServerDatum` struct exists and it isn't wired into `main.rs` dispatch
- It's declared as a UFO `SubKind` of `Mcp` for a structural distinction (local MCP config vs. deployed remote MCP server) that isn't built out
- The intended replacement path is `McpDatum` gaining a `deploy_targets` field (2026-08-16 app4dog-workspace decision), not a standalone struct
- Links back to #1094 for full history

Nothing else touched — `datum_proof.rs`'s no-op match arm, `b00t-lsp`'s token list, and `b00t-admin`'s display list are all left exactly as-is, since the variant isn't being removed.

## Test plan
- [x] `cargo check -p b00t-cli` — exit 0
- [x] `cargo test -p b00t-cli --lib datum_types` — all 7 tests pass unchanged, including `mcp_server_is_subkind_of_mcp_matching_implies`
- [x] Full pre-push gate (selected packages b00t-cli/b00t-mcp/b00t-pyverse) passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)