### PR TITLE
feat(b00t): implement `b00t is <checklist>` Phase 1 (CONOPS-system-normal.md)

### DIFF
--- a/b00t-cli/src/checklist.rs
+++ b/b00t-cli/src/checklist.rs
@@ -1,0 +1,157 @@
+//! `<name>.checklist.toml` — stateful boolean-checklist datum.
+//!
+//! Phase 1 of CONOPS-system-normal.md: reuses `GateSpec` verbatim for each
+//! check (zero new evaluation code), implicit-AND composition only (no
+//! `compose_rhai` yet), no persistence yet. Backs the `b00t is <name>` CLI.
+
+use crate::gates::GateSpec;
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+use ufo_types::Disposition;
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ChecklistCheck {
+    pub id: String,
+    #[serde(flatten)]
+    pub gate: GateSpec,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ChecklistSection {
+    pub name: String,
+    #[serde(rename = "type", default)]
+    pub kind: String,
+    pub hint: Option<String>,
+    #[serde(default, rename = "check")]
+    pub checks: Vec<ChecklistCheck>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ChecklistFile {
+    pub b00t: ChecklistSection,
+}
+
+impl ChecklistFile {
+    pub fn load(path: &Path) -> Result<Self> {
+        let content = std::fs::read_to_string(path)
+            .with_context(|| format!("reading checklist {}", path.display()))?;
+        toml::from_str(&content)
+            .with_context(|| format!("parsing checklist {}", path.display()))
+    }
+
+    pub fn evaluate(&self, base_path: &str) -> ChecklistResult {
+        let outcomes: Vec<CheckOutcome> = self
+            .b00t
+            .checks
+            .iter()
+            .map(|c| CheckOutcome::from_disposition(&c.id, c.gate.eval_disposition(base_path)))
+            .collect();
+
+        let failing: Vec<String> = outcomes
+            .iter()
+            .filter(|o| o.status == "violated")
+            .map(|o| {
+                o.reason
+                    .clone()
+                    .map(|r| format!("{}: {}", o.id, r))
+                    .unwrap_or_else(|| o.id.clone())
+            })
+            .collect();
+
+        let disposition = if !failing.is_empty() {
+            ChecklistDisposition::Violated { failing }
+        } else {
+            let undetermined: Vec<String> = outcomes
+                .iter()
+                .filter(|o| o.status == "unknown")
+                .map(|o| o.id.clone())
+                .collect();
+            if !undetermined.is_empty() {
+                ChecklistDisposition::Unknown { undetermined }
+            } else {
+                ChecklistDisposition::Satisfied
+            }
+        };
+
+        ChecklistResult {
+            name: self.b00t.name.clone(),
+            outcomes,
+            disposition,
+        }
+    }
+}
+
+/// Per-check evaluation outcome. Status is a plain string tag rather than
+/// re-exposing `ufo_types::Disposition` directly so this stays serializable
+/// without depending on Disposition's own (de)serialize impl.
+#[derive(Debug, Clone, Serialize)]
+pub struct CheckOutcome {
+    pub id: String,
+    /// "satisfied" | "violated" | "unknown"
+    pub status: &'static str,
+    pub reason: Option<String>,
+}
+
+impl CheckOutcome {
+    fn from_disposition(id: &str, disposition: Disposition) -> Self {
+        let (status, reason) = match disposition {
+            Disposition::Satisfied => ("satisfied", None),
+            Disposition::Violated { reason } => ("violated", Some(reason)),
+            Disposition::Unknown => ("unknown", None),
+        };
+        CheckOutcome {
+            id: id.to_string(),
+            status,
+            reason,
+        }
+    }
+}
+
+/// Aggregate disposition — deliberately 3-valued (not a bare bool). See
+/// CONOPS-system-normal.md: collapsing a check that couldn't be determined
+/// into "false" was exactly issue #927's bug one layer down in `gates.rs`;
+/// this must not reintroduce it at the checklist aggregate.
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "status", rename_all = "lowercase")]
+pub enum ChecklistDisposition {
+    Satisfied,
+    Violated { failing: Vec<String> },
+    Unknown { undetermined: Vec<String> },
+}
+
+impl ChecklistDisposition {
+    /// 0 = Satisfied, 1 = Violated, 2 = Unknown — lets `if b00t is x; then`
+    /// distinguish "definitely broken" from "couldn't tell".
+    pub fn exit_code(&self) -> i32 {
+        match self {
+            ChecklistDisposition::Satisfied => 0,
+            ChecklistDisposition::Violated { .. } => 1,
+            ChecklistDisposition::Unknown { .. } => 2,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ChecklistResult {
+    pub name: String,
+    pub outcomes: Vec<CheckOutcome>,
+    pub disposition: ChecklistDisposition,
+}
+
+/// List `*.checklist.toml` files present directly under `dir` (no recursion).
+pub fn list_checklists(dir: &Path) -> Vec<String> {
+    let mut found = Vec::new();
+    if let Ok(entries) = std::fs::read_dir(dir) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if let Some(fname) = path.file_name().and_then(|f| f.to_str()) {
+                if let Some(stripped) = fname.strip_suffix(".checklist.toml") {
+                    found.push(stripped.to_string());
+                }
+            }
+        }
+    }
+    found.sort();
+    found
+}

--- a/b00t-cli/src/commands/datum.rs
+++ b/b00t-cli/src/commands/datum.rs
@@ -2144,6 +2144,7 @@ mod tests {
             env: None,
             rhai: None,
             knowledge_backend: None,
+            justfile: None,
             hint: Some("install definitely-not-a-real-command-xyz first".to_string()),
         }]);
 
