### PR TITLE
feat(b00t-server): dogfood the OpenAI-compat gateway on b00t-node

### DIFF
--- a/_b00t_/datums/PROVIDER-VULTR.provider.tomllmd
+++ b/_b00t_/datums/PROVIDER-VULTR.provider.tomllmd
@@ -456,6 +456,56 @@
 #      grant" — capability-forge's actual SkillTier::Restricted default,
 #      not a stubbed response.
 #
+# MEMOIZED 2026-08-26 (cont'd): b00t-server dogfooded onto this node —
+#      the "operator wants b00t-server (MCP proxy + full b00t capability
+#      surface) dogfooded onto this node too" follow-up, open since the
+#      earliest MEMOIZED entries in this datum. Scoped first (a fork
+#      investigation, ~200 words, before any code): b00t-server is not a
+#      separate crate — it's b00t-mcp run with --http --llm (same binary
+#      as the MCP proxy), backed by real, actively-maintained code
+#      (server_llm.rs) that already builds clean and already supports
+#      remote backends via OPENAI_API_KEY/OPENROUTER_API_KEY. No local
+#      GPU required: local backend discovery (mistralrs/llama-cpp/vllm/
+#      qwen3-embed) TCP-probes and silently skips whatever isn't
+#      listening, falling through to the remote list — a legitimate,
+#      already-supported mode, not a hack.
+#      Added a third remote backend, TELNYX_API_KEY, alongside the two
+#      pre-existing entries (appended last, preserving their relative
+#      priority) — same OpenAI-Chat-Completions-compatible endpoint as
+#      capability-forge's judge (see the multi-provider judge entry
+#      above), the one provider with a real working credential anywhere
+#      in this hive.
+#      Builds as a plain native musl cross-compile, unlike capability-forge:
+#      b00t-mcp depends on b00t-cli, which carries this workspace's
+#      `openssl-sys = { features = ["vendored"] }` pin (root Cargo.toml) —
+#      that vendored build compiles OpenSSL from pure C source using plain
+#      musl-gcc, no C++ needed. capability-forge doesn't depend on b00t-cli
+#      so that pin never reaches it, which is the precise, traced reason
+#      it still needs the Alpine-container fallback (section 7 of
+#      deploy_b00t_node.py) while b00t-server (section 8) doesn't.
+#      🤓 openssl-sys itself is never actually used anywhere in b00t-cli's
+#      own source (confirmed via grep) — it's pulled in purely
+#      transitively, via reqwest's default native-tls backend, requested
+#      by several crates (oauth2, opentelemetry-otlp, hyper-tls) that
+#      don't opt into rustls-tls. The vendored pin is a working fix, not
+#      the best possible one — switching the whole workspace to
+#      rustls-tls (pure Rust, zero C dependency, faster builds, no
+#      per-build OpenSSL compile) would be a real, separate, valuable
+#      follow-up; not attempted here since the vendored pin already
+#      unblocks this task.
+#      Verified live (debug build, before the release build used for
+#      actual deploy): started a real b00t-mcp --http --llm instance in
+#      an isolated $HOME with a real TELNYX_API_KEY and no
+#      OPENAI/OPENROUTER key set, minted a real b00t-sk-* key via `b00t
+#      server key create`, and got a genuine 200 chat completion back
+#      through the full proxy chain (auth -> backend discovery -> Telnyx
+#      -> response), with a matching Spotlight usage-telemetry line
+#      written. Confirmed the server correctly logs "upstream (soul/remote
+#      telnyx)" when it selects this new backend.
+#      Not yet deployed live to b00t-node itself, pending the same
+#      operator sign-off already given for capability-forge's live
+#      deploy — see FOLLOW-UP below once that happens.
+#
 # Auth: VULTR_API_KEY env var (Account -> API in the Vultr customer portal).
 # 🤓 GPU flavor/pricing tables deliberately omitted here — unlike
 #    PROVIDER-RUNPOD/PROVIDER-HF, these haven't been independently verified

