### PR TITLE
docs(pyinfra): reproduce capability-forge deploy from scratch + record live fix

### DIFF
--- a/_b00t_/datums/PROVIDER-VULTR.provider.tomllmd
+++ b/_b00t_/datums/PROVIDER-VULTR.provider.tomllmd
@@ -381,6 +381,46 @@
 #         allowlist gate as capability-forge's original intended role —
 #         both remain separate follow-ups, not attempted here.
 #
+# MEMOIZED 2026-08-26 (cont'd, live deploy): item 4 above went beyond "code
+#      fixed, verified locally" — actually deployed to b00t-node, with the
+#      operator's explicit go-ahead first (this touches live production:
+#      NATS auth config, a running service, real secrets). Sequence run
+#      for real against 149.28.189.45:
+#        1. Appended a "capability-forge" user to the live
+#           nats-server.conf (backed up first), validated with
+#           `nats-server -t`, applied via SIGHUP live reload — confirmed
+#           "Reloaded: authorization users" in the NATS log with ZERO
+#           downtime; b00t-historian's existing connection was untouched
+#           (same PID, no reconnect needed).
+#        2. Added CAPFORGE_NATS_USER/CAPFORGE_NATS_PASSWORD to the
+#           existing /opt/b00t/capforge.env (appended only — the
+#           CAPFORGE_ACCOUNT_SEED/PUBKEY already there from an earlier,
+#           never-completed deploy attempt were left untouched and turned
+#           out to already be valid nkeys material).
+#        3. Rebuilt capability-forge with the #1154 fix — same
+#           rust:alpine container approach the historian build used
+#           before #1149 (native musl cross-compile hits a separate
+#           openssl-sys/pkg-config wall for this binary specifically, not
+#           the esaxx-rs issue #1149 fixed — see the pyinfra deploy
+#           script's section 7 comment).
+#        4. Uploaded + atomically swapped the binary, restarted the
+#           service.
+#      Result, confirmed live: `NRestarts=0`, "capability-forge listening
+#      on capability.request.*" in the log, same PID stable 20+ seconds
+#      later. The crash-loop (26099 restarts at the moment of the fix) is
+#      resolved, not just locally reproduced-and-fixed. `deploy_b00t_node.py`
+#      section 7 now reproduces this whole sequence from scratch (minus
+#      the account seed/pubkey, which must be generated once and reused,
+#      never regenerated — regenerating invalidates every grant already
+#      issued).
+#      Still open: b00t-server dogfooding (separate, alpha, its own
+#      future deploy_*.py — unchanged from the FOLLOW-UP note above), and
+#      wiring capability-forge into vultr_delegate's allowlist as the
+#      real authorization backend (currently a hardcoded env-var
+#      allowlist per the "minimal allowlist for now" design decision —
+#      capability-forge being deployable doesn't by itself make that
+#      swap, it's a separate integration task).
+#
 # Auth: VULTR_API_KEY env var (Account -> API in the Vultr customer portal).
 # 🤓 GPU flavor/pricing tables deliberately omitted here — unlike
 #    PROVIDER-RUNPOD/PROVIDER-HF, these haven't been independently verified

--- a/nats/pyinfra/deploy_b00t_node.py
+++ b/nats/pyinfra/deploy_b00t_node.py
@@ -7,12 +7,15 @@ This is the memoized answer to "how do we rebuild this node without an LLM."
 Deliberately NOT reproduced here (known-broken cruft — see the "DEPLOYED
 2026-08-25" and earlier entries in _b00t_/datums/PROVIDER-VULTR.provider.tomllmd
 for the full incident history):
-  - b00t-capability-forge.service — crash-looping (activating/auto-restart)
   - b00t-daprd.service            — crash-looping; Dapr's pubsub.jetstream
     account was never actually provisioned, souls uses plain NATS+JetStream
     instead (see the NATS auth section below)
   - b00t-pingap.service, b00t-maintenance.service — unrelated to souls; add a
     separate deploy_*.py for those if/when they need to be reproducible too
+
+b00t-capability-forge.service WAS in this exclusion list (crash-looping,
+26000+ restarts) — fixed and reproduced here as of 2026-08-26, see section
+7 below / _b00t_#1154.
 
 Usage:
     pyinfra nats/pyinfra/inventory.py nats/pyinfra/deploy_b00t_node.py \\
@@ -40,6 +43,26 @@ if not nats_password:
     raise ValueError(
         "pass --data nats_password=<secret> (e.g. $(openssl rand -hex 24)) — "
         "never hardcode the live credential in this repo"
+    )
+
+# capability-forge's NATS user (section 7) — its password is needed as
+# early as section 5's NATS pod config render, so it's fetched up here
+# alongside nats_password rather than next to the rest of section 7.
+# Required --data: capforge_nats_password, capforge_account_seed,
+# capforge_account_pubkey (generate the account seed/pubkey ONCE with a
+# throwaway `nkeys::KeyPair::new_account()` — e.g. via `cargo run` on a
+# one-off scratch binary — and pass the SAME pair on every re-run; a fresh
+# pair on each run would invalidate every capability grant this service
+# has already issued). Optional: openai_api_key (escalation judge; fails
+# closed without it — base-tier skills work fine either way).
+capforge_nats_password = host.data.get("capforge_nats_password")
+capforge_account_seed = host.data.get("capforge_account_seed")
+capforge_account_pubkey = host.data.get("capforge_account_pubkey")
+if not (capforge_nats_password and capforge_account_seed and capforge_account_pubkey):
+    raise ValueError(
+        "pass --data capforge_nats_password=<secret> --data capforge_account_seed=<nkeys seed> "
+        "--data capforge_account_pubkey=<nkeys pubkey> — generate the seed/pubkey ONCE and reuse "
+        "them on every re-run, never regenerate"
     )
 
 # ─── 1. Base packages ──────────────────────────────────────────────────────