@@ -2183,6 +2184,7 @@ mod tests {
             env: None,
             rhai: None,
             knowledge_backend: None,
+            justfile: None,
             hint: None,
         }]);
 

--- a/b00t-cli/src/commands/install.rs
+++ b/b00t-cli/src/commands/install.rs
@@ -889,6 +889,7 @@ hint = "Test stack"
             env: None,
             rhai: None,
             knowledge_backend: None,
+            justfile: None,
             hint: Some("test command gate".to_string()),
         }];
         let results = evaluate_gates(&gates, "/tmp");
@@ -909,6 +910,7 @@ hint = "Test stack"
             env: None,
             rhai: None,
             knowledge_backend: None,
+            justfile: None,
             hint: Some("test file gate".to_string()),
         }];
         let results = evaluate_gates(&gates, "/tmp");
@@ -924,6 +926,7 @@ hint = "Test stack"
             env: Some("THIS_ENV_VAR_DOES_NOT_EXIST_12345".to_string()),
             rhai: None,
             knowledge_backend: None,
+            justfile: None,
             hint: Some("test env gate".to_string()),
         }];
         let results = evaluate_gates(&gates, "/tmp");
@@ -939,6 +942,7 @@ hint = "Test stack"
             env: None,
             rhai: None,
             knowledge_backend: Some(b00t_c0re_lib::compiled_knowledge_backend().to_string()),
+            justfile: None,
             hint: Some("knowledge backend gate".to_string()),
         }];
         let results = evaluate_gates(&gates, "/tmp");
@@ -960,6 +964,7 @@ hint = "Test stack"
             env: None,
             rhai: None,
             knowledge_backend: Some(mismatched.to_string()),
+            justfile: None,
             hint: Some("knowledge backend gate".to_string()),
         }];
         let results = evaluate_gates(&gates, "/tmp");
@@ -982,6 +987,7 @@ hint = "Test stack"
                 env: None,
                 rhai: None,
                 knowledge_backend: None,
+            justfile: None,
                 hint: Some("file gate".to_string()),
             },
             GateSpec {
@@ -990,6 +996,7 @@ hint = "Test stack"
                 env: Some("PATH".to_string()),
                 rhai: None,
                 knowledge_backend: None,
+            justfile: None,
                 hint: Some("env gate".to_string()),
             },
         ];