--- a/b00t-mcp/src/server_llm.rs
+++ b/b00t-mcp/src/server_llm.rs
@@ -92,6 +92,15 @@ fn default_soul(hostname: &str) -> SoulConfig {
             remote: vec![
                 RemoteBackend { name: "openai".into(), key_env: "OPENAI_API_KEY".into(), base_url: None },
                 RemoteBackend { name: "openrouter".into(), key_env: "OPENROUTER_API_KEY".into(), base_url: Some("https://openrouter.ai/api/v1".into()) },
+                // 🤓 Telnyx Inference — OpenAI-Chat-Completions-compatible
+                // (confirmed live: capability-forge/src/judge.rs's
+                // OpenAiJudge::with_base_url uses the identical endpoint
+                // shape). Appended last, after the two pre-existing entries,
+                // to preserve their relative priority on any host that
+                // happens to have multiple keys set — it's the one that
+                // actually has a working credential anywhere in this hive
+                // today, not necessarily the "best" provider in general.
+                RemoteBackend { name: "telnyx".into(), key_env: "TELNYX_API_KEY".into(), base_url: Some("https://api.telnyx.com/v2/ai".into()) },
             ],
         },
     }
@@ -885,6 +894,78 @@ mod tests {
             "a key created under one TempHome must not leak into a fresh LlmState \
              constructed under a different TempHome"
         );
+    }
+
+    // ── remote backend discovery — Telnyx addition ──────────────────────────
+
+    static REMOTE_BACKEND_ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    fn clear_remote_backend_env() {
+        unsafe {
+            std::env::remove_var("OPENAI_API_KEY");
+            std::env::remove_var("OPENROUTER_API_KEY");
+            std::env::remove_var("TELNYX_API_KEY");
+        }
+    }
+
+    #[test]
+    fn default_soul_includes_telnyx_as_a_remote_backend() {
+        let soul = default_soul("test-host");
+        let telnyx = soul
+            .backends
+            .remote
+            .iter()
+            .find(|b| b.name == "telnyx")
+            .expect("telnyx must be a default remote backend");
+        assert_eq!(telnyx.key_env, "TELNYX_API_KEY");
+        assert_eq!(telnyx.base_url.as_deref(), Some("https://api.telnyx.com/v2/ai"));
+    }
+
+    #[test]
+    fn discover_remote_picks_telnyx_when_it_is_the_only_key_set() {
+        let _guard = REMOTE_BACKEND_ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        clear_remote_backend_env();
+        unsafe {
+            std::env::set_var("TELNYX_API_KEY", "test-telnyx-key");
+        }
+
+        let soul = default_soul("test-host");
+        let found = discover_remote(&soul);
+        clear_remote_backend_env();
+
+        let (name, key, url) = found.expect("a remote backend must be found");
+        assert_eq!(name, "telnyx");
+        assert_eq!(key, "test-telnyx-key");
+        assert_eq!(url, "https://api.telnyx.com/v2/ai");
+    }
+
+    #[test]
+    fn discover_remote_prefers_openai_over_telnyx_when_both_are_set() {
+        // Telnyx was appended AFTER the pre-existing entries specifically to
+        // preserve their relative priority on any host that happens to have
+        // multiple keys configured — this proves that ordering held.
+        let _guard = REMOTE_BACKEND_ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        clear_remote_backend_env();
+        unsafe {
+            std::env::set_var("OPENAI_API_KEY", "test-openai-key");
+            std::env::set_var("TELNYX_API_KEY", "test-telnyx-key");
+        }
+
+        let soul = default_soul("test-host");
+        let found = discover_remote(&soul);
+        clear_remote_backend_env();
+
+        let (name, ..) = found.expect("a remote backend must be found");
+        assert_eq!(name, "openai");
+    }
+
+    #[test]
+    fn discover_remote_finds_nothing_when_no_keys_are_set() {
+        let _guard = REMOTE_BACKEND_ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        clear_remote_backend_env();
+
+        let soul = default_soul("test-host");
+        assert!(discover_remote(&soul).is_none());
     }
 
     // ── proxy_chat #596/#597 wiring — end-to-end against a fake upstream ─────