@@ -127,6 +150,7 @@ files.template(
     src="templates/nats-pod-configured.yaml.j2",
     dest="/opt/b00t/nats-pod-configured.yaml",
     nats_password=nats_password,
+    capforge_nats_password=capforge_nats_password,
 )
 files.put(
     name="Install b00t-nats.service",
@@ -234,3 +258,71 @@ systemd.service(
     enabled=True,
     daemon_reload=True,
 )
+
+# ─── 7. capability-forge ────────────────────────────────────────────────────
+# 🤓 MEMOIZED 2026-08-26: was crash-looping in production (26000+ restarts,
+# journalctl showing "cannot parse user JWT from the credentials file") —
+# it only knew how to authenticate to NATS via a JWT/operator-mode creds
+# file, but this node's NATS server runs plain username/password auth (see
+# section 5 above / this file's nats_password). Fixed at the source in
+# capability-forge's main.rs (_b00t_#1154): it now tries
+# CAPFORGE_NATS_USER/CAPFORGE_NATS_PASSWORD first. Confirmed live: after
+# this exact sequence (new NATS user via config reload, env file, rebuilt
+# binary, service restart) it stayed up with 0 restarts.
+#
+# Unlike b00t-historian/b00t-forge-kv above, this does NOT build with a
+# plain native musl cross-compile — openssl-sys (pulled in transitively,
+# likely via the OpenAI judge client) needs pkg-config cross-compilation
+# support that isn't set up on the controller, and fails outright:
+# "Could not find directory of OpenSSL installation" /
+# "pkg-config has not been configured to support cross-compilation."
+# Falls back to the same rust:alpine container approach the historian
+# build used before _b00t_#1149's esaxx-rs fix (see the commented-out
+# block in section 6) — alpine's musl toolchain + openssl-dev sidesteps
+# the cross-compile pkg-config problem entirely.
+#
+REPO_ROOT = local.shell("git rev-parse --show-toplevel").strip()
+CONTAINER_IMAGE = "docker.io/library/rust:1-alpine"
+
+local.shell(
+    f"podman run --rm --memory=8g --memory-swap=8g -v {REPO_ROOT}:/src:Z -w /src {CONTAINER_IMAGE} sh -c "
+    "'apk add --no-cache build-base perl linux-headers pkgconfig openssl-dev openssl-libs-static "
+    "&& cargo build --release --jobs 4 --bin capability-forge -p capability-forge'"
+)
+
+files.put(
+    name="Upload capability-forge",
+    src=f"{REPO_ROOT}/target/release/capability-forge",
+    dest="/usr/local/b00t/capability-forge",
+    mode="755",
+    add_deploy_dir=False,
+)
+files.link(
+    name="Symlink /usr/local/bin/capability-forge -> /usr/local/b00t/capability-forge",
+    path="/usr/local/bin/capability-forge",
+    target="/usr/local/b00t/capability-forge",
+)
+files.template(
+    name="Write /opt/b00t/capforge.env (0600)",
+    src="templates/capforge.env.j2",
+    dest="/opt/b00t/capforge.env",
+    mode="600",
+    capforge_nats_password=capforge_nats_password,
+    capforge_account_seed=capforge_account_seed,
+    capforge_account_pubkey=capforge_account_pubkey,
+    openai_api_key=host.data.get("openai_api_key", ""),
+)
+files.put(
+    name="Install b00t-capability-forge.service",
+    src="files/b00t-capability-forge.service",
+    dest="/etc/systemd/system/b00t-capability-forge.service",
+)
+systemd.service(
+    name="Enable + start b00t-capability-forge",
+    service="b00t-capability-forge.service",
+    running=True,
+    enabled=True,
+    restarted=True,  # pick up a rebuilt binary / rotated password on re-run
+    daemon_reload=True,
+)
+

--- a/nats/pyinfra/files/b00t-capability-forge.service
+++ b/nats/pyinfra/files/b00t-capability-forge.service
@@ -1,0 +1,50 @@
+# Skill-scoped NATS JWT authorization service — see docs/superpowers/
+# specs/2026-08-13-capability-forge-design.md.
+#
+# 🤓 MEMOIZED 2026-08-26: this originally connected via
+# CAPFORGE_SERVICE_CREDS_FILE (NATS JWT/operator-mode auth, a
+# "capforge-service" user minted via `mint_service_creds`) — crash-looped
+# forever (26000+ restarts) because b00t-node's NATS server runs plain
+# username/password auth, not JWT (see nats-pod-configured.yaml.j2 — the
+# NSC signing key needed for real JWT support was lost). Fixed at the
+# source: capability-forge's main.rs now tries
+# CAPFORGE_NATS_USER/CAPFORGE_NATS_PASSWORD (in /opt/b00t/capforge.env)
+# first, only falling back to the creds file if those are unset — see
+# _b00t_#1154. The Environment=CAPFORGE_SERVICE_CREDS_FILE line below is
+# now inert (present for the JWT fallback path, unused as long as
+# CAPFORGE_NATS_USER/PASSWORD are set) — harmless to leave.
+#
+# 🤓 CAPFORGE_ACCOUNT_SEED and OPENAI_API_KEY are secrets (the seed is
+# the operator account's signing key — equivalent to root authority
+# over every NATS user JWT this service mints). They live in
+# /opt/b00t/capforge.env (0600, written above) via EnvironmentFile=,
+# not inline Environment= here, because this unit file itself is 0644
+# (systemd unit files are conventionally world-readable) and an inline
+# Environment= line would have put the seed in a world-readable file.
+#
+# 🤓 KNOWN GAP: CAPFORGE_JUDGE_MODEL's OpenAI-backed escalation judge
+# needs OPENAI_API_KEY, which does not exist in the global secret
+# store yet (only an Azure OpenAI key does, under a different API
+# shape — see cvat_hitl.tf's OPENAI_API_KEY output, not reusable
+# here). Left empty on purpose rather than blocking on it: the judge
+# fails closed by design (an API error denies the escalation, it
+# never grants), so base-tier skills still work end-to-end without
+# this — only escalatable-tier requests are affected until it's added.
+[Unit]
+Description=capability-forge (skill-scoped NATS JWT authorization service)
+After=b00t-nats.service
+Requires=b00t-nats.service
+
+[Service]
+Type=simple
+Environment=NATS_URL=nats://127.0.0.1:4222
+Environment=CAPFORGE_DB_PATH=/var/lib/b00t/capability-forge.redb
+Environment=CAPFORGE_SERVICE_CREDS_FILE=/opt/b00t/capforge-service.creds
+Environment=CAPFORGE_JUDGE_MODEL=gpt-4o-mini
+EnvironmentFile=/opt/b00t/capforge.env
+ExecStart=/usr/local/bin/capability-forge
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/nats/pyinfra/templates/capforge.env.j2
+++ b/nats/pyinfra/templates/capforge.env.j2
@@ -1,0 +1,5 @@
+CAPFORGE_ACCOUNT_SEED={{ capforge_account_seed }}
+CAPFORGE_ACCOUNT_PUBKEY={{ capforge_account_pubkey }}
+OPENAI_API_KEY={{ openai_api_key|default('') }}
+CAPFORGE_NATS_USER=capability-forge
+CAPFORGE_NATS_PASSWORD={{ capforge_nats_password }}

--- a/nats/pyinfra/templates/nats-pod-configured.yaml.j2
+++ b/nats/pyinfra/templates/nats-pod-configured.yaml.j2
@@ -70,6 +70,7 @@ data:
     authorization {
       users = [
         { user: "b00t-historian", password: "{{ nats_password }}" }
+        { user: "capability-forge", password: "{{ capforge_nats_password }}" }
       ]
     }
 


### PR DESCRIPTION
## Summary
Extends `deploy_b00t_node.py` (section 7) to deploy capability-forge with #1154's NATS-auth fix — was in this script's "deliberately NOT reproduced, known-broken" exclusion list; removed from that list now that it's real, working, reproducible infrastructure.

- Adds a `capability-forge` NATS user to `nats-pod-configured.yaml.j2`'s authorization block, alongside the existing `b00t-historian` one
- Builds capability-forge via the `rust:alpine` container (same fallback the historian build used before #1149 — this binary hits a separate `openssl-sys`/pkg-config cross-compile wall, native musl doesn't work for it)
- Writes `/opt/b00t/capforge.env`, installs the (updated, accurately-commented) systemd unit, enables + starts it
- Requires `capforge_nats_password`/`capforge_account_seed`/`capforge_account_pubkey` as explicit `--data` args, documented as generate-once-reuse-forever

Also records, in the datum, the actual live deployment performed this session against b00t-node (with explicit operator sign-off first — it touches production: NATS auth config via a live SIGHUP reload with zero downtime, real secrets, a running service). Confirmed via `journalctl`: `NRestarts=0`, "capability-forge listening on `capability.request.*`", stable. The crash-loop (26099 restarts at the moment of the fix) is resolved live, not just locally reproduced.

## Test plan
- [x] `python3 -m py_compile`: syntax OK
- [x] Full `pyinfra --dry` against the live b00t-node inventory completes end-to-end and correctly detects the new capability-forge operations — notably "Upload capability-forge" shows **zero change**, confirming this script's build now produces the exact binary already running live
- [x] Datum graph validation gate: passed
- [x] Full pre-push gate: 1572 passed, 0 failed

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>