### PR TITLE
feat(forge-kv): b00t-native RESP2 server — real drop-in for RedisComms

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1791,6 +1791,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "b00t-forge-kv"
+version = "0.10.5"
+dependencies = [
+ "anyhow",
+ "clap",
+ "futures",
+ "redis",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "b00t-grok"
 version = "0.10.5"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ members = [
     # Cargo's "package believes it's in a workspace" error. Restoring
     # membership; it's a leaf wasm-bindgen crate (no path deps), safe to add.
     "b00t-c0re-npm",
+    "b00t-forge-kv",
 ]
 exclude = ["vendor/embed-anything-b00t",
     "vendor/rust-docs-mcp-b00t",

--- a/b00t-forge-kv/Cargo.toml
+++ b/b00t-forge-kv/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "b00t-forge-kv"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "b00t-native RESP2 key-value server — a Redis-protocol-compatible drop-in for the internal KvBackend::ForgeKV detection path, so hive nodes don't need to install/maintain actual Redis or Valkey"
+
+[lib]
+name = "b00t_forge_kv"
+path = "src/lib.rs"
+
+[[bin]]
+name = "b00t-forge-kv"
+path = "src/main.rs"
+
+[dependencies]
+tokio = { version = "1.0", features = ["full"] }
+thiserror = "2.0.17"
+tracing = "0.1"
+tracing-subscriber = "0.3"
+clap = { version = "4", features = ["derive"] }
+anyhow = "1.0"
+
+[dev-dependencies]
+redis = { version = "0.32.4", features = ["aio", "tokio-comp", "connection-manager"] }
+futures = "0.3"

--- a/b00t-forge-kv/src/commands.rs
+++ b/b00t-forge-kv/src/commands.rs
@@ -1,0 +1,288 @@
+//! Command dispatch — the exact ~16-command subset `RedisComms`
+//! (b00t-c0re-lib/src/redis.rs) actually issues, not a full Redis clone.
+//! Deliberately scoped this way: every command implemented here has a real
+//! caller in the b00t codebase, so there's nothing untested/unused to trust.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use crate::resp::RespValue;
+use crate::store::Store;
+
+fn err(msg: impl Into<String>) -> RespValue {
+    RespValue::Error(msg.into())
+}
+
+fn wrong_args(cmd: &str) -> RespValue {
+    err(format!("ERR wrong number of arguments for '{cmd}' command"))
+}
+
+fn as_str(bytes: &[u8]) -> Result<&str, RespValue> {
+    std::str::from_utf8(bytes).map_err(|_| err("ERR invalid UTF-8 in argument"))
+}
+
+/// Non-PUBSUB commands, dispatched per-request. SUBSCRIBE is handled
+/// separately by the connection loop since it changes the connection's
+/// mode (blocks on incoming published messages rather than request/reply).
+pub async fn dispatch(store: &Arc<Store>, args: &[Vec<u8>]) -> RespValue {
+    if args.is_empty() {
+        return err("ERR empty command");
+    }
+    let Ok(cmd_str) = as_str(&args[0]) else {
+        return err("ERR invalid UTF-8 in command name");
+    };
+    let cmd = cmd_str.to_ascii_uppercase();
+    let rest = &args[1..];
+
+    match cmd.as_str() {
+        "PING" => match rest {
+            [] => RespValue::SimpleString("PONG".to_string()),
+            [msg] => match as_str(msg) {
+                Ok(s) => RespValue::bulk(s),
+                Err(e) => e,
+            },
+            _ => wrong_args("PING"),
+        },
+
+        "SET" => {
+            if rest.len() < 2 {
+                return wrong_args("SET");
+            }
+            let Ok(key) = as_str(&rest[0]) else {
+                return err("ERR invalid UTF-8 in key");
+            };
+            store.set(key, rest[1].clone(), None).await;
+            RespValue::ok()
+        }
+
+        "SETEX" => {
+            if rest.len() != 3 {
+                return wrong_args("SETEX");
+            }
+            let (Ok(key), Ok(seconds_str)) = (as_str(&rest[0]), as_str(&rest[1])) else {
+                return err("ERR invalid UTF-8 in argument");
+            };
+            let Ok(seconds) = seconds_str.parse::<u64>() else {
+                return err("ERR value is not an integer or out of range");
+            };
+            store
+                .set(key, rest[2].clone(), Some(Duration::from_secs(seconds)))
+                .await;
+            RespValue::ok()
+        }
+
+        "GET" => {
+            if rest.len() != 1 {
+                return wrong_args("GET");
+            }
+            let Ok(key) = as_str(&rest[0]) else {
+                return err("ERR invalid UTF-8 in key");
+            };
+            match store.get(key).await {
+                Some(v) => RespValue::BulkString(Some(v)),
+                None => RespValue::nil(),
+            }
+        }
+
+        "DEL" => {
+            if rest.is_empty() {
+                return wrong_args("DEL");
+            }
+            match rest.iter().map(|k| as_str(k).map(str::to_string)).collect::<Result<Vec<_>, _>>() {
+                Ok(keys) => RespValue::Integer(store.del(&keys).await),
+                Err(e) => e,
+            }
+        }
+
+        "EXISTS" => {
+            if rest.is_empty() {
+                return wrong_args("EXISTS");
+            }
+            match rest.iter().map(|k| as_str(k).map(str::to_string)).collect::<Result<Vec<_>, _>>() {
+                Ok(keys) => RespValue::Integer(store.exists(&keys).await),
+                Err(e) => e,
+            }
+        }
+
+        "EXPIRE" => {
+            if rest.len() != 2 {
+                return wrong_args("EXPIRE");
+            }
+            let (Ok(key), Ok(seconds_str)) = (as_str(&rest[0]), as_str(&rest[1])) else {
+                return err("ERR invalid UTF-8 in argument");
+            };
+            let Ok(seconds) = seconds_str.parse::<i64>() else {
+                return err("ERR value is not an integer or out of range");
+            };
+            if seconds < 0 {
+                return RespValue::Integer(store.del(&[key.to_string()]).await.min(1));
+            }
+            let ok = store.expire(key, Duration::from_secs(seconds as u64)).await;
+            RespValue::Integer(if ok { 1 } else { 0 })
+        }
+
+        "INCR" => incrby(store, rest, 1).await,
+        "DECR" => incrby(store, rest, -1).await,
+        "INCRBY" => incrby_with_arg(store, rest, 1).await,
+        "DECRBY" => incrby_with_arg(store, rest, -1).await,
+
+        "HSET" => {
+            if rest.len() != 3 {
+                return wrong_args("HSET");
+            }
+            let (Ok(key), Ok(field), Ok(value)) =
+                (as_str(&rest[0]), as_str(&rest[1]), as_str(&rest[2]))
+            else {
+                return err("ERR invalid UTF-8 in argument");
+            };
+            let is_new = store.hset(key, field, value).await;
+            RespValue::Integer(if is_new { 1 } else { 0 })
+        }
+
+        "HGET" => {
+            if rest.len() != 2 {
+                return wrong_args("HGET");
+            }
+            let (Ok(key), Ok(field)) = (as_str(&rest[0]), as_str(&rest[1])) else {
+                return err("ERR invalid UTF-8 in argument");
+            };
+            match store.hget(key, field).await {
+                Some(v) => RespValue::bulk(v),
+                None => RespValue::nil(),
+            }
+        }
+
+        "HGETALL" => {
+            if rest.len() != 1 {
+                return wrong_args("HGETALL");
+            }
+            let Ok(key) = as_str(&rest[0]) else {
+                return err("ERR invalid UTF-8 in key");
+            };
+            let pairs = store.hgetall(key).await;
+            let mut items = Vec::with_capacity(pairs.len() * 2);
+            for (f, v) in pairs {
+                items.push(RespValue::bulk(f));
+                items.push(RespValue::bulk(v));
+            }
+            RespValue::Array(Some(items))
+        }
+
+        "PUBLISH" => {
+            if rest.len() != 2 {
+                return wrong_args("PUBLISH");
+            }
+            let Ok(channel) = as_str(&rest[0]) else {
+                return err("ERR invalid UTF-8 in channel");
+            };
+            let n = store.publish(channel, rest[1].clone()).await;
+            RespValue::Integer(n)
+        }
+
+        "INFO" => RespValue::bulk("# Server\r\nb00t_forge_kv_version:0.1\r\nredis_version:7.0.0-forgekv-compat\r\n"),
+
+        "SUBSCRIBE" => err("ERR SUBSCRIBE must be the connection's first command in a dedicated pub/sub connection (matches real Redis client usage via a separate PubSub connection)"),
+
+        "COMMAND" | "HELLO" | "CLIENT" => RespValue::Array(Some(vec![])),
+
+        other => err(format!("ERR unknown command '{other}', ForgeKV implements the RedisComms subset only")),
+    }
+}
+
+async fn incrby(store: &Arc<Store>, rest: &[Vec<u8>], delta: i64) -> RespValue {
+    if rest.len() != 1 {
+        return wrong_args("INCR/DECR");
+    }
+    let Ok(key) = as_str(&rest[0]) else {
+        return err("ERR invalid UTF-8 in key");
+    };
+    match store.incrby(key, delta).await {
+        Ok(v) => RespValue::Integer(v),
+        Err(e) => err(format!("ERR {e}")),
+    }
+}
+
+/// INCRBY/DECRBY: `sign` flips the direction for DECRBY (Redis's DECRBY
+/// subtracts its argument; sharing incrby's math keeps that one code path).
+async fn incrby_with_arg(store: &Arc<Store>, rest: &[Vec<u8>], sign: i64) -> RespValue {
+    if rest.len() != 2 {
+        return wrong_args("INCRBY/DECRBY");
+    }
+    let Ok(amount_str) = as_str(&rest[1]) else {
+        return err("ERR invalid UTF-8 in argument");
+    };
+    let Ok(amount) = amount_str.parse::<i64>() else {
+        return err("ERR value is not an integer or out of range");
+    };
+    incrby(store, &rest[..1], sign * amount).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    async fn run(store: &Arc<Store>, args: &[&str]) -> RespValue {
+        let args: Vec<Vec<u8>> = args.iter().map(|s| s.as_bytes().to_vec()).collect();
+        dispatch(store, &args).await
+    }
+
+    #[tokio::test]
+    async fn ping_pong() {
+        let store = Arc::new(Store::new());
+        assert_eq!(run(&store, &["PING"]).await, RespValue::SimpleString("PONG".into()));
+    }
+
+    #[tokio::test]
+    async fn set_then_get() {
+        let store = Arc::new(Store::new());
+        assert_eq!(run(&store, &["SET", "k", "v"]).await, RespValue::ok());
+        assert_eq!(run(&store, &["GET", "k"]).await, RespValue::bulk("v"));
+    }
+
+    #[tokio::test]
+    async fn get_missing_key_is_nil() {
+        let store = Arc::new(Store::new());
+        assert_eq!(run(&store, &["GET", "missing"]).await, RespValue::nil());
+    }
+
+    #[tokio::test]
+    async fn hset_hget_hgetall() {
+        let store = Arc::new(Store::new());
+        assert_eq!(run(&store, &["HSET", "h", "f", "v"]).await, RespValue::Integer(1));
+        assert_eq!(run(&store, &["HGET", "h", "f"]).await, RespValue::bulk("v"));
+        assert_eq!(
+            run(&store, &["HGETALL", "h"]).await,
+            RespValue::Array(Some(vec![RespValue::bulk("f"), RespValue::bulk("v")]))
+        );
+    }
+
+    #[tokio::test]
+    async fn publish_with_no_subscribers_returns_zero() {
+        let store = Arc::new(Store::new());
+        assert_eq!(run(&store, &["PUBLISH", "ch", "hi"]).await, RespValue::Integer(0));
+    }
+
+    #[tokio::test]
+    async fn incr_and_decr() {
+        let store = Arc::new(Store::new());
+        assert_eq!(run(&store, &["INCR", "c"]).await, RespValue::Integer(1));
+        assert_eq!(run(&store, &["INCRBY", "c", "5"]).await, RespValue::Integer(6));
+        assert_eq!(run(&store, &["DECR", "c"]).await, RespValue::Integer(5));
+        assert_eq!(run(&store, &["DECRBY", "c", "2"]).await, RespValue::Integer(3));
+    }
+
+    #[tokio::test]
+    async fn unknown_command_is_a_clean_error_not_a_panic() {
+        let store = Arc::new(Store::new());
+        assert_eq!(
+            run(&store, &["BITCOUNT", "k"]).await,
+            err("ERR unknown command 'BITCOUNT', ForgeKV implements the RedisComms subset only")
+        );
+    }
+
+    #[tokio::test]
+    async fn wrong_arity_is_a_clean_error() {
+        let store = Arc::new(Store::new());
+        assert_eq!(run(&store, &["SET", "onlykey"]).await, wrong_args("SET"));
+    }
+}

--- a/b00t-forge-kv/src/lib.rs
+++ b/b00t-forge-kv/src/lib.rs
@@ -1,0 +1,34 @@
+//! Library surface for b00t-forge-kv, so integration tests (and any future
+//! embedder — e.g. running ForgeKV in-process rather than as a subprocess)
+//! can drive the server without shelling out to the binary.
+
+pub mod commands;
+pub mod resp;
+pub mod server;
+pub mod store;
+
+use std::sync::Arc;
+
+use tokio::net::TcpListener;
+
+use store::Store;
+
+/// Runs the accept loop against an already-bound listener. Exists
+/// separately from `main()` so tests can bind an ephemeral port
+/// (`127.0.0.1:0`) and drive the real server in-process.
+pub async fn serve(listener: TcpListener, store: Arc<Store>) {
+    loop {
+        let (socket, peer) = match listener.accept().await {
+            Ok(pair) => pair,
+            Err(e) => {
+                tracing::warn!(error = %e, "accept() failed, continuing");
+                continue;
+            }
+        };
+        tracing::debug!(%peer, "connection accepted");
+        let store = Arc::clone(&store);
+        tokio::spawn(async move {
+            server::handle_connection(socket, store).await;
+        });
+    }
+}

--- a/b00t-forge-kv/src/main.rs
+++ b/b00t-forge-kv/src/main.rs
@@ -1,0 +1,48 @@
+//! b00t-forge-kv — a RESP2-speaking key-value server that's a real drop-in
+//! for `b00t-c0re-lib::redis::RedisComms` (the `redis` crate client used by
+//! agent coordination). Gives `KvBackend::ForgeKV` (b00t-c0re-lib/src/kv_store.rs)
+//! an actual server to detect, instead of just being a fallback label.
+//!
+//! Deployment model matches the existing NATS-on-Vultr pattern
+//! (nats/vultr-node-setup.sh): bind 127.0.0.1 only, reach it over an SSH
+//! tunnel — never expose the KV port publicly. Nothing outside this
+//! process talks RESP2 to the outside world; agents never connect to it
+//! directly (they go through NATS; the historian is the one thing that
+//! may use this store).
+
+use std::sync::Arc;
+
+use clap::Parser;
+use tokio::net::TcpListener;
+
+use b00t_forge_kv::{serve, store::Store};
+
+#[derive(Parser)]
+#[command(name = "b00t-forge-kv", about = "RESP2-compatible KV server — b00t-native Redis/Valkey replacement for hive nodes")]
+struct Args {
+    /// Bind address. Per the vultr-node-setup.sh convention, this should
+    /// stay 127.0.0.1 on any internet-facing host — reach it via an SSH
+    /// tunnel, never expose it publicly.
+    #[arg(long, default_value = "127.0.0.1")]
+    host: String,
+
+    #[arg(long, default_value_t = 6379)]
+    port: u16,
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt::init();
+
+    let args = Args::parse();
+    let addr = format!("{}:{}", args.host, args.port);
+    let listener = TcpListener::bind(&addr).await.map_err(|e| {
+        anyhow::anyhow!(
+            "b00t-forge-kv: failed to bind {addr}: {e} — is another process (redis-server, valkey-server, or a previous b00t-forge-kv) already listening on this port?"
+        )
+    })?;
+    tracing::info!(%addr, "b00t-forge-kv listening (RESP2)");
+
+    serve(listener, Arc::new(Store::new())).await;
+    Ok(())
+}

--- a/b00t-forge-kv/src/resp.rs
+++ b/b00t-forge-kv/src/resp.rs
@@ -1,0 +1,190 @@
+//! Minimal RESP2 wire protocol — just enough to be a drop-in for the
+//! `redis` crate's client (aio + tokio-comp + connection-manager features).
+//! Hand-rolled rather than pulling in a RESP crate: the protocol is small,
+//! and a b00t-native component running on internet-facing hive nodes
+//! benefits from an auditable, dependency-light implementation.
+//!
+//! Reference: https://redis.io/docs/latest/develop/reference/protocol-spec/
+
+use std::io;
+use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum RespValue {
+    SimpleString(String),
+    Error(String),
+    Integer(i64),
+    BulkString(Option<Vec<u8>>),
+    Array(Option<Vec<RespValue>>),
+}
+
+impl RespValue {
+    pub fn ok() -> Self {
+        RespValue::SimpleString("OK".to_string())
+    }
+
+    pub fn nil() -> Self {
+        RespValue::BulkString(None)
+    }
+
+    pub fn bulk(s: impl Into<Vec<u8>>) -> Self {
+        RespValue::BulkString(Some(s.into()))
+    }
+
+    pub fn encode(&self, out: &mut Vec<u8>) {
+        match self {
+            RespValue::SimpleString(s) => {
+                out.push(b'+');
+                out.extend_from_slice(s.as_bytes());
+                out.extend_from_slice(b"\r\n");
+            }
+            RespValue::Error(e) => {
+                out.push(b'-');
+                out.extend_from_slice(e.as_bytes());
+                out.extend_from_slice(b"\r\n");
+            }
+            RespValue::Integer(i) => {
+                out.push(b':');
+                out.extend_from_slice(i.to_string().as_bytes());
+                out.extend_from_slice(b"\r\n");
+            }
+            RespValue::BulkString(None) => {
+                out.extend_from_slice(b"$-1\r\n");
+            }
+            RespValue::BulkString(Some(b)) => {
+                out.push(b'$');
+                out.extend_from_slice(b.len().to_string().as_bytes());
+                out.extend_from_slice(b"\r\n");
+                out.extend_from_slice(b);
+                out.extend_from_slice(b"\r\n");
+            }
+            RespValue::Array(None) => {
+                out.extend_from_slice(b"*-1\r\n");
+            }
+            RespValue::Array(Some(items)) => {
+                out.push(b'*');
+                out.extend_from_slice(items.len().to_string().as_bytes());
+                out.extend_from_slice(b"\r\n");
+                for item in items {
+                    item.encode(out);
+                }
+            }
+        }
+    }
+}
+
+/// Read one client request off the wire. Real clients (including the
+/// `redis` crate) always send requests as a multibulk array of bulk
+/// strings (`*<n>\r\n$<len>\r\n<bytes>\r\n...`) — the legacy "inline
+/// command" format (plain text line, no `*`/`$` framing) is not supported,
+/// matching what every RESP2 client library actually emits.
+pub async fn read_command<R: AsyncBufReadExt + Unpin>(
+    reader: &mut R,
+) -> io::Result<Option<Vec<Vec<u8>>>> {
+    let mut line = String::new();
+    let n = reader.read_line(&mut line).await?;
+    if n == 0 {
+        return Ok(None); // clean EOF
+    }
+    let line = line.trim_end_matches(['\r', '\n']);
+    let Some(count_str) = line.strip_prefix('*') else {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("expected multibulk array ('*'), got: {line:?}"),
+        ));
+    };
+    let count: i64 = count_str
+        .parse()
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "bad multibulk count"))?;
+    if count <= 0 {
+        return Ok(Some(Vec::new()));
+    }
+
+    let mut args = Vec::with_capacity(count as usize);
+    for _ in 0..count {
+        let mut len_line = String::new();
+        reader.read_line(&mut len_line).await?;
+        let len_line = len_line.trim_end_matches(['\r', '\n']);
+        let Some(len_str) = len_line.strip_prefix('$') else {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("expected bulk string ('$'), got: {len_line:?}"),
+            ));
+        };
+        let len: i64 = len_str
+            .parse()
+            .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "bad bulk length"))?;
+        if len < 0 {
+            args.push(Vec::new());
+            continue;
+        }
+        let mut buf = vec![0u8; len as usize + 2]; // +2 for trailing \r\n
+        reader.read_exact(&mut buf).await?;
+        buf.truncate(len as usize);
+        args.push(buf);
+    }
+    Ok(Some(args))
+}
+
+pub async fn write_reply<W: AsyncWriteExt + Unpin>(writer: &mut W, value: &RespValue) -> io::Result<()> {
+    let mut buf = Vec::new();
+    value.encode(&mut buf);
+    writer.write_all(&buf).await?;
+    writer.flush().await
+}
+
+pub type Reader = BufReader<tokio::net::tcp::OwnedReadHalf>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn parses_multibulk_command() {
+        let input = b"*2\r\n$3\r\nGET\r\n$3\r\nfoo\r\n".to_vec();
+        let mut reader = BufReader::new(&input[..]);
+        let cmd = read_command(&mut reader).await.unwrap().unwrap();
+        assert_eq!(cmd, vec![b"GET".to_vec(), b"foo".to_vec()]);
+    }
+
+    #[tokio::test]
+    async fn returns_none_on_clean_eof() {
+        let input: Vec<u8> = Vec::new();
+        let mut reader = BufReader::new(&input[..]);
+        assert_eq!(read_command(&mut reader).await.unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn rejects_inline_command_format() {
+        let input = b"PING\r\n".to_vec();
+        let mut reader = BufReader::new(&input[..]);
+        assert!(read_command(&mut reader).await.is_err());
+    }
+
+    #[test]
+    fn encodes_all_reply_types() {
+        let mut buf = Vec::new();
+        RespValue::ok().encode(&mut buf);
+        assert_eq!(buf, b"+OK\r\n");
+
+        let mut buf = Vec::new();
+        RespValue::Error("ERR bad".into()).encode(&mut buf);
+        assert_eq!(buf, b"-ERR bad\r\n");
+
+        let mut buf = Vec::new();
+        RespValue::Integer(42).encode(&mut buf);
+        assert_eq!(buf, b":42\r\n");
+
+        let mut buf = Vec::new();
+        RespValue::nil().encode(&mut buf);
+        assert_eq!(buf, b"$-1\r\n");
+
+        let mut buf = Vec::new();
+        RespValue::bulk("hi").encode(&mut buf);
+        assert_eq!(buf, b"$2\r\nhi\r\n");
+
+        let mut buf = Vec::new();
+        RespValue::Array(Some(vec![RespValue::bulk("a"), RespValue::Integer(1)])).encode(&mut buf);
+        assert_eq!(buf, b"*2\r\n$1\r\na\r\n:1\r\n");
+    }
+}

--- a/b00t-forge-kv/src/server.rs
+++ b/b00t-forge-kv/src/server.rs
@@ -1,0 +1,132 @@
+//! Per-connection handling: request/reply dispatch, plus SUBSCRIBE mode
+//! (RESP2 pub/sub — once a connection subscribes, it stops accepting
+//! regular commands and instead receives pushed `message` frames, matching
+//! how the `redis` crate's `aio::PubSub` actually drives a connection).
+
+use std::sync::Arc;
+
+use tokio::io::BufReader;
+use tokio::net::TcpStream;
+use tokio::sync::mpsc;
+
+use crate::commands::dispatch;
+use crate::resp::{read_command, write_reply, RespValue};
+use crate::store::Store;
+
+pub async fn handle_connection(socket: TcpStream, store: Arc<Store>) {
+    let peer = socket.peer_addr().map(|a| a.to_string()).unwrap_or_default();
+    let (read_half, mut write_half) = socket.into_split();
+    let mut reader = BufReader::new(read_half);
+
+    loop {
+        let args = match read_command(&mut reader).await {
+            Ok(Some(args)) if !args.is_empty() => args,
+            Ok(Some(_)) => continue, // empty multibulk (e.g. "*0\r\n") — ignore
+            Ok(None) => {
+                tracing::debug!(%peer, "connection closed");
+                return;
+            }
+            Err(e) => {
+                tracing::warn!(%peer, error = %e, "malformed request, closing connection");
+                let _ = write_reply(&mut write_half, &RespValue::Error(format!("ERR Protocol error: {e}"))).await;
+                return;
+            }
+        };
+
+        let cmd_name = String::from_utf8_lossy(&args[0]).to_ascii_uppercase();
+        if cmd_name == "SUBSCRIBE" {
+            let channels: Vec<String> = args[1..]
+                .iter()
+                .map(|c| String::from_utf8_lossy(c).to_string())
+                .collect();
+            if channels.is_empty() {
+                let _ = write_reply(&mut write_half, &RespValue::Error("ERR wrong number of arguments for 'subscribe' command".into())).await;
+                continue;
+            }
+            if run_subscribe_loop(&mut reader, &mut write_half, &store, channels).await.is_err() {
+                tracing::debug!(%peer, "subscriber connection closed");
+            }
+            return; // matches real Redis clients: pub/sub is a connection's terminal mode
+        }
+
+        let reply = dispatch(&store, &args).await;
+        if write_reply(&mut write_half, &reply).await.is_err() {
+            tracing::debug!(%peer, "write failed, closing connection");
+            return;
+        }
+    }
+}
+
+/// Drives a connection once it has entered pub/sub mode: sends a
+/// `subscribe` confirmation per channel, then relays published messages
+/// until the client disconnects. Further SUBSCRIBE/UNSUBSCRIBE/PING on the
+/// same connection are intentionally not supported — RedisComms's actual
+/// usage (`subscriber.subscribe(&channels).await?` once, then a read loop)
+/// never needs it, and real Redis clients open pub/sub as a dedicated
+/// connection for exactly this lifetime.
+async fn run_subscribe_loop(
+    reader: &mut crate::resp::Reader,
+    writer: &mut tokio::net::tcp::OwnedWriteHalf,
+    store: &Arc<Store>,
+    channels: Vec<String>,
+) -> std::io::Result<()> {
+    let (tx, mut rx) = mpsc::channel::<(String, Vec<u8>)>(256);
+
+    for (i, channel) in channels.iter().enumerate() {
+        let confirm = RespValue::Array(Some(vec![
+            RespValue::bulk("subscribe"),
+            RespValue::bulk(channel.as_str()),
+            RespValue::Integer((i + 1) as i64),
+        ]));
+        write_reply(writer, &confirm).await?;
+
+        let mut channel_rx = store.subscribe(channel).await;
+        let channel_name = channel.clone();
+        let tx = tx.clone();
+        tokio::spawn(async move {
+            loop {
+                match channel_rx.recv().await {
+                    Ok(payload) => {
+                        if tx.send((channel_name.clone(), payload)).await.is_err() {
+                            return; // connection gone
+                        }
+                    }
+                    Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => continue,
+                    Err(tokio::sync::broadcast::error::RecvError::Closed) => return,
+                }
+            }
+        });
+    }
+    drop(tx);
+
+    // Client sends no further commands once subscribed (see doc comment
+    // above) — this loop only needs to watch for the client disconnecting
+    // (to stop relaying) and for published messages to relay. Reusing
+    // read_command as the disconnect watch (rather than a raw peek, which
+    // OwnedReadHalf doesn't expose) means EOF/error handling stays in one
+    // place instead of being reimplemented here.
+    loop {
+        tokio::select! {
+            msg = rx.recv() => {
+                match msg {
+                    Some((channel, payload)) => {
+                        let frame = RespValue::Array(Some(vec![
+                            RespValue::bulk("message"),
+                            RespValue::bulk(channel),
+                            RespValue::BulkString(Some(payload)),
+                        ]));
+                        write_reply(writer, &frame).await?;
+                    }
+                    None => return Ok(()), // all channel forwarders ended
+                }
+            }
+            next = read_command(reader) => {
+                match next {
+                    Ok(None) => return Ok(()), // client disconnected
+                    Ok(Some(_)) => {} // extra commands unsupported in this mode — ignore, keep relaying
+                    Err(_) => return Ok(()),
+                }
+            }
+        }
+    }
+}

--- a/b00t-forge-kv/src/store.rs
+++ b/b00t-forge-kv/src/store.rs
@@ -1,0 +1,268 @@
+//! In-process key-value store backing the RESP2 server. Deliberately no
+//! external database — the whole point of ForgeKV is to be a b00t-native
+//! drop-in for `RedisComms` without an extra process/dependency to install
+//! and operate on a hive node.
+
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+use tokio::sync::{broadcast, RwLock};
+
+struct Entry {
+    value: Vec<u8>,
+    expires_at: Option<Instant>,
+}
+
+impl Entry {
+    fn is_expired(&self) -> bool {
+        self.expires_at.is_some_and(|t| Instant::now() >= t)
+    }
+}
+
+#[derive(Default)]
+pub struct Store {
+    strings: RwLock<HashMap<String, Entry>>,
+    hashes: RwLock<HashMap<String, HashMap<String, String>>>,
+    /// One broadcast channel per pub/sub channel name. Created lazily on
+    /// first PUBLISH or SUBSCRIBE, never removed (channel names are a small,
+    /// known set in practice — hive coordination, not user-generated).
+    channels: RwLock<HashMap<String, broadcast::Sender<Vec<u8>>>>,
+}
+
+impl Store {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    // ── strings ──────────────────────────────────────────────────────────
+
+    pub async fn set(&self, key: &str, value: Vec<u8>, ttl: Option<Duration>) {
+        let expires_at = ttl.map(|d| Instant::now() + d);
+        self.strings
+            .write()
+            .await
+            .insert(key.to_string(), Entry { value, expires_at });
+    }
+
+    pub async fn get(&self, key: &str) -> Option<Vec<u8>> {
+        let mut strings = self.strings.write().await;
+        match strings.get(key) {
+            Some(e) if e.is_expired() => {
+                strings.remove(key);
+                None
+            }
+            Some(e) => Some(e.value.clone()),
+            None => None,
+        }
+    }
+
+    pub async fn del(&self, keys: &[String]) -> i64 {
+        let mut strings = self.strings.write().await;
+        let mut hashes = self.hashes.write().await;
+        let mut count = 0i64;
+        for key in keys {
+            if strings.remove(key).is_some() {
+                count += 1;
+            }
+            if hashes.remove(key).is_some() {
+                count += 1;
+            }
+        }
+        count
+    }
+
+    pub async fn exists(&self, keys: &[String]) -> i64 {
+        let mut strings = self.strings.write().await;
+        let hashes = self.hashes.read().await;
+        let mut count = 0i64;
+        for key in keys {
+            let string_hit = match strings.get(key.as_str()) {
+                Some(e) if e.is_expired() => {
+                    strings.remove(key.as_str());
+                    false
+                }
+                Some(_) => true,
+                None => false,
+            };
+            if string_hit || hashes.contains_key(key.as_str()) {
+                count += 1;
+            }
+        }
+        count
+    }
+
+    pub async fn expire(&self, key: &str, ttl: Duration) -> bool {
+        let mut strings = self.strings.write().await;
+        match strings.get_mut(key) {
+            Some(e) if !e.is_expired() => {
+                e.expires_at = Some(Instant::now() + ttl);
+                true
+            }
+            _ => false,
+        }
+    }
+
+    /// INCRBY semantics: missing key treated as 0, value must parse as i64.
+    pub async fn incrby(&self, key: &str, delta: i64) -> Result<i64, &'static str> {
+        let mut strings = self.strings.write().await;
+        let current = match strings.get(key) {
+            Some(e) if e.is_expired() => 0,
+            Some(e) => std::str::from_utf8(&e.value)
+                .ok()
+                .and_then(|s| s.parse::<i64>().ok())
+                .ok_or("value is not an integer or out of range")?,
+            None => 0,
+        };
+        let next = current
+            .checked_add(delta)
+            .ok_or("increment or decrement would overflow")?;
+        strings.insert(
+            key.to_string(),
+            Entry {
+                value: next.to_string().into_bytes(),
+                expires_at: None,
+            },
+        );
+        Ok(next)
+    }
+
+    // ── hashes ───────────────────────────────────────────────────────────
+
+    /// Returns true if `field` is new (matches Redis HSET's "1 if new" reply).
+    pub async fn hset(&self, key: &str, field: &str, value: &str) -> bool {
+        let mut hashes = self.hashes.write().await;
+        let map = hashes.entry(key.to_string()).or_default();
+        map.insert(field.to_string(), value.to_string()).is_none()
+    }
+
+    pub async fn hget(&self, key: &str, field: &str) -> Option<String> {
+        self.hashes
+            .read()
+            .await
+            .get(key)
+            .and_then(|m| m.get(field))
+            .cloned()
+    }
+
+    pub async fn hgetall(&self, key: &str) -> Vec<(String, String)> {
+        self.hashes
+            .read()
+            .await
+            .get(key)
+            .map(|m| m.iter().map(|(k, v)| (k.clone(), v.clone())).collect())
+            .unwrap_or_default()
+    }
+
+    // ── pub/sub ──────────────────────────────────────────────────────────
+
+    /// Publish to `channel`, returning the number of current subscribers
+    /// (matches Redis PUBLISH's reply). A channel with zero subscribers has
+    /// no sender yet — that's correctly 0, not an error.
+    pub async fn publish(&self, channel: &str, message: Vec<u8>) -> i64 {
+        let channels = self.channels.read().await;
+        match channels.get(channel) {
+            Some(tx) => tx.send(message).map(|n| n as i64).unwrap_or(0),
+            None => 0,
+        }
+    }
+
+    pub async fn subscribe(&self, channel: &str) -> broadcast::Receiver<Vec<u8>> {
+        let mut channels = self.channels.write().await;
+        channels
+            .entry(channel.to_string())
+            .or_insert_with(|| broadcast::channel(256).0)
+            .subscribe()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn set_get_roundtrip() {
+        let store = Store::new();
+        store.set("k", b"v".to_vec(), None).await;
+        assert_eq!(store.get("k").await, Some(b"v".to_vec()));
+    }
+
+    #[tokio::test]
+    async fn expired_key_reads_as_missing() {
+        let store = Store::new();
+        store.set("k", b"v".to_vec(), Some(Duration::from_millis(1))).await;
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        assert_eq!(store.get("k").await, None);
+    }
+
+    #[tokio::test]
+    async fn del_counts_strings_and_hashes() {
+        let store = Store::new();
+        store.set("s", b"v".to_vec(), None).await;
+        store.hset("h", "f", "v").await;
+        assert_eq!(store.del(&["s".into(), "h".into(), "missing".into()]).await, 2);
+        assert_eq!(store.get("s").await, None);
+    }
+
+    #[tokio::test]
+    async fn exists_treats_expired_as_absent() {
+        let store = Store::new();
+        store.set("k", b"v".to_vec(), Some(Duration::from_millis(1))).await;
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        assert_eq!(store.exists(&["k".into()]).await, 0);
+    }
+
+    #[tokio::test]
+    async fn incrby_treats_missing_key_as_zero_and_persists() {
+        let store = Store::new();
+        assert_eq!(store.incrby("counter", 5).await, Ok(5));
+        assert_eq!(store.incrby("counter", -2).await, Ok(3));
+    }
+
+    #[tokio::test]
+    async fn incrby_rejects_non_integer_value() {
+        let store = Store::new();
+        store.set("k", b"not-a-number".to_vec(), None).await;
+        assert!(store.incrby("k", 1).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn hset_reports_new_vs_existing_field() {
+        let store = Store::new();
+        assert!(store.hset("h", "f", "v1").await);
+        assert!(!store.hset("h", "f", "v2").await);
+        assert_eq!(store.hget("h", "f").await, Some("v2".to_string()));
+    }
+
+    #[tokio::test]
+    async fn hgetall_returns_all_fields() {
+        let store = Store::new();
+        store.hset("h", "a", "1").await;
+        store.hset("h", "b", "2").await;
+        let mut fields = store.hgetall("h").await;
+        fields.sort();
+        assert_eq!(fields, vec![("a".to_string(), "1".to_string()), ("b".to_string(), "2".to_string())]);
+    }
+
+    #[tokio::test]
+    async fn publish_before_any_subscriber_returns_zero() {
+        let store = Store::new();
+        assert_eq!(store.publish("ch", b"hi".to_vec()).await, 0);
+    }
+
+    #[tokio::test]
+    async fn subscriber_receives_published_message() {
+        let store = Store::new();
+        let mut rx = store.subscribe("ch").await;
+        assert_eq!(store.publish("ch", b"hello".to_vec()).await, 1);
+        assert_eq!(rx.recv().await.unwrap(), b"hello".to_vec());
+    }
+
+    #[tokio::test]
+    async fn expire_extends_ttl_on_existing_key_only() {
+        let store = Store::new();
+        assert!(!store.expire("missing", Duration::from_secs(10)).await);
+        store.set("k", b"v".to_vec(), None).await;
+        assert!(store.expire("k", Duration::from_millis(1)).await);
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        assert_eq!(store.get("k").await, None);
+    }
+}

--- a/b00t-forge-kv/tests/redis_client_compat.rs
+++ b/b00t-forge-kv/tests/redis_client_compat.rs
@@ -1,0 +1,138 @@
+//! Proves b00t-forge-kv is a real drop-in for the `redis` crate client that
+//! `b00t-c0re-lib::redis::RedisComms` actually uses — not just a RESP2
+//! implementation in isolation. Runs the real server in-process and drives
+//! it with the same crate/version RedisComms depends on.
+
+use std::sync::Arc;
+
+use b00t_forge_kv::{serve, store::Store};
+use futures::StreamExt as _;
+use redis::AsyncCommands;
+use tokio::net::TcpListener;
+
+/// Binds an ephemeral port, spawns the real server against it, and returns
+/// a connected `redis` crate client pointed at it.
+async fn spawn_server() -> redis::Client {
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind ephemeral port");
+    let addr = listener.local_addr().expect("local_addr");
+    tokio::spawn(serve(listener, Arc::new(Store::new())));
+
+    redis::Client::open(format!("redis://{addr}")).expect("build redis client")
+}
+
+#[tokio::test]
+async fn ping() {
+    let client = spawn_server().await;
+    let mut conn = client.get_multiplexed_async_connection().await.expect("connect");
+    let pong: String = redis::cmd("PING").query_async(&mut conn).await.expect("PING");
+    assert_eq!(pong, "PONG");
+}
+
+#[tokio::test]
+async fn set_get_roundtrip() {
+    let client = spawn_server().await;
+    let mut conn = client.get_multiplexed_async_connection().await.expect("connect");
+    let _: () = conn.set("k", "v").await.expect("SET");
+    let v: String = conn.get("k").await.expect("GET");
+    assert_eq!(v, "v");
+}
+
+#[tokio::test]
+async fn get_missing_key_is_none() {
+    let client = spawn_server().await;
+    let mut conn = client.get_multiplexed_async_connection().await.expect("connect");
+    let v: Option<String> = conn.get("missing").await.expect("GET");
+    assert_eq!(v, None);
+}
+
+#[tokio::test]
+async fn setex_then_expires() {
+    let client = spawn_server().await;
+    let mut conn = client.get_multiplexed_async_connection().await.expect("connect");
+    let _: () = redis::cmd("SETEX")
+        .arg("k")
+        .arg(1u64)
+        .arg("v")
+        .query_async(&mut conn)
+        .await
+        .expect("SETEX");
+    let v: Option<String> = conn.get("k").await.expect("GET before expiry");
+    assert_eq!(v, Some("v".to_string()));
+
+    tokio::time::sleep(std::time::Duration::from_millis(1100)).await;
+    let v: Option<String> = conn.get("k").await.expect("GET after expiry");
+    assert_eq!(v, None);
+}
+
+#[tokio::test]
+async fn hset_hget_hgetall() {
+    let client = spawn_server().await;
+    let mut conn = client.get_multiplexed_async_connection().await.expect("connect");
+    let _: i32 = conn.hset("h", "a", "1").await.expect("HSET a");
+    let _: i32 = conn.hset("h", "b", "2").await.expect("HSET b");
+    let v: String = conn.hget("h", "a").await.expect("HGET a");
+    assert_eq!(v, "1");
+    let all: std::collections::HashMap<String, String> = conn.hgetall("h").await.expect("HGETALL");
+    assert_eq!(all.get("a"), Some(&"1".to_string()));
+    assert_eq!(all.get("b"), Some(&"2".to_string()));
+}
+
+/// RedisComms (b00t-c0re-lib/src/redis.rs) issues literal `INCR`/`DECR`
+/// (no argument) and `INCRBY` with an explicit amount — mirrored here via
+/// raw `redis::cmd` rather than the `redis` crate's `.incr()`/`.decr()`
+/// convenience methods, which pick INCRBY/DECRBY depending on the delta
+/// argument and would silently test a different command than RedisComms
+/// actually sends.
+#[tokio::test]
+async fn incr_decr() {
+    let client = spawn_server().await;
+    let mut conn = client.get_multiplexed_async_connection().await.expect("connect");
+
+    let v: i64 = redis::cmd("INCR").arg("c").query_async(&mut conn).await.expect("INCR");
+    assert_eq!(v, 1);
+    let v: i64 = redis::cmd("INCRBY").arg("c").arg(5).query_async(&mut conn).await.expect("INCRBY");
+    assert_eq!(v, 6);
+    let v: i64 = redis::cmd("DECR").arg("c").query_async(&mut conn).await.expect("DECR");
+    assert_eq!(v, 5);
+    let v: i64 = redis::cmd("DECRBY").arg("c").arg(2).query_async(&mut conn).await.expect("DECRBY");
+    assert_eq!(v, 3);
+}
+
+#[tokio::test]
+async fn del_and_exists() {
+    let client = spawn_server().await;
+    let mut conn = client.get_multiplexed_async_connection().await.expect("connect");
+    let _: () = conn.set("k", "v").await.expect("SET");
+    let exists: i32 = conn.exists("k").await.expect("EXISTS");
+    assert_eq!(exists, 1);
+    let deleted: i32 = conn.del("k").await.expect("DEL");
+    assert_eq!(deleted, 1);
+    let exists: i32 = conn.exists("k").await.expect("EXISTS after DEL");
+    assert_eq!(exists, 0);
+}
+
+/// The core RedisComms use case: publish + subscribe, exactly matching
+/// `agent_coordination.rs`'s presence/routing pattern (HSET registry, then
+/// PUBLISH to a channel a subscriber is already listening on).
+#[tokio::test]
+async fn publish_reaches_subscriber() {
+    let client = spawn_server().await;
+
+    let mut pubsub = client.get_async_pubsub().await.expect("pubsub connection");
+    pubsub.subscribe("b00t:agents:presence").await.expect("SUBSCRIBE");
+    let mut stream = pubsub.on_message();
+
+    let mut publisher = client.get_multiplexed_async_connection().await.expect("connect");
+    let subscribers: i32 = publisher
+        .publish("b00t:agents:presence", "agent-online:fung1")
+        .await
+        .expect("PUBLISH");
+    assert_eq!(subscribers, 1, "PUBLISH should report exactly one live subscriber");
+
+    let msg = tokio::time::timeout(std::time::Duration::from_secs(2), stream.next())
+        .await
+        .expect("did not receive published message in time")
+        .expect("stream ended unexpectedly");
+    let payload: String = msg.get_payload().expect("decode payload");
+    assert_eq!(payload, "agent-online:fung1");
+}

--- a/nats/vultr-forge-kv-deploy.sh
+++ b/nats/vultr-forge-kv-deploy.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+# Deploy b00t-forge-kv to a Vultr node as a Redis/Valkey replacement,
+# matching vultr-node-setup.sh's security model exactly: binds 127.0.0.1
+# only, reached over the same SSH tunnel already in place for NATS — never
+# exposed publicly, and agents never connect to it directly (only whatever
+# local service needs a KV/pub-sub backing store does).
+#
+# Builds a static (musl) binary locally rather than building on the remote
+# node or shipping a glibc-linked one: musl sidesteps glibc-version skew
+# between this build host and the target Debian release entirely, and Vultr
+# nodes in this hive are provisioned lean (no Rust toolchain) per the
+# existing nats-server deploy pattern (prebuilt binary, not built in place).
+#
+# Usage: ./vultr-forge-kv-deploy.sh <ssh-host-alias> [port]
+set -euo pipefail
+
+HOST="${1:?usage: vultr-forge-kv-deploy.sh <ssh-host-alias> [port]}"
+PORT="${2:-6379}"
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TARGET="x86_64-unknown-linux-musl"
+
+echo "== Building b00t-forge-kv (release, static musl) =="
+if ! rustup target list --installed | grep -q "$TARGET"; then
+  rustup target add "$TARGET"
+fi
+( cd "$REPO_ROOT" && cargo build --release --target "$TARGET" -p b00t-forge-kv )
+BINARY="$REPO_ROOT/target/$TARGET/release/b00t-forge-kv"
+[[ -x "$BINARY" ]] || { echo "❌ build did not produce $BINARY" >&2; exit 1; }
+
+echo "== Checking what's currently on :$PORT on $HOST =="
+if ssh "$HOST" "systemctl is-active redis-server 2>/dev/null || systemctl is-active valkey-server 2>/dev/null" | grep -q active; then
+  echo "⚠️  An active redis-server/valkey-server unit was found on $HOST."
+  echo "    This script does not stop/uninstall it for you — confirm nothing"
+  echo "    else depends on it, then stop it manually before (or after)"
+  echo "    enabling the b00t-forge-kv unit below, so only one process ever"
+  echo "    binds 127.0.0.1:$PORT."
+fi
+
+echo "== Copying binary to $HOST =="
+scp "$BINARY" "$HOST:/tmp/b00t-forge-kv"
+ssh "$HOST" "sudo install -m 755 /tmp/b00t-forge-kv /usr/local/bin/b00t-forge-kv && rm -f /tmp/b00t-forge-kv"
+
+echo "== Installing systemd unit (127.0.0.1:$PORT only — never public) =="
+ssh "$HOST" "sudo tee /etc/systemd/system/b00t-forge-kv.service > /dev/null" <<EOF
+[Unit]
+Description=b00t-forge-kv — RESP2 KV server (Redis/Valkey replacement)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+ExecStart=/usr/local/bin/b00t-forge-kv --host 127.0.0.1 --port ${PORT}
+Restart=always
+RestartSec=5
+DynamicUser=yes
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+ssh "$HOST" "sudo systemctl daemon-reload && sudo systemctl enable --now b00t-forge-kv && sudo systemctl status b00t-forge-kv --no-pager -l | head -10"
+
+echo ""
+echo "== Smoke test (from $HOST itself — the port is not reachable from here) =="
+ssh "$HOST" "printf '*1\r\n\$4\r\nPING\r\n' | timeout 2 bash -c 'cat > /dev/tcp/127.0.0.1/${PORT}; cat < /dev/tcp/127.0.0.1/${PORT}' 2>&1 | head -c 20 || echo 'FAILED — inspect with: ssh $HOST journalctl -u b00t-forge-kv -n 50'"
+
+echo ""
+echo "== Done =="
+echo "b00t-forge-kv is listening on ${HOST}:127.0.0.1:${PORT} (localhost-only, same"
+echo "reachability model as the existing NATS leaf: over whatever SSH tunnel"
+echo "already reaches this host, never public)."
+echo ""
+echo "Once confirmed healthy and nothing depends on the old redis-server unit:"
+echo "  ssh $HOST 'sudo systemctl disable --now redis-server'  # or valkey-server"


### PR DESCRIPTION
## Summary
Gives `KvBackend::ForgeKV` (`b00t-c0re-lib/src/kv_store.rs`) an actual server to detect, instead of just being an unimplemented fallback label. Part of getting b00t-server to replace Redis/Valkey on hive nodes (starting with the NATS Vultr leaf node) without needing an extra process/dependency installed there.

- Speaks real RESP2 protocol — hand-rolled parser/encoder rather than pulling in a general-purpose RESP crate, since a b00t-native component meant to run on internet-facing hive nodes benefits from an auditable, dependency-light implementation.
- Scope is deliberately narrow: implements exactly the ~16 commands `RedisComms` (`b00t-c0re-lib/src/redis.rs`) actually issues — `PING`, `SET`/`SETEX`/`GET`, `DEL`/`EXISTS`/`EXPIRE`, `INCR`/`DECR`/`INCRBY`/`DECRBY`, `HSET`/`HGET`/`HGETALL`, `PUBLISH`/`SUBSCRIBE` — not a general Redis clone.
- In-process store, no external DB: strings with optional TTL, hashes, per-channel pub/sub via tokio broadcast channels.
- Deployment model matches the existing NATS-on-Vultr pattern (`nats/vultr-node-setup.sh`): binds `127.0.0.1` only by default, reached over an SSH tunnel, never exposed publicly. Agents never connect to this directly.

## Test plan
- [x] `cargo test -p b00t-forge-kv` — 23 unit tests + 8 integration tests, 0 failed
- [x] Integration suite (`tests/redis_client_compat.rs`) uses the **real `redis` crate** (same version `RedisComms` depends on) against the real server running in-process — not just the hand-rolled protocol tested in isolation. Covers PING, SET/GET, SETEX expiry, HSET/HGET/HGETALL, INCR/DECR/INCRBY/DECRBY, DEL/EXISTS, and a PUBLISH-reaches-SUBSCRIBE round trip matching `agent_coordination.rs`'s actual presence/routing pattern.
- [x] Full pre-push gate (`cargo test -p b00t-cli --lib`) — 1539 passed, 0 failed

## Not done here
Actual deployment to the Vultr node — no SSH access configured for that host in this environment. This PR is the buildable, testable server component; deploying it (replacing the redis-server install step, binding to 127.0.0.1 like the existing nats-server unit) is a follow-up once SSH access is available.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>