### PR TITLE
feat(datum): Postel-tolerant loader — degraded fallback, dangling classification, --strict (#163)

### DIFF
--- a/b00t-cli/src/boot_datum.rs
+++ b/b00t-cli/src/boot_datum.rs
@@ -281,6 +281,11 @@ pub struct BootDatum {
     //     Remove after all datums have been audited.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub required_for_core: Option<bool>,
+
+    // #163 Postel loader tolerance: raw TOML source parked when strict parse
+    // fails and the datum loads via the lenient fallback path. In-memory only.
+    #[serde(skip)]
+    pub raw_source: Option<String>,
 }
 
 // Re-export ApiProvides from config_types (needed by BootDatum)

--- a/b00t-cli/src/commands/datum.rs
+++ b/b00t-cli/src/commands/datum.rs
@@ -1219,17 +1219,61 @@ impl Satisfies<BootDatumSchemaConstraint> for DatumTomlSubject<'_> {
 
 fn handle_validate_graph(datum_path: &str) -> Result<()> {
     let store = HashMapStore::from_path(datum_path)?;
-    let errors = store.validate_references();
+    let diagnostics = store.diagnose_references();
 
-    if errors.is_empty() {
-        println!("datum graph: valid ({} datums)", store.len());
+    if diagnostics.is_empty() {
+        println!("datum graph: valid ({} datums loaded from {datum_path})", store.len());
         return Ok(());
     }
 
-    for error in &errors {
-        eprintln!("  ERROR: {error}");
+    for diagnostic in &diagnostics {
+        eprintln!("  ERROR: {diagnostic}");
     }
-    anyhow::bail!("datum graph validation failed: {} reference error(s)", errors.len());
+    eprintln!("{}", render_graph_summary(&store, &diagnostics, datum_path));
+    anyhow::bail!(
+        "datum graph validation failed: {} reference error(s)",
+        diagnostics.len()
+    );
+}
+
+/// #163: summary block — total datums loaded, errors grouped per source datum,
+/// count per field type. Deterministic (BTreeMap) ordering.
+fn render_graph_summary(
+    store: &HashMapStore,
+    diagnostics: &[crate::datum_store::ReferenceDiagnostic],
+    datum_path: &str,
+) -> String {
+    use std::collections::BTreeMap;
+    use std::fmt::Write as _;
+
+    let mut per_datum: BTreeMap<&str, (Option<&str>, usize)> = BTreeMap::new();
+    let mut per_field: BTreeMap<&str, usize> = BTreeMap::new();
+    for d in diagnostics {
+        let entry = per_datum
+            .entry(d.error.datum_key())
+            .or_insert((d.source_path.as_deref(), 0));
+        entry.1 += 1;
+        *per_field.entry(d.error.field_name()).or_insert(0) += 1;
+    }
+
+    let mut out = String::new();
+    let _ = writeln!(out, "\n── datum graph summary ──────────────────────────");
+    let _ = writeln!(out, "datums loaded: {} from {datum_path}", store.len());
+    let _ = writeln!(
+        out,
+        "reference errors: {} across {} source datum(s)",
+        diagnostics.len(),
+        per_datum.len()
+    );
+    let _ = writeln!(out, "errors per source datum:");
+    for (key, (path, count)) in &per_datum {
+        let _ = writeln!(out, "  {key} ({}): {count}", path.unwrap_or("<in-memory>"));
+    }
+    let _ = writeln!(out, "errors per field:");
+    for (field, count) in &per_field {
+        let _ = writeln!(out, "  {field}: {count}");
+    }
+    out.trim_end().to_string()
 }
 
 fn print_validation_result(errors: &[String], warnings: &[String]) -> Result<()> {

--- a/b00t-cli/src/commands/datum.rs
+++ b/b00t-cli/src/commands/datum.rs
@@ -286,7 +286,7 @@ pub fn handle_datum_command(path: &str, datum_command: &DatumCommands) -> Result
         }
         DatumCommands::Validate { target, strict, graph } => {
             if *graph {
-                handle_validate_graph(path)
+                handle_validate_graph(path, *strict)
             } else {
                 let Some(target) = target else {
                     anyhow::bail!("specify datum key, file path, or --graph");
@@ -1217,23 +1217,44 @@ impl Satisfies<BootDatumSchemaConstraint> for DatumTomlSubject<'_> {
     }
 }
 
-fn handle_validate_graph(datum_path: &str) -> Result<()> {
+fn handle_validate_graph(datum_path: &str, strict: bool) -> Result<()> {
     let store = HashMapStore::from_path(datum_path)?;
     let diagnostics = store.diagnose_references();
 
     if diagnostics.is_empty() {
         println!("datum graph: valid ({} datums loaded from {datum_path})", store.len());
+        let scan = store.scan_diagnostics();
+        if !scan.degraded.is_empty() {
+            eprintln!(
+                "note: {} file(s) loaded via lenient fallback (degraded)",
+                scan.degraded.len()
+            );
+        }
         return Ok(());
     }
 
+    // Postel (#163): dangling references are warnings by default;
+    // --strict restores hard-fail for audits/CI opt-in.
+    let label = if strict { "ERROR" } else { "WARN" };
     for diagnostic in &diagnostics {
-        eprintln!("  ERROR: {diagnostic}");
+        let class = diagnostic
+            .dangling_class()
+            .map(|c| format!(" [{c}]"))
+            .unwrap_or_default();
+        eprintln!("  {label}{class}: {diagnostic}");
     }
     eprintln!("{}", render_graph_summary(&store, &diagnostics, datum_path));
-    anyhow::bail!(
-        "datum graph validation failed: {} reference error(s)",
+    if strict {
+        anyhow::bail!(
+            "datum graph validation failed: {} reference error(s)",
+            diagnostics.len()
+        );
+    }
+    println!(
+        "datum graph: {} dangling reference warning(s) — non-fatal (use --strict to enforce)",
         diagnostics.len()
     );
+    Ok(())
 }
 
 /// #163: summary block — total datums loaded, errors grouped per source datum,
@@ -1248,17 +1269,34 @@ fn render_graph_summary(
 
     let mut per_datum: BTreeMap<&str, (Option<&str>, usize)> = BTreeMap::new();
     let mut per_field: BTreeMap<&str, usize> = BTreeMap::new();
+    let mut per_class: BTreeMap<String, usize> = BTreeMap::new();
     for d in diagnostics {
         let entry = per_datum
             .entry(d.error.datum_key())
             .or_insert((d.source_path.as_deref(), 0));
         entry.1 += 1;
         *per_field.entry(d.error.field_name()).or_insert(0) += 1;
+        if let Some(class) = d.dangling_class() {
+            *per_class.entry(class.to_string()).or_insert(0) += 1;
+        }
     }
 
     let mut out = String::new();
     let _ = writeln!(out, "\n── datum graph summary ──────────────────────────");
     let _ = writeln!(out, "datums loaded: {} from {datum_path}", store.len());
+    let scan = store.scan_diagnostics();
+    let _ = writeln!(
+        out,
+        "files degraded (lenient fallback): {} | keys shadowed by higher-precedence files: {}",
+        scan.degraded.len(),
+        scan.shadowed.len()
+    );
+    for (path, reason) in &scan.degraded {
+        let _ = writeln!(out, "  degraded {path}: {reason}");
+    }
+    for (key, loser, winner) in &scan.shadowed {
+        let _ = writeln!(out, "  shadowed {key}: {loser} superseded by {winner}");
+    }
     let _ = writeln!(
         out,
         "reference errors: {} across {} source datum(s)",
@@ -1272,6 +1310,10 @@ fn render_graph_summary(
     let _ = writeln!(out, "errors per field:");
     for (field, count) in &per_field {
         let _ = writeln!(out, "  {field}: {count}");
+    }
+    let _ = writeln!(out, "dangling references by class:");
+    for (class, count) in &per_class {
+        let _ = writeln!(out, "  {class}: {count}");
     }
     out.trim_end().to_string()
 }

--- a/b00t-cli/src/datum_store.rs
+++ b/b00t-cli/src/datum_store.rs
@@ -102,7 +102,15 @@ pub trait DatumStore: Send + Sync {
     /// Reports: missing graph references, self-deps, empty ref strings, missing members.
     /// Override in bulk-query backends (e.g. SQL JOIN) for efficiency.
     fn validate_references(&self) -> Vec<ReferenceError> {
-        let key_set: HashSet<String> = self.iter().map(|d| d.key.as_ref().to_owned()).collect();
+        // Degraded (unparseable) datums are excluded from the resolvable key set:
+        // a reference to a datum whose own file failed to parse must still be
+        // reported as dangling (Postel's Law tolerates the degraded file loading
+        // as a stub; it does not silently declare it a valid reference target).
+        let key_set: HashSet<String> = self
+            .iter()
+            .filter(|d| d.datum.status.as_deref() != Some("degraded"))
+            .map(|d| d.key.as_ref().to_owned())
+            .collect();
         let mut errors = Vec::new();
         for d in self.iter() {
             let key = d.key.as_ref();
@@ -863,6 +871,31 @@ mod tests {
         assert!(errs.iter().any(|e| matches!(e, ReferenceError::MissingDependency {
             datum, missing_key
         } if datum == "broken.role" && missing_key == "nonexistent.cli")));
+    }
+
+    #[test]
+    fn validate_references_flags_dependency_on_degraded_datum() {
+        // Postel tolerance (#163, #1140): a datum that failed strict parse still
+        // loads as a degraded stub so it isn't silently dropped -- but a
+        // *reference* to that stub must still be reported as dangling, the same
+        // way it was before the degraded-fallback loader existed. If this
+        // regresses, --strict silently stops catching broken referenced files.
+        let mut store = store_with_refs();
+        store.intern("vendor-foo.role", BootDatum {
+            name: "vendor-foo".to_string(),
+            status: Some("degraded".to_string()),
+            ..Default::default()
+        });
+        store.intern("depends-on-broken.role", BootDatum {
+            name: "depends-on-broken".to_string(), hint: "x".to_string(),
+            depends_on: Some(vec!["vendor-foo.role".to_string()]),
+            ..Default::default()
+        });
+        let errs = store.validate_references();
+        assert!(errs.iter().any(|e| matches!(e, ReferenceError::MissingDependency {
+            datum, missing_key
+        } if datum == "depends-on-broken.role" && missing_key == "vendor-foo.role")),
+            "reference to a degraded datum must still be dangling: {errs:?}");
     }
 
     #[test]

--- a/b00t-cli/src/datum_store.rs
+++ b/b00t-cli/src/datum_store.rs
@@ -29,7 +29,7 @@ use crate::datum_proof::{
     AsJobDatum, AsJustfileDatum, AsK8sDatum, AsMcpDatum, AsNixDatum, AsRepoDatum,
     AsRoleDatum, AsSkillDatum, AsStackDatum, AsUnknownDatum, AsVscodeDatum, Provable,
 };
-use crate::datum_utils::get_all_datums;
+use crate::datum_utils::get_all_datums_with_paths;
 use crate::{BootDatum, DatumType};
 use anyhow::Result;
 use std::collections::{HashMap, HashSet};
@@ -294,23 +294,194 @@ impl fmt::Display for ReferenceError {
     }
 }
 
+impl ReferenceError {
+    /// Key of the datum that declares the offending reference.
+    pub fn datum_key(&self) -> &str {
+        match self {
+            Self::MissingDependency { datum, .. }
+            | Self::SelfDependency { datum }
+            | Self::EmptyDependency { datum }
+            | Self::MissingReference { datum, .. }
+            | Self::EmptyReference { datum, .. } => datum,
+            Self::MissingMember { stack, .. } => stack,
+        }
+    }
+
+    /// Edge field the reference appears in.
+    pub fn field_name(&self) -> &'static str {
+        match self {
+            Self::MissingDependency { .. }
+            | Self::SelfDependency { .. }
+            | Self::EmptyDependency { .. } => "depends_on",
+            Self::MissingMember { .. } => "members",
+            Self::MissingReference { field, .. } | Self::EmptyReference { field, .. } => field,
+        }
+    }
+
+    /// The unresolved key, for missing-reference variants.
+    pub fn missing_key(&self) -> Option<&str> {
+        match self {
+            Self::MissingDependency { missing_key, .. }
+            | Self::MissingReference { missing_key, .. } => Some(missing_key),
+            Self::MissingMember { missing_member, .. } => Some(missing_member),
+            _ => None,
+        }
+    }
+}
+
+// ── ReferenceDiagnostic (#163) ────────────────────────────────────────────────
+
+/// Fallback suffix `reference_resolves` probes for a given edge field.
+/// MUST mirror the `fallback_suffix` arguments passed in `validate_references`.
+pub fn fallback_suffix_for_field(field: &str) -> Option<&'static str> {
+    match field {
+        "skills" => Some(".skill"),
+        _ => None,
+    }
+}
+
+/// Exact key patterns `reference_resolves` probes for `reference` in `field`.
+pub fn probe_patterns(reference: &str, field: &str) -> Vec<String> {
+    let mut probed = vec![reference.to_string()];
+    if let Some(suffix) = fallback_suffix_for_field(field) {
+        if !reference.contains('.') {
+            probed.push(format!("{reference}{suffix}"));
+        }
+    }
+    probed
+}
+
+/// Classic two-row Levenshtein edit distance. Small keys only — O(n*m) is fine.
+fn levenshtein(a: &str, b: &str) -> usize {
+    let a: Vec<char> = a.chars().collect();
+    let b: Vec<char> = b.chars().collect();
+    let mut prev: Vec<usize> = (0..=b.len()).collect();
+    for (i, ca) in a.iter().enumerate() {
+        let mut curr = vec![i + 1; b.len() + 1];
+        for (j, cb) in b.iter().enumerate() {
+            let cost = usize::from(ca != cb);
+            curr[j + 1] = (prev[j] + cost).min(prev[j + 1] + 1).min(curr[j] + 1);
+        }
+        prev = curr;
+    }
+    prev[b.len()]
+}
+
+/// Nearest-key suggestion for an unresolved reference: substring containment
+/// (either direction) or small edit distance. Deterministic tie-break.
+pub fn nearest_key<'a>(keys: impl IntoIterator<Item = &'a str>, missing: &str) -> Option<String> {
+    if missing.len() < 3 {
+        return None;
+    }
+    let mut best: Option<(usize, &str)> = None;
+    for key in keys {
+        if key == missing {
+            continue;
+        }
+        let containment = key.len() >= 3 && (key.contains(missing) || missing.contains(key));
+        let score = if containment {
+            key.len().abs_diff(missing.len())
+        } else {
+            let d = levenshtein(missing, key);
+            if d > 2.max(missing.len() / 4) {
+                continue; // too far — no suggestion from this key
+            }
+            d
+        };
+        let better = match best {
+            None => true,
+            Some((s, k)) => score < s || (score == s && key < k),
+        };
+        if better {
+            best = Some((score, key));
+        }
+    }
+    best.map(|(_, k)| k.to_string())
+}
+
+/// A `ReferenceError` enriched with actionable context (#163):
+/// source file of the referencing datum, patterns probed, nearest-key suggestion.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ReferenceDiagnostic {
+    pub error: ReferenceError,
+    /// Source file the referencing datum was loaded from (None for in-memory datums).
+    pub source_path: Option<String>,
+    /// Key patterns `reference_resolves` probed (exact + fallback-suffixed).
+    pub probed: Vec<String>,
+    /// Nearest existing key, when a close match exists in the store.
+    pub suggestion: Option<String>,
+}
+
+impl fmt::Display for ReferenceDiagnostic {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.error)?;
+        write!(f, "\n    source: {}", self.source_path.as_deref().unwrap_or("<in-memory>"))?;
+        if !self.probed.is_empty() {
+            let probed: Vec<String> = self.probed.iter().map(|p| format!("'{p}'")).collect();
+            write!(f, "\n    probed: {}", probed.join(", "))?;
+        }
+        if let Some(s) = &self.suggestion {
+            write!(f, "\n    suggestion: did you mean '{s}'?")?;
+        }
+        Ok(())
+    }
+}
+
 // ── HashMapStore ──────────────────────────────────────────────────────────────
 
 /// Concrete store backed by an in-memory HashMap. Equivalent to Chalk's Box strategy.
 #[derive(Default)]
 pub struct HashMapStore {
     inner: HashMap<String, InternedDatum>,
+    /// Source file each datum was loaded from (key -> path). Diagnostics only (#163).
+    source_paths: HashMap<String, String>,
 }
 
 impl HashMapStore {
     /// Load all datums from a `_b00t_` directory path (standard TOML scan).
+    /// Same scan as `get_all_datums`, but source file paths are retained for diagnostics.
     pub fn from_path(b00t_path: &str) -> Result<Self> {
-        let raw = get_all_datums(b00t_path)?;
+        let raw = get_all_datums_with_paths(b00t_path, None)?;
         let mut store = Self::default();
-        for (key, datum) in raw {
-            store.intern(&key, datum);
+        for (key, (datum, path)) in raw {
+            store.intern_with_path(&key, datum, &path);
         }
         Ok(store)
+    }
+
+    /// Intern a datum and record the source file it was loaded from.
+    pub fn intern_with_path(&mut self, key: &str, datum: BootDatum, source_path: &str) -> InternedDatum {
+        self.source_paths.insert(key.to_string(), source_path.to_string());
+        self.intern(key, datum)
+    }
+
+    /// Source file a datum was loaded from, if known.
+    pub fn source_path(&self, key: &str) -> Option<&str> {
+        self.source_paths.get(key).map(String::as_str)
+    }
+
+    /// `validate_references` with actionable context (#163). Wraps each error 1:1 —
+    /// resolution semantics are untouched, only diagnostics are added.
+    pub fn diagnose_references(&self) -> Vec<ReferenceDiagnostic> {
+        let keys: Vec<&str> = self.inner.keys().map(String::as_str).collect();
+        self.validate_references()
+            .into_iter()
+            .map(|error| {
+                let (probed, suggestion) = match error.missing_key() {
+                    Some(missing) => (
+                        probe_patterns(missing, error.field_name()),
+                        nearest_key(keys.iter().copied(), missing),
+                    ),
+                    None => (Vec::new(), None),
+                };
+                ReferenceDiagnostic {
+                    source_path: self.source_path(error.datum_key()).map(str::to_owned),
+                    probed,
+                    suggestion,
+                    error,
+                }
+            })
+            .collect()
     }
 }
 
@@ -766,5 +937,100 @@ mod tests {
             .collect();
         assert!(self_deps.is_empty(), "self-dependencies in real _b00t_: {self_deps:?}");
         assert!(empty_deps.is_empty(), "empty depends_on entries in real _b00t_: {empty_deps:?}");
+    }
+
+    // ── #163: actionable validate --graph diagnostics ─────────────────────────
+
+    fn store_for_diagnostics() -> HashMapStore {
+        let mut store = HashMapStore::default();
+        store.intern_with_path("gemma-4-26b-a4b-local.model.ai", BootDatum {
+            name: "gemma-4-26b-a4b-local".to_string(), hint: "local gemma".to_string(),
+            ..Default::default()
+        }, "_b00t_/gemma-4-26b-a4b-local.model.ai.tomllmd");
+        store.intern_with_path("hive-cmdb.skill", BootDatum {
+            name: "hive-cmdb".to_string(), hint: "cmdb".to_string(),
+            ..Default::default()
+        }, "_b00t_/hive-cmdb.skill.toml");
+        store.intern_with_path("pi-gemma4-hive.stack", BootDatum {
+            name: "pi-gemma4-hive".to_string(), hint: "stack".to_string(),
+            members: Some(vec!["gemma-4-26b-a4b-local.model".to_string()]),
+            ..Default::default()
+        }, "_b00t_/pi-gemma4-hive.stack.toml");
+        store.intern_with_path("executive.role", BootDatum {
+            name: "executive".to_string(), hint: "role".to_string(),
+            skills: Some(vec!["hive-cmd".to_string()]),
+            ..Default::default()
+        }, "_b00t_/AGENTS/executive.role.toml");
+        store
+    }
+
+    #[test]
+    fn diagnose_missing_member_has_path_probes_and_suggestion() {
+        let store = store_for_diagnostics();
+        let diags = store.diagnose_references();
+        let d = diags.iter()
+            .find(|d| d.error.missing_key() == Some("gemma-4-26b-a4b-local.model"))
+            .expect("missing-member diagnostic present");
+        assert_eq!(d.source_path.as_deref(), Some("_b00t_/pi-gemma4-hive.stack.toml"));
+        assert_eq!(d.probed, vec!["gemma-4-26b-a4b-local.model".to_string()]);
+        assert_eq!(d.suggestion.as_deref(), Some("gemma-4-26b-a4b-local.model.ai"));
+    }
+
+    #[test]
+    fn diagnose_skills_probes_fallback_suffix() {
+        let store = store_for_diagnostics();
+        let diags = store.diagnose_references();
+        let d = diags.iter()
+            .find(|d| d.error.missing_key() == Some("hive-cmd"))
+            .expect("missing-skill diagnostic present");
+        assert_eq!(d.probed, vec!["hive-cmd".to_string(), "hive-cmd.skill".to_string()]);
+        assert_eq!(d.suggestion.as_deref(), Some("hive-cmdb.skill"));
+    }
+
+    #[test]
+    fn diagnostic_display_is_actionable() {
+        let store = store_for_diagnostics();
+        let diags = store.diagnose_references();
+        let d = diags.iter()
+            .find(|d| d.error.missing_key() == Some("hive-cmd"))
+            .unwrap();
+        let s = d.to_string();
+        assert!(s.contains("_b00t_/AGENTS/executive.role.toml"), "source path in display: {s}");
+        assert!(s.contains("probed: 'hive-cmd', 'hive-cmd.skill'"), "probe patterns in display: {s}");
+        assert!(s.contains("did you mean 'hive-cmdb.skill'"), "suggestion in display: {s}");
+    }
+
+    #[test]
+    fn diagnose_does_not_change_error_count_or_semantics() {
+        let store = store_for_diagnostics();
+        let errors = store.validate_references();
+        let diags = store.diagnose_references();
+        assert_eq!(errors.len(), diags.len(), "diagnostics wrap errors 1:1");
+        let wrapped: Vec<&ReferenceError> = diags.iter().map(|d| &d.error).collect();
+        for e in &errors {
+            assert!(wrapped.contains(&e), "error preserved in diagnostics: {e}");
+        }
+    }
+
+    #[test]
+    fn nearest_key_edit_distance_and_none() {
+        let keys = ["git.cli", "gh.cli", "kaizen.skill"];
+        assert_eq!(nearest_key(keys.iter().copied(), "git.clii").as_deref(), Some("git.cli"));
+        assert_eq!(nearest_key(keys.iter().copied(), "zzz-unrelated-thing"), None);
+    }
+
+    #[test]
+    fn from_path_records_source_paths() {
+        use std::io::Write;
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let file_path = temp_dir.path().join("solo.cli.toml");
+        let mut f = std::fs::File::create(&file_path).unwrap();
+        write!(f, "[b00t]\nname = \"solo\"\ntype = \"cli\"\nhint = \"solo tool\"\n").unwrap();
+        let store = HashMapStore::from_path(temp_dir.path().to_str().unwrap()).unwrap();
+        assert_eq!(store.len(), 1);
+        assert_eq!(
+            store.source_path("solo.cli"),
+            Some(file_path.to_string_lossy().as_ref())
+        );
     }
 }

--- a/b00t-cli/src/datum_store.rs
+++ b/b00t-cli/src/datum_store.rs
@@ -29,7 +29,7 @@ use crate::datum_proof::{
     AsJobDatum, AsJustfileDatum, AsK8sDatum, AsMcpDatum, AsNixDatum, AsRepoDatum,
     AsRoleDatum, AsSkillDatum, AsStackDatum, AsUnknownDatum, AsVscodeDatum, Provable,
 };
-use crate::datum_utils::get_all_datums_with_paths;
+use crate::datum_utils::{ScanDiagnostics, get_all_datums_with_diagnostics};
 use crate::{BootDatum, DatumType};
 use anyhow::Result;
 use std::collections::{HashMap, HashSet};
@@ -399,6 +399,28 @@ pub fn nearest_key<'a>(keys: impl IntoIterator<Item = &'a str>, missing: &str) -
     best.map(|(_, k)| k.to_string())
 }
 
+/// Classification of a dangling reference (#163, Postel):
+/// warnings by default — hard-fail only under `--strict`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DanglingClass {
+    /// A close key exists in the store — likely a typo (suggestion available).
+    NearMiss,
+    /// No close match — the target datum was likely never authored.
+    Aspirational,
+    /// Reference text looks like prose / a logical capability name, not a key.
+    Prose,
+}
+
+impl fmt::Display for DanglingClass {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NearMiss => write!(f, "near-miss"),
+            Self::Aspirational => write!(f, "aspirational"),
+            Self::Prose => write!(f, "prose"),
+        }
+    }
+}
+
 /// A `ReferenceError` enriched with actionable context (#163):
 /// source file of the referencing datum, patterns probed, nearest-key suggestion.
 #[derive(Debug, Clone, PartialEq)]
