### PR TITLE
test(b00t-mcp): sandbox server_llm tests from real $HOME (#1113)

### DIFF
--- a/b00t-mcp/src/server_llm.rs
+++ b/b00t-mcp/src/server_llm.rs
@@ -619,9 +619,60 @@ async fn fallback_not_found(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::{Mutex, MutexGuard};
+
+    // ── Sandbox tests from the real $HOME (#1113 hygiene fix) ───────────────
+    //
+    // `LlmState::from_config` resolves `keys_file`/`spotlight_log` against
+    // `dirs_next()`, which reads the process-wide `HOME` env var. Without
+    // sandboxing, every test in this module reads/writes the developer's
+    // real `~/.b00t/server-keys.json` and `~/.b00t/spotlight.jsonl`. This
+    // mirrors the `TempHome` pattern already used independently in
+    // `b00t-c0re-lib/src/events.rs` and `b00t-cli/src/lib.rs`.
+
+    static HOME_LOCK: Mutex<()> = Mutex::new(());
+
+    struct TempHome {
+        _guard: MutexGuard<'static, ()>,
+        old_home: Option<String>,
+        _temp_dir: tempfile::TempDir,
+    }
+
+    impl TempHome {
+        fn new() -> Self {
+            let guard = HOME_LOCK.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+            let temp_dir = tempfile::tempdir().unwrap();
+            std::fs::create_dir_all(temp_dir.path().join(".b00t")).unwrap();
+            let old_home = std::env::var("HOME").ok();
+            unsafe {
+                std::env::set_var("HOME", temp_dir.path().to_str().unwrap());
+            }
+
+            Self {
+                _guard: guard,
+                old_home,
+                _temp_dir: temp_dir,
+            }
+        }
+    }
+
+    impl Drop for TempHome {
+        fn drop(&mut self) {
+            if let Some(old) = &self.old_home {
+                unsafe {
+                    std::env::set_var("HOME", old);
+                }
+            } else {
+                unsafe {
+                    std::env::remove_var("HOME");
+                }
+            }
+        }
+    }
 
     #[tokio::test]
     async fn test_key_create_and_validate() {
+        let _temp_home = TempHome::new();
         let state = Arc::new(LlmState::from_config("http://localhost:8181/v1", ""));
         let key = state.create_key("test-consumer", &[]).await;
         assert!(key.starts_with("b00t-sk-"));
@@ -632,6 +683,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_unknown_key_is_none() {
+        let _temp_home = TempHome::new();
         let state = Arc::new(LlmState::from_config("http://localhost:8181/v1", ""));
         let entry = state.validate_key("bogus-key").await;
         assert!(entry.is_none());
@@ -639,12 +691,40 @@ mod tests {
 
     #[tokio::test]
     async fn test_spotlight_emit() {
+        let _temp_home = TempHome::new();
         let state = Arc::new(LlmState::from_config("http://localhost:8181/v1", ""));
         state.emit_spotlight("test-consumer", "chat_completions", "test-model", 42).await;
         let content = std::fs::read_to_string(&state.spotlight_log).unwrap_or_default();
         assert!(content.contains("spotlight.llm.chat_completions"));
         assert!(content.contains("test-consumer"));
         assert!(content.contains("test-model"));
+    }
+
+    /// Proves the sandboxing actually isolates instances from each other via
+    /// the filesystem, not just that tests pass. Two sequential `TempHome`
+    /// scopes: a key created under the first is invisible to a fresh
+    /// `LlmState` constructed under the second, because `validate_key` is a
+    /// pure in-memory read of the `keys` map populated at construction time
+    /// (it never re-reads `keys_file`), and the second `TempHome` points
+    /// `HOME` at an entirely different, empty temp directory.
+    #[tokio::test]
+    async fn test_temp_home_isolates_state_across_instances() {
+        let key = {
+            let _first_home = TempHome::new();
+            let state = LlmState::from_config("http://localhost:8181/v1", "");
+            let key = state.create_key("consumer-in-first-home", &[]).await;
+            assert!(state.validate_key(&key).await.is_some(), "key must be visible within its own instance");
+            key
+            // _first_home dropped here: HOME restored, temp dir removed
+        };
+
+        let _second_home = TempHome::new();
+        let fresh_state = LlmState::from_config("http://localhost:8181/v1", "");
+        assert!(
+            fresh_state.validate_key(&key).await.is_none(),
+            "a key created under one TempHome must not leak into a fresh LlmState \
+             constructed under a different TempHome"
+        );
     }
 
     // ── proxy_chat #596/#597 wiring — end-to-end against a fake upstream ─────
@@ -697,6 +777,7 @@ mod tests {
 
     #[tokio::test]
     async fn proxy_chat_drives_verify_tool_loop_end_to_end() {
+        let _temp_home = TempHome::new();
         let upstream_url = spawn_fake_upstream(vec![
             tool_call_upstream_response("(assert true)(check-sat)"),
             stop_upstream_response("verified via loop"),
@@ -732,6 +813,7 @@ mod tests {
             eprintln!("skipping proxy_chat_audits_hallucinated_grammar_shaped_result: z3 not in PATH");
             return;
         }
+        let _temp_home = TempHome::new();
         // Model emits grammar-shaped content claiming "sat" for an assertion
         // that is actually unsat — proxy_chat must correct it before
         // returning to the client (#596 grammar-shape audit bridge).


### PR DESCRIPTION
Addresses #1113.

## Finding: the reported flake could not be reproduced
352 reproduction attempts (sequential, parallel-in-process, 8-way concurrent cross-process, `--test-threads=1`) across `test_key_create_and_validate` — **zero failures**. Static analysis confirms the code path is structurally immune to the reported order-dependence race: `validate_key()` is a pure in-memory read that never touches disk, and `LlmState.keys` is a fresh per-instance `Arc<RwLock<HashMap>>`, not a global/static. Full evidence posted as a comment on #1113: https://github.com/elasticdotventures/_b00t_/issues/1113#issuecomment-5385952546

Most likely explanation: a transient environmental fluke on a host that runs many concurrent, resource-contending agent worktrees (directly observed during this investigation).

## What this PR actually fixes
A real, separate, confirmed bug found along the way: `server_llm.rs`'s tests construct `LlmState` against the developer's **real, unsandboxed `$HOME`** (`~/.b00t/server-keys.json` grew from 63 to 331 entries during the investigation's stress testing). This is genuine test-hygiene pollution, independent of the flake itself.

## Changes
- Added a `TempHome`/`HOME_LOCK` fixture to `server_llm.rs`'s test module, mirroring the existing independent implementations in `b00t-c0re-lib/src/events.rs` and `b00t-cli/src/lib.rs` (no new dependency — `tempfile` was already a dev-dependency).
- Applied it to all 5 existing tests that construct `LlmState`.
- Added `test_temp_home_isolates_state_across_instances`, proving the isolation property directly.
- Filed #1128 as a separate follow-up for a real, out-of-scope finding: `save_keys_to_file`'s non-atomic write is a lost-update race between two live `LlmState` instances — doesn't affect this fix, left unfixed here per scope.

## Test plan
- [x] `test_key_create_and_validate` passes in isolation.
- [x] `test_spotlight_emit` verified not to depend on log accumulation across runs under sandboxing.
- [x] 120 sequential iterations of the full `server_llm::tests` filter (6 tests/iteration, `--test-threads=4`) run directly against the built binary — 0 failures.
- [x] Confirmed zero real-`$HOME` pollution: `~/.b00t/server-keys.json` entry count 331→331, `~/.b00t/spotlight.jsonl` line count 1242→1242, before vs. after the 120-iteration run.
- [x] `cargo test -p b00t-mcp --lib` full crate suite: 61 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)