### PR TITLE
fix(ledgrrr-tenant-registry): remove TOKEN_SIGNING_KEY from wrangler.jsonc vars

### DIFF
--- a/workers/ledgrrr-tenant-registry/.gitignore
+++ b/workers/ledgrrr-tenant-registry/.gitignore
@@ -1,2 +1,3 @@
 .wrangler/
 node_modules/
+.dev.vars

--- a/workers/ledgrrr-tenant-registry/wrangler.jsonc
+++ b/workers/ledgrrr-tenant-registry/wrangler.jsonc
@@ -18,8 +18,5 @@
   },
   "migrations": [
     { "tag": "v1", "new_sqlite_classes": ["TenantNode"] }
-  ],
-  "vars": {
-    "TOKEN_SIGNING_KEY": "test-signing-key-not-for-production"
-  }
+  ]
 }


### PR DESCRIPTION
## Summary — real production issue, already remediated live

`wrangler.jsonc`'s `vars` block is shared between local dev/test config AND real `wrangler deploy`. PR #1137 put a test-only placeholder there (`test-signing-key-not-for-production`) for local test runs — but that same file governs production deploys, so redeploying from `main` after #1137 merged bundled the plaintext test value into the live Worker, where it **overwrote/deleted the real `TOKEN_SIGNING_KEY` secret** (Cloudflare treats a `var` and `secret` with the same binding name as the same slot; deploying the var wins).

Found by actually redeploying and checking `wrangler secret list` — the real secret was gone afterward. **Already remediated on the live Worker**: moved the test value to `.dev.vars` (gitignored, the standard wrangler mechanism for local-only vars that `wrangler deploy` never reads), redeployed, re-provisioned the real `TOKEN_SIGNING_KEY` secret. Exposure window was one deploy cycle.

## Verification (against the live, already-fixed deployment)
- [x] `wrangler secret list` shows both `REGISTRY_ADMIN_KEY` and `TOKEN_SIGNING_KEY` as real secrets, no `vars` in the deploy output
- [x] 26/26 tests still pass locally with the value now coming from `.dev.vars`
- [x] Full end-to-end flow verified live: create tenant (with owner) → 201 + `rootNodeId` → request token → 200 signed token → verify valid token → 200 correct payload → verify tampered token → 401 `invalid signature`

This PR brings the git source back in sync with the already-fixed live state — merging it prevents the same regression from being reintroduced by a future redeploy from `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)