### PR TITLE
fix(bash_profile): strip quotes when exporting ~/.env vars

### DIFF
--- a/bash/.bash_profile
+++ b/bash/.bash_profile
@@ -125,8 +125,16 @@ if [ -f ~/.env ]; then
         [[ "$line" =~ ^#.*$ || -z "$line" ]] && continue
 
         # Validate KEY=VALUE format
-        if [[ "$line" =~ ^[^=]+=[^=]+$ ]]; then
-            export "$line"
+        if [[ "$line" =~ ^([^=]+)=(.*)$ ]]; then
+            key="${BASH_REMATCH[1]}"
+            value="${BASH_REMATCH[2]}"
+            # Strip one matching pair of surrounding quotes, if present
+            if [[ "$value" =~ ^\"(.*)\"$ ]]; then
+                value="${BASH_REMATCH[1]}"
+            elif [[ "$value" =~ ^\'(.*)\'$ ]]; then
+                value="${BASH_REMATCH[1]}"
+            fi
+            export "$key=$value"
         else
             echo "Invalid line in .env: $line"
         fi


### PR DESCRIPTION
## Summary
- `~/.bash_profile`'s `.env` loader did `export "$line"` on raw `KEY="value"` lines, which does not strip the quote characters — they end up embedded in the exported value.
- Found while debugging why `CLOUDFLARE_ACCOUNT_ID` was failing R2 S3 signature checks: the exported value literally contained the surrounding `"` characters.
- Affects every quoted line in `~/.env` (14+ vars on the box where this was found), not just Cloudflare ones.
- Fix: parse key/value via regex, strip one matching pair of surrounding single- or double-quotes before `export`.

## Test plan
- [x] Verified fix locally: `CLOUDFLARE_ACCOUNT_ID` now exports as clean 32-char hex with zero embedded quote characters (was previously polluted)
- [x] `wrangler whoami` / real Cloudflare API calls now authenticate correctly using values loaded through this path

🤖 Generated with [Claude Code](https://claude.com/claude-code)