### PR TITLE
docs(spec): amend isolation guarantee to name its registry-integrity dependency

### DIFF
--- a/docs/superpowers/specs/2026-08-23-ledgrrr-tenant-identity-design.md
+++ b/docs/superpowers/specs/2026-08-23-ledgrrr-tenant-identity-design.md
@@ -309,6 +309,19 @@ asked for ("cross-tenant queries must be handled separately for security
 reasons") and it is enforced by Cloudflare's DO addressing model itself, not
 by convention or a `WHERE tenant_id = ?` clause that could be forgotten.
 
+**Precise scope of this guarantee** (amended after implementation review):
+the DO-addressing property above holds unconditionally *given* the
+`tenants` registry row is correct — `root_do_id` is read from a shared,
+multi-writer D1 (`b00t-agents`, also bound by the `b00t-mcp-vault` Worker),
+so the actual guarantee is "DO addressing is structurally isolated,
+conditioned on registry-row integrity," not an isolation property with no
+external dependency at all. A `UNIQUE` constraint on `tenants.root_do_id`
+closes the accidental-collision case (two rows aliasing one DO) at the
+schema level; it does not defend against a writer with direct D1 access
+deliberately repointing a `root_do_id`. Guarding *that* is an access-control
+problem for whatever holds write access to `b00t-agents` itself, out of
+this sub-project's scope.
+
 ## Error handling
 
 - **Tenant not found** (bad `tenant_id` in a token request): D1 registry


### PR DESCRIPTION
## Summary
- The final whole-branch review of the tenant-registry implementation (PR #1133) correctly flagged that the spec's isolation claim overstates itself: "enforced by Cloudflare's DO addressing model itself" reads as unconditional, but `root_do_id` is read from a shared, multi-writer D1 (`b00t-agents`, also bound by `b00t-mcp-vault`).
- Amends `docs/superpowers/specs/2026-08-23-ledgrrr-tenant-identity-design.md` to name the dependency: isolation holds *given* registry-row integrity, and clarifies what the `UNIQUE` constraint on `root_do_id` does (closes accidental collision) and doesn't (guard against a malicious/buggy direct D1 writer) cover.

Doc-only change, no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)