--- a/nats/pyinfra/deploy_b00t_node.py
+++ b/nats/pyinfra/deploy_b00t_node.py
@@ -17,6 +17,10 @@ b00t-capability-forge.service WAS in this exclusion list (crash-looping,
 26000+ restarts) — fixed and reproduced here as of 2026-08-26, see section
 7 below / _b00t_#1154.
 
+The "operator wants b00t-server dogfooded onto this node" follow-up (also
+present since the earliest entries in this datum) is likewise resolved and
+reproduced here — see section 8 below.
+
 Usage:
     pyinfra nats/pyinfra/inventory.py nats/pyinfra/deploy_b00t_node.py \\
         --data nats_password=$(openssl rand -hex 24)
@@ -325,4 +329,64 @@ systemd.service(
     restarted=True,  # pick up a rebuilt binary / rotated password on re-run
     daemon_reload=True,
 )
+
+# ─── 8. b00t-server (OpenAI-compat gateway) ─────────────────────────────────
+# 🤓 MEMOIZED 2026-08-26: reproduces the "dogfood b00t-server on this node"
+# follow-up that's been open since the earliest MEMOIZED entries in
+# PROVIDER-VULTR.provider.tomllmd. b00t-server is just b00t-mcp run with
+# --http --llm — the same binary, no separate crate. Builds as a plain
+# native musl cross-compile (unlike capability-forge in section 7): b00t-mcp
+# depends on b00t-cli, which carries this workspace's `openssl-sys =
+# { features = ["vendored"] }` pin — that vendored build compiles OpenSSL
+# from C source using plain musl-gcc (pure C, no C++ needed, same reason
+# the section-6 fix in _b00t_#1149 worked once esaxx-rs's C++ requirement
+# was removed). capability-forge doesn't depend on b00t-cli, so that pin
+# never reaches it, which is why it still needs the Alpine container.
+#
+# Backend discovery is entirely runtime-config-driven (see
+# b00t-mcp/src/server_llm.rs's SoulConfig) — local backends (mistralrs,
+# llama-cpp, vllm, qwen3-embed) are TCP-probed and silently skipped when
+# nothing's listening (this node has no GPU; that's expected, not a
+# degraded mode), falling through to the remote backend list. TELNYX_API_KEY
+# is templated below because it's the one provider confirmed to have a
+# real working credential anywhere in this hive as of 2026-08-26 — see
+# this file's own section for how that was verified.
+#
+# Required --data: telnyx_api_key.
+telnyx_api_key = host.data.get("telnyx_api_key")
+if not telnyx_api_key:
+    raise ValueError("pass --data telnyx_api_key=<secret> — no other remote LLM backend has a working credential in this hive yet")
+
+local.shell(
+    f"cargo build --release --target {MUSL_TARGET} --jobs 4 --bin b00t-mcp -p b00t-mcp"
+)
+
+files.put(
+    name="Upload b00t-mcp",
+    src=f"{TARGET_DIR}/{MUSL_TARGET}/release/b00t-mcp",
+    dest="/usr/local/bin/b00t-mcp",
+    mode="755",
+    add_deploy_dir=False,
+)
+files.template(
+    name="Write /opt/b00t/b00t-server.env (0600)",
+    src="templates/b00t-server.env.j2",
+    dest="/opt/b00t/b00t-server.env",
+    mode="600",
+    telnyx_api_key=telnyx_api_key,
+)
+files.put(
+    name="Install b00t-server.service",
+    src="files/b00t-server.service",
+    dest="/etc/systemd/system/b00t-server.service",
+)
+systemd.service(
+    name="Enable + start b00t-server",
+    service="b00t-server.service",
+    running=True,
+    enabled=True,
+    restarted=True,  # pick up a rebuilt binary / rotated key on re-run
+    daemon_reload=True,
+)
+
 

