### PR TITLE
feat(ledgrrr-tenant-registry): HMAC-sign issued tokens, add verifyToken + POST /verify

### DIFF
--- a/workers/ledgrrr-tenant-registry/src/index.ts
+++ b/workers/ledgrrr-tenant-registry/src/index.ts
@@ -1,12 +1,13 @@
 import { createTenant, lookupTenant } from "./registry";
 import { TenantNode } from "./tenant-do";
-import { issueToken } from "./token";
+import { issueToken, verifyToken } from "./token";
 export { TenantNode } from "./tenant-do";
 
 export interface Env {
   DB: D1Database;
   TENANT_DO: DurableObjectNamespace<TenantNode>;
   REGISTRY_ADMIN_KEY: string;
+  TOKEN_SIGNING_KEY: string;
 }
 
 function isAuthorized(request: Request, env: Env): boolean {
@@ -101,6 +102,27 @@ export default {
         });
       }
       return new Response(JSON.stringify(result), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    if (request.method === "POST" && url.pathname === "/verify") {
+      const body = await request.json<{ token?: string }>();
+      if (typeof body.token !== "string") {
+        return new Response(JSON.stringify({ error: "token is required" }), {
+          status: 400,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      const result = await verifyToken(env, body.token);
+      if (!result.valid) {
+        return new Response(JSON.stringify({ error: result.error }), {
+          status: 401,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      return new Response(JSON.stringify(result.payload), {
         status: 200,
         headers: { "Content-Type": "application/json" },
       });

--- a/workers/ledgrrr-tenant-registry/src/token.ts
+++ b/workers/ledgrrr-tenant-registry/src/token.ts
@@ -4,6 +4,7 @@ import type { TenantNode } from "./tenant-do";
 export interface Env {
   DB: D1Database;
   TENANT_DO: DurableObjectNamespace<TenantNode>;
+  TOKEN_SIGNING_KEY: string;
 }
 
 export interface IssueTokenInput {
@@ -14,6 +15,98 @@ export interface IssueTokenInput {
 }
 
 export type IssueTokenResult = { token: string } | { error: string };
+
+export interface TokenPayload {
+  tenantId: string;
+  agentId: string;
+  rootDoId: string;
+  nodeId: string;
+  shards: string[];
+  issuedAt: string;
+  expiresAt: string;
+}
+
+const TOKEN_TTL_MS = 60 * 60 * 1000; // 1 hour
+
+function bufferToBase64Url(buffer: ArrayBufferLike): string {
+  const bytes = new Uint8Array(buffer);
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+function base64UrlToBuffer(base64url: string): ArrayBuffer {
+  const base64 = base64url.replace(/-/g, "+").replace(/_/g, "/");
+  const padded = base64 + "=".repeat((4 - (base64.length % 4)) % 4);
+  const binary = atob(padded);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  return bytes.buffer;
+}
+
+function stringToBase64Url(str: string): string {
+  return bufferToBase64Url(new TextEncoder().encode(str).buffer);
+}
+
+function base64UrlToString(base64url: string): string {
+  return new TextDecoder().decode(base64UrlToBuffer(base64url));
+}
+
+async function getSigningKey(secret: string): Promise<CryptoKey> {
+  return crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign", "verify"]
+  );
+}
+
+async function signData(secret: string, data: string): Promise<ArrayBuffer> {
+  const key = await getSigningKey(secret);
+  return crypto.subtle.sign("HMAC", key, new TextEncoder().encode(data));
+}
+
+async function verifySignature(secret: string, data: string, signature: ArrayBuffer): Promise<boolean> {
+  const key = await getSigningKey(secret);
+  return crypto.subtle.verify("HMAC", key, signature, new TextEncoder().encode(data));
+}
+
+export async function signPayload(secret: string, payload: TokenPayload): Promise<string> {
+  const payloadPart = stringToBase64Url(JSON.stringify(payload));
+  const signature = await signData(secret, payloadPart);
+  const signaturePart = bufferToBase64Url(signature);
+  return `${payloadPart}.${signaturePart}`;
+}
+
+export type VerifyTokenResult = { valid: true; payload: TokenPayload } | { valid: false; error: string };
+
+export async function verifyToken(env: Env, token: string): Promise<VerifyTokenResult> {
+  const parts = token.split(".");
+  if (parts.length !== 2) {
+    return { valid: false, error: "malformed token" };
+  }
+  const [payloadPart, signaturePart] = parts;
+
+  const signature = base64UrlToBuffer(signaturePart);
+  const signatureValid = await verifySignature(env.TOKEN_SIGNING_KEY, payloadPart, signature);
+  if (!signatureValid) {
+    return { valid: false, error: "invalid signature" };
+  }
+
+  let payload: TokenPayload;
+  try {
+    payload = JSON.parse(base64UrlToString(payloadPart));
+  } catch {
+    return { valid: false, error: "malformed payload" };
+  }
+
+  if (new Date(payload.expiresAt).getTime() < Date.now()) {
+    return { valid: false, error: "expired" };
+  }
+
+  return { valid: true, payload };
+}
 
 export async function issueToken(env: Env, input: IssueTokenInput): Promise<IssueTokenResult> {
   const tenant = await lookupTenant(env.DB, input.tenantId);
@@ -33,14 +126,16 @@ export async function issueToken(env: Env, input: IssueTokenInput): Promise<Issu
     return { error: "unauthorized" };
   }
 
-  const payload = {
+  const now = Date.now();
+  const payload: TokenPayload = {
     tenantId: input.tenantId,
     agentId: input.agentId,
     rootDoId: tenant.rootDoId,
     nodeId: input.nodeId,
     shards: input.requestedShards,
-    issuedAt: new Date().toISOString(),
+    issuedAt: new Date(now).toISOString(),
+    expiresAt: new Date(now + TOKEN_TTL_MS).toISOString(),
   };
-  const token = btoa(JSON.stringify(payload));
+  const token = await signPayload(env.TOKEN_SIGNING_KEY, payload);
   return { token };
 }

--- a/workers/ledgrrr-tenant-registry/test/env.d.ts
+++ b/workers/ledgrrr-tenant-registry/test/env.d.ts
@@ -2,5 +2,6 @@ declare module "cloudflare:test" {
   interface ProvidedEnv {
     DB: D1Database;
     TENANT_DO: DurableObjectNamespace<import("../src/tenant-do").TenantNode>;
+    TOKEN_SIGNING_KEY: string;
   }
 }

--- a/workers/ledgrrr-tenant-registry/test/token-signing.test.ts
+++ b/workers/ledgrrr-tenant-registry/test/token-signing.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { env } from "cloudflare:test";
+import { createTenant } from "../src/registry";
+import { issueToken, signPayload, verifyToken } from "../src/token";
+import type { TokenPayload } from "../src/token";
+
+describe("token signing", () => {
+  beforeAll(async () => {
+    // Create the tenants table (migration equivalent) — each test file gets
+    // isolated D1 storage under vitest-pool-workers, mirroring token.test.ts.
+    await env.DB.exec(
+      "CREATE TABLE IF NOT EXISTS tenants (id TEXT PRIMARY KEY, kind TEXT NOT NULL CHECK (kind IN ('personal', 'organizational')), display_name TEXT NOT NULL, root_do_id TEXT NOT NULL, created_at TEXT NOT NULL)"
+    );
+  });
+
+  async function issueValidToken() {
+    const tenant = await createTenant(env.DB, env.TENANT_DO, {
+      kind: "organizational",
+      displayName: "Acme",
+      ownerAgentId: "agent-owner",
+    });
+    const stub = env.TENANT_DO.get(env.TENANT_DO.idFromString(tenant.rootDoId));
+    const node = await stub.createNode({
+      parentId: null,
+      kind: "business_unit",
+      name: "Eng",
+      settingsJson: JSON.stringify({ grantedShards: ["project"] }),
+    });
+    await stub.addMember("agent-1", node.id, "member");
+
+    return issueToken(env, {
+      tenantId: tenant.id,
+      agentId: "agent-1",
+      nodeId: node.id,
+      requestedShards: ["project"],
+    });
+  }
+
+  it("issues a token and verifies it round-trip", async () => {
+    const result = await issueValidToken();
+    expect("token" in result).toBe(true);
+    if (!("token" in result)) return;
+
+    const verified = await verifyToken(env, result.token);
+    expect(verified.valid).toBe(true);
+    if (verified.valid) {
+      expect(verified.payload.agentId).toBe("agent-1");
+      expect(verified.payload.tenantId).toBeTruthy();
+      expect(verified.payload.nodeId).toBeTruthy();
+      expect(verified.payload.shards).toEqual(["project"]);
+    }
+  });
+
+  it("rejects a token with a tampered payload", async () => {
+    const result = await issueValidToken();
+    expect("token" in result).toBe(true);
+    if (!("token" in result)) return;
+
+    const [payloadPart, signaturePart] = result.token.split(".");
+    const corruptedChar = payloadPart[0] === "a" ? "b" : "a";
+    const tamperedPayload = corruptedChar + payloadPart.slice(1);
+    const tamperedToken = `${tamperedPayload}.${signaturePart}`;
+
+    const verified = await verifyToken(env, tamperedToken);
+    expect(verified).toEqual({ valid: false, error: "invalid signature" });
+  });
+
+  it("rejects a token with a tampered signature", async () => {
+    const result = await issueValidToken();
+    expect("token" in result).toBe(true);
+    if (!("token" in result)) return;
+
+    const [payloadPart, signaturePart] = result.token.split(".");
+    const corruptedChar = signaturePart[0] === "a" ? "b" : "a";
+    const tamperedSignature = corruptedChar + signaturePart.slice(1);
+    const tamperedToken = `${payloadPart}.${tamperedSignature}`;
+
+    const verified = await verifyToken(env, tamperedToken);
+    expect(verified).toEqual({ valid: false, error: "invalid signature" });
+  });
+
+  it("rejects an expired token", async () => {
+    const payload: TokenPayload = {
+      tenantId: "tenant-1",
+      agentId: "agent-1",
+      rootDoId: "root-do-1",
+      nodeId: "node-1",
+      shards: ["project"],
+      issuedAt: new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(),
+      expiresAt: new Date(Date.now() - 60 * 60 * 1000).toISOString(),
+    };
+    const token = await signPayload(env.TOKEN_SIGNING_KEY, payload);
+
+    const verified = await verifyToken(env, token);
+    expect(verified).toEqual({ valid: false, error: "expired" });
+  });
+
+  it("rejects a malformed token", async () => {
+    const verified = await verifyToken(env, "not-a-valid-token-no-dot");
+    expect(verified).toEqual({ valid: false, error: "malformed token" });
+  });
+});

--- a/workers/ledgrrr-tenant-registry/test/token.test.ts
+++ b/workers/ledgrrr-tenant-registry/test/token.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeAll } from "vitest";
 import { env } from "cloudflare:test";
 import { createTenant } from "../src/registry";
-import { issueToken } from "../src/token";
+import { issueToken, verifyToken } from "../src/token";
 
 describe("issueToken", () => {
   beforeAll(async () => {
@@ -36,8 +36,11 @@ describe("issueToken", () => {
 
     expect("token" in result).toBe(true);
     if ("token" in result) {
-      const payload = JSON.parse(atob(result.token));
-      expect(payload.agentId).toBe("agent-1");
+      const verified = await verifyToken(env, result.token);
+      expect(verified.valid).toBe(true);
+      if (verified.valid) {
+        expect(verified.payload.agentId).toBe("agent-1");
+      }
     }
   });
 

--- a/workers/ledgrrr-tenant-registry/wrangler.jsonc
+++ b/workers/ledgrrr-tenant-registry/wrangler.jsonc
@@ -18,5 +18,8 @@
   },
   "migrations": [
     { "tag": "v1", "new_sqlite_classes": ["TenantNode"] }
-  ]
+  ],
+  "vars": {
+    "TOKEN_SIGNING_KEY": "test-signing-key-not-for-production"
+  }
 }


### PR DESCRIPTION
## Summary
Closes the "unsigned/forgeable token" gap deferred from PR #1133's final review, per explicit operator decision: **trust the signature alone on verification** — no live re-check of `hasMembershipPath`/`nodeGrantsShards` against the DO on every verify. Security comes from unforgeability at issuance time (standard signed-token model), not re-derivation on use.

- HMAC-SHA256 via Web Crypto (`crypto.subtle.sign`/`crypto.subtle.verify` — timing-safe, no manual byte comparison anywhere)
- `signPayload(secret, payload)` — new testable seam, also used internally by `issueToken`
- `verifyToken(env, token)` — checks signature, then `expiresAt` (1-hour TTL), returns the trusted payload or a specific error
- New `POST /verify` route, gated behind the same bearer auth as every other route
- UTF-8-safe base64url encoding throughout (also fixes a previously-flagged minor: raw `btoa` threw on non-Latin1 characters in caller-controlled fields)

## Test plan
- [x] 26/26 tests passing, `tsc --noEmit` clean
- [x] Reviewer independently mutation-tested the signature check (stubbed `verifySignature` to always return `true`) — 2/3 signature-related tests correctly failed, confirming genuine discriminating power despite one flagged process deviation (tests written alongside implementation rather than strict red-first TDD)
- [x] `TOKEN_SIGNING_KEY` test value is an unambiguous placeholder (`wrangler.jsonc` vars), not exploitable as a real secret

## Before deploy
- `wrangler secret put TOKEN_SIGNING_KEY` needs provisioning (same pattern as `REGISTRY_ADMIN_KEY`) before this can issue real signed tokens in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)