### PR TITLE
fix: bump vendor/ledgrrr pin to main tip, track main not b00t-patches

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -69,7 +69,7 @@
 [submodule "vendor/ledgrrr"]
 	path = vendor/ledgrrr
 	url = https://github.com/PromptExecution/ledgrrr.git
-	branch = b00t-patches
+	branch = main
 
 [submodule "vendor/llama-patch"]
 	path = vendor/llama-patch


### PR DESCRIPTION
## Summary
- `AGENTS.md` (from #1121) points agents to ledgrrr's `docs/sysml-v2-tooling-survey.md` as evidence SysML-v2 tooling is "existing infrastructure, not a green field" — but that file didn't exist at the previously-pinned commit.
- Root cause: the pin was simply stale.
- **Updated per code review:** the originally-proposed target (`606ac51`) was itself stale by merge time — `_b00t_`'s `main` had independently bumped `vendor/ledgrrr` to `2d546ed6` in the interim (a reconciled/rebased state), and `606ac51`'s lineage doesn't contain that reconciliation. Rather than hand-reconcile two diverging lineages, this now bumps straight to ledgrrr's own `origin/main` tip (`98abd845`), a confirmed strict superset of `606ac51` (`git merge-base --is-ancestor`), which contains the survey doc.
- `.gitmodules`' `branch` field for `vendor/ledgrrr` updated from `b00t-patches` to `main`, to match what's now actually tracked.

## Known gap (not resolved here, filing follow-up)
Commit `dc8431e` ("wire up ufo-types — `Stereotyped` for `ArtifactKind`" on `origin/b00t-patches`) is real, non-trivial work that is **not** an ancestor of either the old or new pin -- `b00t-patches` and `main` have diverged and neither contains the other. That reconciliation is a separate task; will file a `b00t task` to re-apply `dc8431e`'s `ArtifactKind` UFO-stereotype wiring onto current `main`.

## Test plan
- [x] Confirmed `docs/sysml-v2-tooling-survey.md` exists and reads correctly at the new pin (`98abd845`)
- [x] Confirmed `98abd845` is a strict git-ancestor superset of the originally-proposed `606ac51`
- [x] Full pre-push gate (`cargo test -p b00t-cli --lib`) -- 1519 passed, 0 failed

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>