--- a/nats/pyinfra/files/b00t-server.service
+++ b/nats/pyinfra/files/b00t-server.service
@@ -1,0 +1,29 @@
+# b00t-server — OpenAI-compatible gateway + API-key authority + Spotlight
+# usage telemetry. Runs b00t-mcp (the same binary as the MCP proxy) in
+# --http --llm mode. See b00t-mcp/src/server_llm.rs for the backend
+# discovery logic (local ports probed first, falling back to whichever
+# remote entry in ~/.b00t/server-soul.tomllm has its key_env set — that
+# file self-generates on first run with sane defaults, no template needed
+# here).
+#
+# 🤓 On a no-GPU node like this one, every local backend probe
+# (mistralrs:8181, llama-cpp:8080, vllm:8000, qwen3-embed:8003) fails its
+# TCP connect and falls through to the remote list — a legitimate,
+# already-supported mode, not a degraded fallback. See
+# _b00t_/datums/PROVIDER-VULTR.provider.tomllmd's b00t-server section for
+# which remote credential actually has a working key in this hive.
+[Unit]
+Description=b00t-server (OpenAI-compat gateway + API-key authority)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+Environment=HOME=/root
+EnvironmentFile=/opt/b00t/b00t-server.env
+ExecStart=/usr/local/bin/b00t-mcp --http --llm --port 5273 --host 127.0.0.1
+Restart=on-failure
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target

--- a/nats/pyinfra/templates/b00t-server.env.j2
+++ b/nats/pyinfra/templates/b00t-server.env.j2
@@ -1,0 +1,10 @@
+TELNYX_API_KEY={{ telnyx_api_key }}
+
+# 🤓 b00t-server tries remote backends in this order (see
+# b00t-mcp/src/server_llm.rs's default_soul()): openai, openrouter,
+# telnyx. Telnyx is templated above because it's the one provider
+# confirmed to have a real working credential in this hive as of
+# 2026-08-26 (see PROVIDER-VULTR.provider.tomllmd) — uncomment either of
+# these instead/additionally if a real key for it ever exists:
+# OPENAI_API_KEY=
+# OPENROUTER_API_KEY=


### PR DESCRIPTION
## Summary
Resolves the "operator wants b00t-server dogfooded onto this node too" follow-up, open since the earliest MEMOIZED entries in `PROVIDER-VULTR.provider.tomllmd`. Scoped first via a research-only fork before any code: b00t-server isn't a separate crate, it's `b00t-mcp` run with `--http --llm` (same binary as the MCP proxy), backed by real, actively-maintained code that already builds clean and already supports remote LLM backends via env-var-driven key discovery — a no-GPU node is already a legitimate, supported mode (local backend probing just silently skips whatever isn't listening), not a hack needing new design work.

`server_llm.rs`: adds Telnyx Inference as a third remote backend option (`TELNYX_API_KEY`), alongside the two pre-existing entries (openai, openrouter) — appended last to preserve their relative priority. Same OpenAI-Chat-Completions-compatible endpoint already proven for capability-forge's judge — the one provider with a real working credential anywhere in this hive today.

`nats/pyinfra/deploy_b00t_node.py`: new section 8 reproduces the full deploy from scratch — builds b00t-mcp as a plain native musl cross-compile (works via the workspace's vendored-openssl-sys pin inherited through b00t-cli; no Alpine container needed, unlike capability-forge), uploads the binary, writes the env file, installs + enables the systemd unit.

## Test plan
- [x] 4 new unit tests (`server_llm::tests`) covering the Telnyx backend's presence and `discover_remote()`'s priority ordering — pure, no network needed
- [x] Full `b00t-mcp` test suite: 67 passed, 0 failed
- [x] **Live end-to-end proof** (not mocked): started a real `b00t-mcp --http --llm` instance in an isolated `$HOME` with a real `TELNYX_API_KEY` and no OPENAI/OPENROUTER key, minted a real `b00t-sk-*` key via `b00t server key create`, got a genuine 200 chat completion back through the full proxy chain, with a matching Spotlight usage-telemetry line written
- [x] Full `pyinfra --dry` against the live b00t-node inventory completes end-to-end and correctly detects every new section-8 operation

Not yet deployed live to b00t-node itself — pending the same kind of operator sign-off already given for capability-forge's live deploy.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>