--- a/b00t-cli/src/commands/is_cmd.rs
+++ b/b00t-cli/src/commands/is_cmd.rs
@@ -1,0 +1,86 @@
+//! `b00t is <name>` — stateful system-normal checklist gate.
+//! Phase 1 of CONOPS-system-normal.md: no persistence, implicit-AND only.
+
+use crate::checklist::{ChecklistDisposition, ChecklistFile, list_checklists};
+use anyhow::{Result, bail};
+
+pub fn execute(path: &str, name: Option<&str>, as_json: bool, explain: bool) -> Result<()> {
+    let base = shellexpand::tilde(path).to_string();
+    let base_dir = std::path::Path::new(&base);
+
+    let Some(name) = name else {
+        let found = list_checklists(base_dir);
+        if as_json {
+            println!("{}", serde_json::to_string_pretty(&found)?);
+        } else if found.is_empty() {
+            println!("No checklists found in {}", base_dir.display());
+        } else {
+            println!("Available checklists in {}:", base_dir.display());
+            for f in &found {
+                println!("  {f}");
+            }
+        }
+        return Ok(());
+    };
+
+    let file_path = base_dir.join(format!("{name}.checklist.toml"));
+    if !file_path.exists() {
+        bail!(
+            "checklist not found: {} (looked for {})",
+            name,
+            file_path.display()
+        );
+    }
+
+    let checklist = ChecklistFile::load(&file_path)?;
+    let result = checklist.evaluate(&base);
+    let exit_code = result.disposition.exit_code();
+
+    if as_json {
+        println!("{}", serde_json::to_string_pretty(&result)?);
+    } else {
+        for outcome in &result.outcomes {
+            let icon = match outcome.status {
+                "satisfied" => "✅",
+                "violated" => "❌",
+                _ => "❓",
+            };
+            println!("  {icon} {}", outcome.id);
+            if explain {
+                if let Some(reason) = &outcome.reason {
+                    println!("      ↳ {reason}");
+                }
+            }
+        }
+        match &result.disposition {
+            ChecklistDisposition::Satisfied => {
+                println!("✅ {}: system normal", result.name);
+            }
+            ChecklistDisposition::Violated { failing } => {
+                println!("❌ {}: {} check(s) failed", result.name, failing.len());
+                if explain {
+                    for f in failing {
+                        println!("   - {f}");
+                    }
+                }
+            }
+            ChecklistDisposition::Unknown { undetermined } => {
+                println!(
+                    "❓ {}: {} check(s) undetermined",
+                    result.name,
+                    undetermined.len()
+                );
+                if explain {
+                    for u in undetermined {
+                        println!("   - {u}");
+                    }
+                }
+            }
+        }
+    }
+
+    if exit_code != 0 {
+        std::process::exit(exit_code);
+    }
+    Ok(())
+}

--- a/b00t-cli/src/commands/mod.rs
+++ b/b00t-cli/src/commands/mod.rs
@@ -32,6 +32,7 @@ pub mod guard_manager;
 pub mod hive;
 pub mod init;
 pub mod install;
+pub mod is_cmd;
 pub mod job;
 pub mod justfile;
 pub mod k8s;

--- a/b00t-cli/src/datum_justfile.rs
+++ b/b00t-cli/src/datum_justfile.rs
@@ -302,7 +302,14 @@ impl CliExecutor for JustfileDatum {
                         .iter()
                         .map(|p| ParameterSignature {
                             name: p.name.clone(),
-                            default_value: p.default.clone(),
+                            // A literal default renders as its plain string;
+                            // a non-literal default (e.g. `image=SOME_VAR`)
+                            // comes back as a nested AST Value, not a bare
+                            // string — fall back to its JSON text rather
+                            // than losing the value.
+                            default_value: p.default.as_ref().map(|v| {
+                                v.as_str().map(str::to_string).unwrap_or_else(|| v.to_string())
+                            }),
                             required: p.default.is_none() && p.kind == "singular",
                             kind: p.kind.clone(),
                         })

--- a/b00t-cli/src/dispatch.rs
+++ b/b00t-cli/src/dispatch.rs
@@ -426,6 +426,7 @@ fn create_mcp_datum_from_json(
                             env: env.map(|s| s.to_string()),
                             rhai: rhai.map(|s| s.to_string()),
                             knowledge_backend: knowledge_backend.map(|s| s.to_string()),
+                            justfile: None,
                             hint,
                         })
                     })

--- a/b00t-cli/src/gates.rs
+++ b/b00t-cli/src/gates.rs
@@ -17,6 +17,9 @@ pub struct GateSpec {
     pub rhai: Option<String>,
     /// Knowledge backend that must match the compiled b00t-c0re-lib backend
     pub knowledge_backend: Option<String>,
+    /// Justfile path (supports ~) that must parse cleanly (`just --list`
+    /// via `JustfileAst::validate()` — reused as-is, no new validation logic)
+    pub justfile: Option<String>,
     /// Freeform description shown when gate fails
     pub hint: Option<String>,
 }
