### PR TITLE
fix(reviewer): 4 real bugs in system-normal.rhai broke the precriteria gate

### DIFF
--- a/_b00t_/datums/SYSTEM-NORMAL.tomllmd
+++ b/_b00t_/datums/SYSTEM-NORMAL.tomllmd
@@ -39,7 +39,7 @@ rationale = "Non-empty stash = interrupted work; may contain unreleased features
 [[system_normal.checks]]
 id        = "git-no-merge-conflict"
 label     = "no active merge/rebase conflict markers"
-command   = "git status --porcelain 2>/dev/null | grep -c '^UU\\|^AA\\|^DD' || echo 0"
+command   = "git status --porcelain 2>/dev/null | grep -c '^UU\\|^AA\\|^DD'; true"
 expected  = "0"
 severity  = "error"
 message   = "unresolved merge/rebase conflicts present — resolve before continuing"
@@ -65,7 +65,7 @@ fix       = "git checkout -b task/<id>-<slug>"
 [[system_normal.checks]]
 id        = "submodules-in-sync"
 label     = "all vendor subrepos are in sync — no dirty trees, no unpushed commits"
-command   = "git submodule status 2>/dev/null | grep -c '^[+M]' || echo 0"
+command   = "git submodule status 2>/dev/null | grep -c '^[+M]'; true"
 expected  = "0"
 severity  = "warn"
 message   = "submodule(s) have unpushed commits or dirty working trees — sync before task operations"

--- a/_b00t_/skills/reviewer/system-normal.rhai
+++ b/_b00t_/skills/reviewer/system-normal.rhai
@@ -11,9 +11,11 @@
 
 fn shell(cmd) {
     try {
-        run_cmd(cmd).trim()
+        let output = run_cmd(cmd);
+        output.trim(); // Rhai's trim() mutates in place and returns (), not a value
+        return output;
     } catch(e) {
-        ""
+        return "";
     }
 }
 
@@ -41,7 +43,7 @@ let c1 = check_exact(
 );
 
 // Check 2: no merge/rebase conflict markers (error — blocks on fail)
-let c2_cmd = "git status --porcelain 2>/dev/null | grep -c '^UU\\|^AA\\|^DD' || echo 0";
+let c2_cmd = "git status --porcelain 2>/dev/null | grep -c '^UU\\|^AA\\|^DD'; true";
 let c2_output = shell(c2_cmd);
 let c2 = #{
     id: "git-no-merge-conflict",
@@ -76,7 +78,7 @@ let c4 = #{
 let c5 = check_exact(
     "submodules-in-sync",
     "all submodules in sync",
-    "git submodule status 2>/dev/null | grep -c '^[+M]' || echo 0",
+    "git submodule status 2>/dev/null | grep -c '^[+M]'; true",
     "0",
     "warn",
     "submodule(s) have unpushed commits or dirty trees — sync before task operations"
@@ -88,8 +90,8 @@ let checks = [c1, c2, c3, c4, c5];
 
 let has_error = false;
 let has_warn = false;
-let mut pass_count = 0;
-let mut fail_count = 0;
+let pass_count = 0;
+let fail_count = 0;
 
 for c in checks {
     if c.passed {


### PR DESCRIPTION
## Summary

Found while running `b00t script run _b00t_/skills/reviewer/system-normal.rhai` (the command behind `just reviewer system-normal`) for the first time against a live repo — it had never actually executed successfully.

1. **`let mut pass_count/fail_count`** — Rhai has no `mut` keyword (all `let` bindings are already mutable); this was a hard syntax error that made the script fail to parse at all.
2. **`shell()`'s `try { run_cmd(cmd).trim() } catch(e) { "" }` never returned a value** — Rhai's `try/catch` is a statement, not an expression, so a function with no explicit `return` implicitly returns `()` regardless of what happens inside. Every check was silently comparing against unit.
3. **Rhai's `.trim()` is an in-place, void-returning mutating method** (not a value-returning pure function like Rust's `str::trim()` — a genuine Rhai language gotcha, not a b00t bug). `s.trim()` mutates `s`; it does not return the trimmed string. `let x = s.trim()` silently binds `x` to `()`.
4. **`grep -c PATTERN || echo 0` double-prints `"0\n0"`** when the count is genuinely zero, because `grep -c` already prints `0` and still exits 1 on no match — so the `||` fallback fires too, producing a 2-line string. This made the merge-conflict and submodule-sync checks compare against a multi-line value and false-positive-fail even on a clean repo. Fixed in both the `.rhai` script and the canonical `SYSTEM-NORMAL.tomllmd` datum (which mirrors the same commands) by replacing `|| echo 0` with `; true`.

## Test plan
- [x] `b00t script run _b00t_/skills/reviewer/system-normal.rhai` now parses and all 5 checks execute, returning real string values instead of crashing on `Function not found: contains (())`.
- [x] Against a real repo state (on `main`, one dirty submodule pointer, 8 pre-existing unreviewed stashes), it now correctly reports `WARN` with 3 accurate warnings — previously it either crashed outright or (once the `mut`/return bugs were fixed in isolation) false-failed on "merge conflict" with zero actual conflicts present.
- [x] Full pre-push gate (`cargo test -p b00t-cli --lib`) — 1519 passed, 0 failed

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>