@@ -410,6 +432,20 @@ pub struct ReferenceDiagnostic {
     pub probed: Vec<String>,
     /// Nearest existing key, when a close match exists in the store.
     pub suggestion: Option<String>,
+}
+
+impl ReferenceDiagnostic {
+    /// Classify a dangling (missing) reference; None for non-missing variants.
+    pub fn dangling_class(&self) -> Option<DanglingClass> {
+        let missing = self.error.missing_key()?;
+        Some(if missing.contains(char::is_whitespace) {
+            DanglingClass::Prose
+        } else if self.suggestion.is_some() {
+            DanglingClass::NearMiss
+        } else {
+            DanglingClass::Aspirational
+        })
+    }
 }
 
 impl fmt::Display for ReferenceDiagnostic {
@@ -435,18 +471,26 @@ pub struct HashMapStore {
     inner: HashMap<String, InternedDatum>,
     /// Source file each datum was loaded from (key -> path). Diagnostics only (#163).
     source_paths: HashMap<String, String>,
+    /// Loader-level diagnostics from `from_path` (skipped/shadowed files) (#163).
+    scan: ScanDiagnostics,
 }
 
 impl HashMapStore {
     /// Load all datums from a `_b00t_` directory path (standard TOML scan).
     /// Same scan as `get_all_datums`, but source file paths are retained for diagnostics.
     pub fn from_path(b00t_path: &str) -> Result<Self> {
-        let raw = get_all_datums_with_paths(b00t_path, None)?;
+        let (raw, scan) = get_all_datums_with_diagnostics(b00t_path, None)?;
         let mut store = Self::default();
         for (key, (datum, path)) in raw {
             store.intern_with_path(&key, datum, &path);
         }
+        store.scan = scan;
         Ok(store)
+    }
+
+    /// Loader diagnostics from the `from_path` scan (skipped/shadowed files).
+    pub fn scan_diagnostics(&self) -> &ScanDiagnostics {
+        &self.scan
     }
 
     /// Intern a datum and record the source file it was loaded from.
@@ -1010,6 +1054,32 @@ mod tests {
         for e in &errors {
             assert!(wrapped.contains(&e), "error preserved in diagnostics: {e}");
         }
+    }
+
+    #[test]
+    fn dangling_class_partitions_warnings() {
+        let mut store = store_for_diagnostics();
+        store.intern_with_path("classify.role", BootDatum {
+            name: "classify".to_string(), hint: "role".to_string(),
+            skills: Some(vec!["role-scoped capability loading".to_string()]),
+            depends_on: Some(vec!["totally-novel-unwritten-datum".to_string()]),
+            ..Default::default()
+        }, "_b00t_/classify.role.toml");
+        let diags = store.diagnose_references();
+        let class_of = |missing: &str| {
+            diags.iter()
+                .find(|d| d.error.missing_key() == Some(missing))
+                .and_then(|d| d.dangling_class())
+        };
+        assert_eq!(class_of("hive-cmd"), Some(DanglingClass::NearMiss));
+        assert_eq!(
+            class_of("role-scoped capability loading"),
+            Some(DanglingClass::Prose)
+        );
+        assert_eq!(
+            class_of("totally-novel-unwritten-datum"),
+            Some(DanglingClass::Aspirational)
+        );
     }
 
     #[test]

--- a/b00t-cli/src/datum_utils.rs
+++ b/b00t-cli/src/datum_utils.rs
@@ -119,18 +119,41 @@ pub fn get_all_datums_with_paths(
     b00t_path: &str,
     max_depth: Option<usize>,
 ) -> Result<HashMap<String, (BootDatum, String)>> {
+    let (datums, _diag) = get_all_datums_with_diagnostics(b00t_path, max_depth)?;
+    Ok(datums)
+}
+
+/// Scan-level diagnostics (#163): degraded (lenient-fallback) files + key shadowing.
+/// Postel's Law: the loader is tolerant — nothing vanishes silently.
+#[derive(Debug, Default, Clone)]
+pub struct ScanDiagnostics {
+    /// Files that failed strict `UnifiedConfig` parse (or were unreadable) and
+    /// loaded via the lenient fallback path instead: (file path, one-line reason).
+    pub degraded: Vec<(String, String)>,
+    /// Same datum key claimed by multiple files: (key, shadowed path, winning path).
+    /// Precedence: .tomllmd > .tomllm > .toml; equal rank — later scan wins.
+    /// A good parse always beats a degraded fallback, regardless of rank.
+    pub shadowed: Vec<(String, String, String)>,
+}
+
+/// Like `get_all_datums_with_paths` but also returns scan diagnostics (#163).
+pub fn get_all_datums_with_diagnostics(
+    b00t_path: &str,
+    max_depth: Option<usize>,
+) -> Result<(HashMap<String, (BootDatum, String)>, ScanDiagnostics)> {
     let expanded_path = shellexpand::tilde(b00t_path);
     let path = Path::new(expanded_path.as_ref());
     let mut datums = HashMap::new();
+    let mut diag = ScanDiagnostics::default();
 
     if !path.exists() {
-        return Ok(datums);
+        return Ok((datums, diag));
     }
 
     let depth = max_depth.unwrap_or(DEFAULT_MAX_DEPTH);
-    scan_datums_recursive(path, &mut datums, 0, depth)?;
+    scan_datums_recursive(path, &mut datums, &mut diag, 0, depth)?;
 
-    Ok(datums)
+    Ok((datums, diag))
 }
 
 /// Merge `b00t.*` Git attributes into a parsed datum without mutating the datum file.
@@ -262,6 +285,7 @@ fn find_git_worktree_root(path: &Path) -> Option<std::path::PathBuf> {
 fn scan_datums_recursive(
     dir: &Path,
     datums: &mut HashMap<String, (BootDatum, String)>,
+    diag: &mut ScanDiagnostics,
     current_depth: usize,
     max_depth: usize,
 ) -> Result<()> {
@@ -283,7 +307,7 @@ fn scan_datums_recursive(
 
         if entry_path.is_dir() {
             // Recurse into subdirectories
-            scan_datums_recursive(&entry_path, datums, current_depth + 1, max_depth)?;
+            scan_datums_recursive(&entry_path, datums, diag, current_depth + 1, max_depth)?;
         } else if matches!(
             entry_path.extension().and_then(|s| s.to_str()),
             Some("toml") | Some("tomllm") | Some("tomllmd") // 🤓 .tomllmd currently downgrades to the generic .tomllm parser path
@@ -297,42 +321,88 @@ fn scan_datums_recursive(
                     continue;
                 }
 
-                // Try to parse as unified config
-                if let Ok(content) = fs::read_to_string(&entry_path) {
-                    if let Ok(mut config) = toml::from_str::<UnifiedConfig>(&content) {
-                        apply_git_attributes_to_config(&mut config, &entry_path);
-                        // Strip outer extension (.tomllmd / .tomllm / .toml) for datum key.
-                        // 🤓 precedence: .tomllmd > .tomllm > .toml.
-                        let ext = if filename.ends_with(".tomllmd") {
-                            ".tomllmd"
-                        } else if filename.ends_with(".tomllm") {
-                            ".tomllm"
-                        } else {
-                            ".toml"
-                        };
-                        let datum_key = filename.trim_end_matches(ext).to_string();
-                        let path_str = entry_path.to_string_lossy().to_string();
-                        let new_rank = match ext {
-                            ".tomllmd" => 3,
-                            ".tomllm" => 2,
-                            _ => 1,
-                        };
-                        let current_rank = datums
-                            .get(&datum_key)
-                            .map(|(_, existing_path)| {
-                                if existing_path.ends_with(".tomllmd") {
-                                    3
-                                } else if existing_path.ends_with(".tomllm") {
-                                    2
-                                } else {
-                                    1
-                                }
-                            })
-                            .unwrap_or(0);
-                        if new_rank >= current_rank {
-                            datums.insert(datum_key, (config.b00t, path_str));
+                // Tolerant parse (Postel #163): strict parse first; on failure the
+                // datum still loads via lenient fallback — key from filename, raw
+                // TOML parked, marked degraded. Nothing vanishes silently.
+                let path_str = entry_path.to_string_lossy().to_string();
+                let ext = if filename.ends_with(".tomllmd") {
+                    ".tomllmd"
+                } else if filename.ends_with(".tomllm") {
+                    ".tomllm"
+                } else {
+                    ".toml"
+                };
+                let datum_key = filename.trim_end_matches(ext).to_string();
+                // 🤓 precedence: .tomllmd > .tomllm > .toml.
+                let new_rank = match ext {
+                    ".tomllmd" => 3,
+                    ".tomllm" => 2,
+                    _ => 1,
+                };
+
+                let parsed: Result<BootDatum, String> = match fs::read_to_string(&entry_path) {
+                    Err(e) => Err(format!("unreadable: {e}")),
+                    Ok(content) => match toml::from_str::<UnifiedConfig>(&content) {
+                        Ok(mut config) => {
+                            apply_git_attributes_to_config(&mut config, &entry_path);
+                            Ok(config.b00t)
                         }
+                        Err(e) => {
+                            let one_line = e
+                                .to_string()
+                                .lines()
+                                .map(str::trim)
+                                .filter(|l| !l.is_empty())
+                                .collect::<Vec<_>>()
+                                .join("; ");
+                            let mut fallback = BootDatum::default();
+                            fallback.name = datum_key
+                                .split('.')
+                                .next()
+                                .unwrap_or(&datum_key)
+                                .to_string();
+                            fallback.hint = format!("degraded: {filename} failed strict parse");
+                            fallback.status = Some("degraded".to_string());
+                            fallback.status_msg = Some(one_line.clone());
+                            fallback.type_tags = Some(vec!["degraded".to_string()]);
+                            fallback.raw_source = Some(content);
+                            diag.degraded.push((path_str.clone(), one_line));
+                            datums.entry(datum_key.clone()).or_insert((fallback, path_str.clone()));
+                            continue; // degraded never displaces an existing entry
+                        }
+                    },
+                };
+                let datum = match parsed {
+                    Ok(d) => d,
+                    Err(reason) => {
+                        diag.degraded.push((path_str, reason));
+                        continue;
                     }
+                };
+
+                let existing = datums.get(&datum_key).map(|(d, existing_path)| {
+                    let rank = if existing_path.ends_with(".tomllmd") {
+                        3
+                    } else if existing_path.ends_with(".tomllm") {
+                        2
+                    } else {
+                        1
+                    };
+                    (rank, existing_path.clone(), d.status.as_deref() == Some("degraded"))
+                });
+                let current_rank = match &existing {
+                    // a good parse always beats a degraded fallback
+                    Some((_, _, true)) => 0,
+                    Some((rank, _, false)) => *rank,
+                    None => 0,
+                };
+                if new_rank >= current_rank {
+                    if let Some((_, old_path, _)) = existing {
+                        diag.shadowed.push((datum_key.clone(), old_path, path_str.clone()));
+                    }
+                    datums.insert(datum_key, (datum, path_str));
+                } else if let Some((_, winning_path, _)) = existing {
+                    diag.shadowed.push((datum_key, path_str, winning_path));
                 }
             }
         }
@@ -773,6 +843,83 @@ mod tests {
 
     fn create_test_datum_file(dir: &std::path::Path, name: &str, content: &str) {
         fs::write(dir.join(name), content).unwrap();
+    }
+
+    // ── #163: scan diagnostics — skipped (unparseable) + shadowed files ──────
+
+    #[test]
+    fn scan_degrades_unparseable_file_instead_of_dropping_it() {
+        let temp_dir = TempDir::new().unwrap();
+        create_test_datum_file(
+            temp_dir.path(),
+            "good.cli.toml",
+            "[b00t]\nname = \"good\"\ntype = \"cli\"\nhint = \"ok\"\n",
+        );
+        let raw = "[b00t]\nname = \"broken\"\nthis is not = valid toml [[[\n";
+        create_test_datum_file(temp_dir.path(), "broken.cli.toml", raw);
+        let (datums, diag) =
+            get_all_datums_with_diagnostics(temp_dir.path().to_str().unwrap(), Some(0)).unwrap();
+        // Postel: the broken file MUST NOT vanish — it loads as a degraded datum.
+        assert_eq!(datums.len(), 2, "degraded datum still loads");
+        let (degraded, path) = &datums["broken.cli"];
+        assert!(path.ends_with("broken.cli.toml"));
+        assert_eq!(degraded.name, "broken", "name captured from filename");
+        assert_eq!(degraded.status.as_deref(), Some("degraded"));
+        assert_eq!(degraded.raw_source.as_deref(), Some(raw), "raw TOML parked");
+        assert!(degraded.status_msg.as_deref().unwrap_or("").contains("TOML parse error"));
+        // and the parse problem is surfaced in scan diagnostics
+        assert_eq!(diag.degraded.len(), 1, "degraded file reported");
+        let (dpath, reason) = &diag.degraded[0];
+        assert!(dpath.ends_with("broken.cli.toml"), "degraded path: {dpath}");
+        assert!(!reason.is_empty() && !reason.contains('\n'), "one-line reason: {reason:?}");
+    }
+
+    #[test]
+    fn good_parse_always_beats_degraded_fallback() {
+        // broken .tomllm (higher rank) must NOT shadow a good .toml parse
+        let temp_dir = TempDir::new().unwrap();
+        create_test_datum_file(
+            temp_dir.path(),
+            "solo.role.toml",
+            "[b00t]\nname = \"solo\"\ntype = \"role\"\nhint = \"good toml\"\n",
+        );
+        create_test_datum_file(
+            temp_dir.path(),
+            "solo.role.tomllm",
+            "not even = toml [[[\n",
+        );
+        let (datums, diag) =
+            get_all_datums_with_diagnostics(temp_dir.path().to_str().unwrap(), Some(0)).unwrap();
+        assert_eq!(datums.len(), 1);
+        let (winner, winner_path) = &datums["solo.role"];
+        assert!(winner_path.ends_with("solo.role.toml"), "good parse wins: {winner_path}");
+        assert!(winner.status.is_none(), "winner is not degraded");
+        assert_eq!(diag.degraded.len(), 1, "broken variant still surfaced");
+    }
+
+    #[test]
+    fn scan_diagnostics_reports_shadowed_key() {
+        let temp_dir = TempDir::new().unwrap();
+        create_test_datum_file(
+            temp_dir.path(),
+            "solo.role.toml",
+            "[b00t]\nname = \"solo\"\ntype = \"role\"\nhint = \"toml variant\"\n",
+        );
+        create_test_datum_file(
+            temp_dir.path(),
+            "solo.role.tomllm",
+            "[b00t]\nname = \"solo\"\ntype = \"role\"\nhint = \"tomllm variant\"\n",
+        );
+        let (datums, diag) =
+            get_all_datums_with_diagnostics(temp_dir.path().to_str().unwrap(), Some(0)).unwrap();
+        assert_eq!(datums.len(), 1, "one key survives");
+        let (_, winner_path) = &datums["solo.role"];
+        assert!(winner_path.ends_with("solo.role.tomllm"), ".tomllm outranks .toml");
+        assert_eq!(diag.shadowed.len(), 1, "shadowing reported");
+        let (key, loser, winner) = &diag.shadowed[0];
+        assert_eq!(key, "solo.role");
+        assert!(loser.ends_with("solo.role.toml"), "loser: {loser}");
+        assert!(winner.ends_with("solo.role.tomllm"), "winner: {winner}");
     }
 
     #[test]

--- a/b00t-cli/src/lib.rs
+++ b/b00t-cli/src/lib.rs
@@ -448,6 +448,7 @@ hint = "containers"
             uninstall: None, hook_uninstall: None, unlocks: None,
             type_tags: None, maintenance: None, required_for_core: None,
             runtime: None, polyseme: None, trigger_words: None, compose: None,
+            raw_source: None,
             requires_competency: None,
         }
     }


### PR DESCRIPTION
## Summary
- The datum loader is now tolerant per Postel's Law: a file that fails strict TOML/`UnifiedConfig` parse loads as a degraded placeholder (name from filename, raw source parked in `BootDatum::raw_source`, `status="degraded"`) instead of silently vanishing. The parse failure is recorded in `ScanDiagnostics`.
- A good parse always outranks a degraded fallback regardless of `.tomllmd`/`.tomllm`/`.toml` precedence; same-rank key collisions are reported as shadowed keys.
- `validate --graph`: dangling references are classified (near-miss / aspirational / prose) and reported as `WARN` by default; `--strict` restores the old hard-fail behavior for CI/audit opt-in.
- Summary output surfaces degraded files and shadowed keys alongside per-class dangling-reference counts.

## Fixed per code review (Critical)
The first version of this PR had a real regression: a reference to a datum whose file failed strict parse (e.g. `VENDOR-*.tomllmd` files, confirmed present in this repo via `doctor_cmd.rs`'s own comment) previously produced a hard `MissingDependency`/`MissingMember` error. Because the degraded stub still inserted into the interned store under its key, `validate_references()`'s `key_set` had no filter on `status`, so the reference silently "resolved" against the stub — the error didn't downgrade to `WARN`, it vanished entirely, in both default and `--strict` mode, directly contradicting this PR's own claim that `--strict` restores old hard-fail semantics.

Fixed by excluding `status == "degraded"` entries from the `key_set` used by `validate_references()` — a reference to a degraded datum is dangling again, exactly as before this feature existed. Added `validate_references_flags_dependency_on_degraded_datum` as a regression test for this exact case.

## Test plan
- [x] `cargo test -p b00t-cli --lib datum` — 296 passed, 0 failed (295 from the original PR + 1 new regression test for the degraded-reference fix)
- [x] Full pre-push gate (`cargo test -p b00t-cli --lib`) — 1539 passed, 0 failed

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>