@@ -232,6 +235,58 @@ impl GateSpec {
                     backend,
                     b00t_c0re_lib::compiled_knowledge_backend()
                 )));
+            }
+        }
+
+        // Justfile gate: reuses JustfileAst::validate() (runs `just --list`
+        // against the file) rather than reimplementing parse-checking here.
+        if let Some(ref justfile_path) = self.justfile {
+            let expanded = expand_tilde_path(justfile_path);
+            let candidate = if expanded.is_absolute() {
+                expanded.clone()
+            } else {
+                let base = {
+                    let p = std::path::Path::new(path);
+                    if p.is_dir() {
+                        p.to_path_buf()
+                    } else {
+                        p.parent()
+                            .map(|q| q.to_path_buf())
+                            .unwrap_or_else(|| std::path::PathBuf::from("."))
+                    }
+                };
+                base.join(&expanded)
+            };
+            // Mirror the `file` gate's dual resolution: try datum-dir-relative
+            // first, fall back to cwd-relative (a checklist commonly points at
+            // the repo-root justfile, not one inside the datum dir itself).
+            let resolved = if candidate.exists() {
+                candidate
+            } else if expanded.exists() {
+                expanded.clone()
+            } else {
+                candidate
+            };
+            // Absolutize: JustfileAst::load's run_dump sets current_dir to the
+            // resolved path's parent *and* re-passes that same relative path to
+            // `just --justfile`, so a relative path with a parent component gets
+            // joined twice (e.g. "_b00t_/justfile" -> ".../_b00t_/_b00t_/justfile").
+            let resolved = std::fs::canonicalize(&resolved).unwrap_or(resolved);
+            match crate::just_ast::JustfileAst::load(&resolved) {
+                Ok(ast) => {
+                    let errors = ast.validate();
+                    if !errors.is_empty() {
+                        outcomes.push(FieldOutcome::Violated(format!(
+                            "justfile '{}' failed validation: {}",
+                            justfile_path,
+                            errors.join("; ")
+                        )));
+                    }
+                }
+                Err(e) => outcomes.push(FieldOutcome::Violated(format!(
+                    "justfile '{}' could not be loaded: {}",
+                    justfile_path, e
+                ))),
             }
         }
 

--- a/b00t-cli/src/just_ast.rs
+++ b/b00t-cli/src/just_ast.rs
@@ -63,7 +63,12 @@ pub struct JustRecipe {
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
 pub struct JustParameter {
     pub name: String,
-    pub default: Option<String>,
+    /// A literal default is a plain JSON string, but just's dump format
+    /// represents a non-literal default (e.g. `image=SAM1_IMAGE`, referencing
+    /// another variable) as a nested AST array like `["variable", "NAME"]` —
+    /// same tagged-array shape `JustRecipe::body` and `JustAssignment::value`
+    /// already use. `Option<String>` rejects that shape outright.
+    pub default: Option<serde_json::Value>,
     #[serde(default)]
     pub export: bool,
     /// "singular" | "plus" (one-or-more) | "star" (zero-or-more)

--- a/b00t-cli/src/lib.rs
+++ b/b00t-cli/src/lib.rs
@@ -149,6 +149,7 @@ pub mod config_types;
 pub mod compose;
 pub mod polyseme;
 pub mod gates;
+pub mod checklist;
 pub mod hooks;
 pub mod dispatch;
 pub mod lifecycle;

--- a/b00t-cli/src/main.rs
+++ b/b00t-cli/src/main.rs
@@ -438,10 +438,22 @@ The system will:
         #[clap(subcommand)]
         skill_command: SkillCommands,
     },
-    #[clap(about = "Query system information", aliases = ["inspect", "is"])]
+    #[clap(about = "Query system information", aliases = ["inspect"])]
     Whatismy {
         #[clap(subcommand)]
         whatismy_command: WhatismyCommands,
+    },
+    #[clap(
+        about = "Stateful system-normal checklist gate — one boolean answer from named checks",
+        long_about = "Evaluate a <name>.checklist.toml under --path and print pass/fail per check\nplus one aggregate disposition (Satisfied/Violated/Unknown — 3-valued, not\na bare bool: see CONOPS-system-normal.md). Exit code 0/1/2 respectively.\n\nExamples:\n  b00t is                       → list available checklists\n  b00t is system-normal         → run the system-normal checklist\n  b00t is system-normal --json  → full per-check disposition as JSON\n  b00t is system-normal --explain → show failure/undetermined reasons"
+    )]
+    Is {
+        #[clap(help = "Checklist name (without .checklist.toml). Omit to list available checklists.")]
+        name: Option<String>,
+        #[clap(long, help = "Output full per-check disposition as JSON")]
+        json: bool,
+        #[clap(long, help = "Show reasons for failing/undetermined checks")]
+        explain: bool,
     },
     #[clap(about = "Show status dashboard of all available tools and services")]
     // 🤓 ENTANGLED: b00t-mcp/src/mcp_tools.rs StatusCommand
