### PR TITLE
feat(ledgrrr-tenant-registry): expose root node id from tenant creation

### DIFF
--- a/workers/ledgrrr-tenant-registry/src/registry.ts
+++ b/workers/ledgrrr-tenant-registry/src/registry.ts
@@ -8,6 +8,10 @@ export interface Tenant {
   createdAt: string;
 }
 
+export interface CreatedTenant extends Tenant {
+  rootNodeId: string;
+}
+
 interface TenantRow {
   id: string;
   kind: string;
@@ -38,7 +42,7 @@ export async function createTenant(
   db: D1Database,
   doNamespace: DurableObjectNamespace<TenantNode>,
   input: { kind: "personal" | "organizational"; displayName: string; ownerAgentId: string }
-): Promise<Tenant> {
+): Promise<CreatedTenant> {
   const id = crypto.randomUUID();
   const doId = doNamespace.newUniqueId();
   const rootDoId = doId.toString();
@@ -55,5 +59,12 @@ export async function createTenant(
   const rootNode = await stub.createNode({ parentId: null, kind: "business_unit", name: "root" });
   await stub.addMember(input.ownerAgentId, rootNode.id, "owner");
 
-  return { id, kind: input.kind, displayName: input.displayName, rootDoId, createdAt };
+  return {
+    id,
+    kind: input.kind,
+    displayName: input.displayName,
+    rootDoId,
+    createdAt,
+    rootNodeId: rootNode.id,
+  };
 }

--- a/workers/ledgrrr-tenant-registry/test/registry.test.ts
+++ b/workers/ledgrrr-tenant-registry/test/registry.test.ts
@@ -26,9 +26,11 @@ describe("lookupTenant", () => {
     expect(created.kind).toBe("organizational");
     expect(created.displayName).toBe("Acme Corp");
     expect(created.rootDoId).toBeTruthy();
+    expect(created.rootNodeId).toBeTruthy();
 
     const found = await lookupTenant(env.DB, created.id);
-    expect(found).toEqual(created);
+    const { rootNodeId: _rootNodeId, ...createdTenantFields } = created;
+    expect(found).toEqual(createdTenantFields);
   });
 
   it("seeds a root node and adds the owner as a member on tenant creation", async () => {
@@ -39,6 +41,9 @@ describe("lookupTenant", () => {
       ownerAgentId: "agent-owner",
     });
 
+    expect(tenant.rootNodeId).toEqual(expect.any(String));
+    expect(tenant.rootNodeId.length).toBeGreaterThan(0);
+
     const stub = env.TENANT_DO.get(env.TENANT_DO.idFromString(tenant.rootDoId));
 
     const rootNodeId = await runInDurableObject(stub, async (_instance, state) => {
@@ -48,6 +53,10 @@ describe("lookupTenant", () => {
       expect(rows).toHaveLength(1);
       return rows[0].id;
     });
+
+    // Cross-check: the id returned from createTenant must match the DO's
+    // actual root node id, not just be "present".
+    expect(tenant.rootNodeId).toBe(rootNodeId);
 
     const hasMembership = await stub.hasMembershipPath("agent-owner", rootNodeId);
     expect(hasMembership).toBe(true);


### PR DESCRIPTION
## Summary
Closes the residual gap from PR #1133's final review (I2, partially): `createTenant` already seeds a root node + owner membership, but nothing exposed the root node's id to external callers, so there was no way to discover which node to request a token for after creating a tenant.

- New `CreatedTenant extends Tenant { rootNodeId: string }` type — kept separate from the base `Tenant` type (which `lookupTenant` also returns) to avoid an ambiguous "sometimes present" field, since D1's `tenants` table has no `root_node_id` column.
- `createTenant`'s return type changes to `Promise<CreatedTenant>`; `POST /tenants` needed zero route changes — TypeScript inference + `JSON.stringify` picks it up automatically.
- New test cross-checks the returned `rootNodeId` against the DO's actual root node (queried directly via SQL), not just a truthy check.

## Test plan
- [x] 21/21 tests passing
- [x] `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)