@@ -2507,6 +2519,14 @@ async fn main() {
         Some(Commands::Whatismy { whatismy_command }) => {
             if let Err(e) = whatismy_command.execute(&cli.path) {
                 eprintln!("Error: {}", e);
+                std::process::exit(1);
+            }
+        }
+        Some(Commands::Is { name, json, explain }) => {
+            if let Err(e) =
+                b00t_cli::commands::is_cmd::execute(&cli.path, name.as_deref(), *json, *explain)
+            {
+                eprintln!("Error: {e}");
                 std::process::exit(1);
             }
         }


### PR DESCRIPTION
## What

Ships Phase 1 of the previously-drafted, unbuilt CONOPS (`CONOPS-system-normal.md`): a real top-level `b00t is <name>` verb backed by `<name>.checklist.toml` datums, reusing `GateSpec` verbatim (implicit-AND only, no `compose_rhai` yet, no persistence yet).

`is` was a bare clap alias for `whatismy`; the alias is now `inspect` only, freeing `is` for this.

- `checklist.rs`: `ChecklistFile`/`ChecklistCheck` (flattens `GateSpec`) + 3-valued `ChecklistDisposition` (Satisfied/Violated/Unknown, exit codes 0/1/2) — deliberately not collapsed to bool, per issue #927's precedent (a Rhai eval *error* must not silently read as `false`).
- `commands/is_cmd.rs`: `b00t is [name] [--json] [--explain]`.
- `gates.rs`: new `GateSpec.justfile` field, reusing `JustfileAst::validate()` (runs `just --list`) rather than reimplementing parse-checking.

## Two real bugs found wiring this up against a real justfile (app4dog's)

- `just_ast.rs` `run_dump()`: passed a relative `--justfile` path to `just` while also setting `current_dir` to that path's parent, double-joining any relative path with a parent component (`_b00t_/justfile` → `.../_b00t_/_b00t_/justfile`). Fixed by absolutizing before load; also added dual datum-dir/cwd-relative resolution matching the `file` gate's existing fallback behavior.
- `just_ast.rs` `JustParameter.default` was `Option<String>`, but `just`'s own `--dump --dump-format json` represents a non-literal parameter default (e.g. `image=SOME_VAR`, referencing another variable) as a nested AST array like `["variable","SOME_VAR"]`, not a plain string — rejected outright by deserialization on any justfile with a non-literal default. Widened to `Option<serde_json::Value>`; the one call site (`datum_justfile.rs`'s `ParameterSignature`) only needs display text, so it now falls back to the value's JSON text for non-literal defaults instead of losing the value.

## Test plan

- [x] `cargo test --lib gates::` — 16/16 pass
- [x] `cargo test --lib install::` — 71/71 pass (test-only `GateSpec` literals needed the new field)
- [x] `cargo test --lib just_ast::` — 3/3 pass
- [x] End-to-end against app4dog: `b00t --path _b00t_ is system-normal --explain` exits 0, all 9 checks pass (companion app4dog PR: app4dog/workspace#144)
- [x] Full pre-push suite: 1519 + 62 passed (one `b00t-mcp::server_llm` test flaked on the first attempt, reproduced clean in isolation twice and clean on retry — pre-existing flake unrelated to this change, not touched)