### PR TITLE
fix: keys-file write race, flaky test root cause, /tmp hardcode, lfmf dedup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1898,6 +1898,7 @@ dependencies = [
  "chrono",
  "clap",
  "dirs",
+ "fs2",
  "jsonwebtoken",
  "lazy_static",
  "notify 7.0.0",

--- a/_b00t_/learn/cargo-workspace-install.md
+++ b/_b00t_/learn/cargo-workspace-install.md
@@ -1,2 +1,2 @@
 ---
-Use cargo install --locked for workspace path binaries to preserve the repository lockfile and MSRV-compatible resolution: Use cargo install --locked for workspace path binaries to preserve the repository lockfile and MSRV-compatible resolution <!-- salvaged:no_colon -->
+Use cargo install --locked for…: Use cargo install --locked for workspace path binaries to preserve the repository lockfile and MSRV-compatible resolution <!-- salvaged:no_colon -->

--- a/_b00t_/lfmf.tomllmd
+++ b/_b00t_/lfmf.tomllmd
@@ -5,14 +5,28 @@
 #   input) fronting b00t-c0re-lib/src/lfmf.rs (LfmfSystem::record_lesson — the
 #   storage layer). Issue #934 found two example lessons on disk
 #   (_b00t_/learn/cargo-workspace-install.md, guard-session-fixtures.md) that
-#   looked corrupted — one really was (a pre-refactor hyphen-slugified,
-#   `MSRV`→`MSRS`-mangled duplicate, from before commit 969e6e09's
-#   salvage-first rewrite); the other turned out to be the CURRENT writer's
-#   correct, if verbose, no-colon salvage output (topic is a legitimately
-#   token-budgeted prefix of body, not corruption) — re-verified by literally
-#   re-running both through the current binary; see git history for this file
-#   for the byte-for-byte comparison. Both files were re-emitted with the
-#   current writer as part of closing out #934.
+#   looked corrupted. `guard-session-fixtures.md` was (and still is) correct:
+#   its topic is a legitimately token-budgeted prefix of a much longer body,
+#   not a duplicate — that's the salvage writer working as designed.
+#   `cargo-workspace-install.md` genuinely was corrupted, in TWO separate,
+#   sequential bugs, not one:
+#     1. A pre-refactor hyphen-slugifier + `MSRV`→`MSRS` mangling (predates
+#        commit 969e6e09's salvage-first rewrite) — fixed by PR #970, which
+#        re-emitted the file with correct spelling/spacing.
+#     2. `auto_topic()` in `b00t-cli/src/commands/lfmf.rs` returned the ENTIRE
+#        input verbatim as "topic" whenever the whole no-colon lesson already
+#        fit within `topic_max` tokens (this lesson's real content, ~16
+#        words, cleared the 25-token production budget without ever
+#        triggering the truncation loop) — so `"{topic}: {body}"` wrote the
+#        same sentence twice. PR #970 fixed bug 1 but never touched
+#        `auto_topic`, so this file was STILL duplicated after that "fix" —
+#        a prior version of this very comment incorrectly claimed both files
+#        were already correctly re-emitted; that was wrong for this file.
+#        Bug 2 is now fixed (`auto_topic` caps at a short word-prefix +
+#        ellipsis when the full text would otherwise be returned verbatim),
+#        regression-locked via two new fixture cases in
+#        `lfmf_salvage_cases.json`, and `cargo-workspace-install.md` has been
+#        re-emitted again with the corrected writer.
 #
 # @tribal: don't validate stricter in the CLI layer than the storage layer
 #   accepts — see the meta-pattern doc comment on ParsedLesson in

--- a/b00t-c0re-lib/src/kv_store.rs
+++ b/b00t-c0re-lib/src/kv_store.rs
@@ -530,9 +530,14 @@ mod tests {
 
     #[test]
     fn test_gate_cache_writes_keys() {
-        // Use a temp file path to avoid clobbering real state
+        // 🤓 #998: a hardcoded "/tmp/..." literal here ignored TMPDIR and used a
+        // fixed filename shared across concurrent test runs — false-negatived the
+        // pre-push gate under real /tmp disk pressure. `tempfile::tempdir()`
+        // respects TMPDIR and gives each test run its own unique directory.
+        let temp_dir = tempfile::tempdir().unwrap();
+        let cache_path = temp_dir.path().join("b00t-test-gate-cache.json");
         let mut config = KvConfig::default();
-        config.file_path = Some("/tmp/b00t-test-gate-cache.json".to_string());
+        config.file_path = Some(cache_path.to_str().unwrap().to_string());
         let store = KvStore::new(config);
 
         let result = GateResult::Allow;
@@ -558,7 +563,6 @@ mod tests {
             .unwrap();
         assert_eq!(agent, "test-agent");
 
-        // Clean up
-        let _ = std::fs::remove_file("/tmp/b00t-test-gate-cache.json");
+        // temp_dir cleans itself up on drop — no manual removal needed.
     }
 }

--- a/b00t-cli/src/commands/lfmf.rs
+++ b/b00t-cli/src/commands/lfmf.rs
@@ -37,11 +37,26 @@ pub struct ParsedLesson {
 }
 
 /// Longest word-prefix of `text` that fits within `topic_max` tokens (≥1 word).
+///
+/// 🤓 #934: every caller of `auto_topic` also stores `body` as `text` itself
+/// (or a superset of it, e.g. the full raw lesson). If `text` already fits
+/// entirely within `topic_max` — the loop below never shrinks `end` — this
+/// used to return `text` verbatim as the "topic," so the emitted
+/// `"{topic}: {body} <!-- salvaged:... -->"` line duplicated the whole
+/// lesson word-for-word. When that happens, force a genuinely shorter
+/// summary (a short word-prefix with an ellipsis) instead — unless `text`
+/// is already a single word, where there's nothing shorter to derive and
+/// `topic == body` is the only honest answer.
 fn auto_topic(text: &str, count_tokens: &dyn Fn(&str) -> usize, topic_max: usize) -> String {
     let words: Vec<&str> = text.split_whitespace().collect();
     let mut end = words.len();
     while end > 1 && count_tokens(&words[..end].join(" ")) > topic_max {
         end -= 1;
+    }
+    if end == words.len() && words.len() > 1 {
+        const SUMMARY_WORDS: usize = 5;
+        let summary_end = SUMMARY_WORDS.min(words.len() - 1);
+        return format!("{}…", words[..summary_end].join(" ").trim_end_matches(':'));
     }
     words[..end].join(" ").trim_end_matches(':').to_string()
 }

--- a/b00t-cli/src/commands/server.rs
+++ b/b00t-cli/src/commands/server.rs
@@ -57,6 +57,36 @@ pub enum KeyAction {
 
 const KEYS_FILE: &str = "server-keys.json";
 
+/// Locked, read-merge-write, atomic-rename insert into the shared keys file —
+/// mirrors `b00t-mcp/src/server_llm.rs`'s `write_keys_file_locked` (#1128).
+/// Re-reads the file's CURRENT on-disk state after acquiring the lock, so a
+/// key a concurrently-running `b00t-mcp --http --llm` server just persisted
+/// via `LlmState::save_keys_to_file` isn't lost to this process's own write.
+fn create_key_locked(keys_path: &std::path::Path, key: &str, entry: Value) -> anyhow::Result<()> {
+    use fs2::FileExt;
+
+    if let Some(parent) = keys_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let lock_file = std::fs::OpenOptions::new().create(true).write(true).open(keys_path)?;
+    lock_file.lock_exclusive()?;
+
+    let mut data: Value =
+        serde_json::from_str(&std::fs::read_to_string(keys_path).unwrap_or_default())
+            .unwrap_or_else(|_| serde_json::from_str(r###"{"keys":{}}"###).unwrap());
+    data["keys"]
+        .as_object_mut()
+        .ok_or_else(|| anyhow::anyhow!("invalid keys file"))?
+        .insert(key.to_string(), entry);
+
+    let tmp_path = keys_path.with_extension("json.tmp");
+    std::fs::write(&tmp_path, serde_json::to_string_pretty(&data)?)?;
+    std::fs::rename(&tmp_path, keys_path)?;
+
+    // Lock releases when lock_file drops at function end.
+    Ok(())
+}
+
 pub fn handle_server_command(cmd: &ServerCommands) -> anyhow::Result<()> {
     match cmd {
         ServerCommands::Start {
@@ -89,12 +119,6 @@ pub fn handle_server_command(cmd: &ServerCommands) -> anyhow::Result<()> {
                     .unwrap_or_else(|| std::path::PathBuf::from("."))
                     .join(".b00t")
                     .join(KEYS_FILE);
-                let mut data: Value =
-                    serde_json::from_str(&std::fs::read_to_string(&keys_path).unwrap_or_default())
-                        .unwrap_or_else(|_| serde_json::from_str(r###"{"keys":{}}"###).unwrap());
-                let keys = data["keys"]
-                    .as_object_mut()
-                    .ok_or_else(|| anyhow::anyhow!("invalid keys file"))?;
                 let access_json: Vec<Value> = access
                     .iter()
                     .map(|a| {
@@ -102,18 +126,17 @@ pub fn handle_server_command(cmd: &ServerCommands) -> anyhow::Result<()> {
                         serde_json::json!({"class": class, "action": action})
                     })
                     .collect();
-                keys.insert(
-                    key.clone(),
-                    serde_json::json!({
-                        "consumer": consumer,
-                        "created_at": chrono::Utc::now().to_rfc3339(),
-                        "access": access_json,
-                    }),
-                );
-                if let Some(parent) = keys_path.parent() {
-                    std::fs::create_dir_all(parent)?;
-                }
-                std::fs::write(&keys_path, serde_json::to_string_pretty(&data)?)?;
+                let new_entry = serde_json::json!({
+                    "consumer": consumer,
+                    "created_at": chrono::Utc::now().to_rfc3339(),
+                    "access": access_json,
+                });
+                // Locked read-merge-write + atomic rename — a `b00t-mcp
+                // --http --llm` server process may be writing this same file
+                // (LlmState::save_keys_to_file) around the same time; without
+                // the lock, whichever of the two writes last would silently
+                // drop the other's key. See #1128.
+                create_key_locked(&keys_path, &key, new_entry)?;
                 eprintln!("✅ Key created for consumer '{}'", consumer);
                 if !access.is_empty() {
                     eprintln!("   Access: {}", access.join(", "));

--- a/b00t-cli/tests/fixtures/lfmf_salvage_cases.json
+++ b/b00t-cli/tests/fixtures/lfmf_salvage_cases.json
@@ -48,9 +48,23 @@
     {
       "name": "empty_topic_salvaged",
       "raw": ": just a body here",
-      "topic": "just a body here",
+      "topic": "just a body…",
       "body": "just a body here",
       "salvage": "empty_part"
+    },
+    {
+      "name": "no_colon_fits_entirely_under_topic_max_934",
+      "raw": "keep secrets out of logs",
+      "topic": "keep secrets out of…",
+      "body": "keep secrets out of logs",
+      "salvage": "no_colon"
+    },
+    {
+      "name": "no_colon_single_word_topic_equals_body_934",
+      "raw": "atomicity",
+      "topic": "atomicity",
+      "body": "atomicity",
+      "salvage": "no_colon"
     },
     {
       "name": "colon_in_body_not_defeated",

--- a/b00t-mcp/Cargo.toml
+++ b/b00t-mcp/Cargo.toml
@@ -62,6 +62,10 @@ notify = "7"
 oauth2 = { version = "5.0", default-features = false, features = ["reqwest", "rustls-tls"] }
 jsonwebtoken = { version = "10.2.0", features = ["rust_crypto"] }
 uuid = { version = "1.0", features = ["v4"] }
+# 🤓 same crate/version b00t-cli/src/erp.rs already uses for advisory file
+#    locking (BashLineQueue) — reused here for server_llm.rs's keys-file
+#    lock, not a new dependency choice.
+fs2 = "0.4"
 base64 = "0.22"
 axum-macros = "0.5"
 lazy_static = "1.5"

--- a/b00t-mcp/src/server_llm.rs
+++ b/b00t-mcp/src/server_llm.rs
@@ -343,6 +343,58 @@ fn load_keys_from_file(keys_file: &std::path::Path) -> HashMap<String, KeyEntry>
     keys
 }
 
+/// Locked, read-merge-write, atomic-rename persist of the keys file — the fix
+/// for #1128 (`LlmState::save_keys_to_file` non-atomic cross-process write
+/// race). Two live processes writing around the same time — two server
+/// instances, or this server plus a separate `b00t server key create`
+/// invocation — no longer silently lose one side's key: the exclusive lock
+/// serializes writers, and re-reading the current on-disk map (via the same
+/// `load_keys_from_file` used at startup/hot-reload) before merging in
+/// `new_keys` means whatever the other writer already persisted survives.
+/// The write itself goes to a temp file then `rename`s over `keys_file`, so
+/// any reader that doesn't take the lock (`reload_if_changed`, the CLI's own
+/// `KeyAction::List`) never observes a partial write.
+fn write_keys_file_locked(
+    keys_file: &std::path::Path,
+    new_keys: &HashMap<String, KeyEntry>,
+) -> std::io::Result<()> {
+    use fs2::FileExt;
+
+    if let Some(parent) = keys_file.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    // Opened purely as a lock target — the actual write goes to a temp file,
+    // this handle is never itself written to or truncated.
+    let lock_file = std::fs::OpenOptions::new().create(true).write(true).open(keys_file)?;
+    lock_file.lock_exclusive()?;
+
+    let mut merged = load_keys_from_file(keys_file);
+    for (k, v) in new_keys {
+        merged.insert(k.clone(), v.clone());
+    }
+
+    let mut map = serde_json::Map::new();
+    for (k, v) in &merged {
+        let access_json: Vec<Value> = v.access.iter().map(|p| json!({
+            "class": p.class,
+            "action": serde_json::to_value(&p.action).unwrap_or(json!("execute")),
+        })).collect();
+        map.insert(k.clone(), json!({
+            "consumer": v.consumer,
+            "created_at": v.created_at.to_rfc3339(),
+            "access": access_json,
+        }));
+    }
+    let data = json!({"keys": map});
+
+    let tmp_path = keys_file.with_extension("json.tmp");
+    std::fs::write(&tmp_path, data.to_string())?;
+    std::fs::rename(&tmp_path, keys_file)?;
+
+    // Lock releases when lock_file drops at function end.
+    Ok(())
+}
+
 impl LlmState {
     pub fn new() -> Self {
         let soul = SoulConfig::load();
@@ -421,25 +473,22 @@ impl LlmState {
         key
     }
 
+    /// Persists this instance's in-memory keys to disk. Delegates to
+    /// `write_keys_file_locked` (locked read-merge-write + atomic rename) so a
+    /// concurrently-running second process (another `b00t-mcp --http --llm`, or
+    /// a `b00t server key create` CLI invocation) never has its own key silently
+    /// dropped by this process overwriting the file from its own stale view.
+    /// See #1128. Locking is blocking I/O, so it runs off the async runtime via
+    /// `spawn_blocking`.
     async fn save_keys_to_file(&self) {
-        let keys = self.keys.read().await;
-        let mut map = serde_json::Map::new();
-        for (k, v) in keys.iter() {
-            let access_json: Vec<Value> = v.access.iter().map(|p| json!({
-                "class": p.class,
-                "action": serde_json::to_value(&p.action).unwrap_or(json!("execute")),
-            })).collect();
-            map.insert(k.clone(), json!({
-                "consumer": v.consumer,
-                "created_at": v.created_at.to_rfc3339(),
-                "access": access_json,
-            }));
+        let keys_file = self.keys_file.clone();
+        let in_memory = self.keys.read().await.clone();
+        let result = tokio::task::spawn_blocking(move || write_keys_file_locked(&keys_file, &in_memory)).await;
+        match result {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => eprintln!("⚠️ save_keys_to_file: {e}"),
+            Err(e) => eprintln!("⚠️ save_keys_to_file: blocking task panicked: {e}"),
         }
-        let data = json!({"keys": map});
-        if let Some(parent) = self.keys_file.parent() {
-            let _ = std::fs::create_dir_all(parent);
-        }
-        let _ = std::fs::write(&self.keys_file, data.to_string());
     }
 
     async fn emit_spotlight(&self, consumer: &str, endpoint: &str, model: &str, latency_ms: u64) {
@@ -837,6 +886,17 @@ mod tests {
         // running — this is the exact scenario the reload-on-mtime-change fix
         // targets (Phase A.2). Writes the same {"keys": {...}} shape
         // commands/server.rs produces, bypassing state.create_key() entirely.
+        //
+        // 🤓 #1113 follow-up: this test was missing the `TempHome` guard every
+        // other test in this module has, so it ran against the REAL `$HOME`.
+        // When it happened to overlap with another thread's TempHome-guarded
+        // test (which temporarily repoints the process-wide `HOME` env var at
+        // a temp dir, then deletes it on Drop), this test could construct its
+        // `LlmState` mid-repoint and then fail its own `keys_file` write with
+        // ENOENT once the other test's temp dir was gone — a real, reproduced
+        // instance of exactly the order/concurrency-dependent flake class
+        // #1113 investigated (the write below failed once, confirming this).
+        let _temp_home = TempHome::new();
         let state = Arc::new(LlmState::from_config("http://localhost:8181/v1", ""));
 
         // Confirm the key genuinely doesn't exist yet (no accidental collision).
@@ -862,6 +922,38 @@ mod tests {
         let entry = state.validate_key(&external_key).await;
         assert!(entry.is_some(), "key written externally must be picked up without restart");
         assert_eq!(entry.unwrap().consumer, "external-process-consumer");
+    }
+
+    /// Regression test for #1128: two `LlmState` instances sharing the same
+    /// `keys_file` (simulating two live processes — e.g. two server instances,
+    /// or this server plus a `b00t server key create` CLI invocation), each
+    /// unaware of the other's key, both call `create_key`. Before the fix,
+    /// the second instance's `save_keys_to_file` blindly overwrote the file
+    /// with only its own in-memory map, silently dropping the first
+    /// instance's key from disk. After the fix (locked read-merge-write),
+    /// both keys must survive on disk.
+    #[tokio::test]
+    async fn test_concurrent_instances_do_not_lose_each_others_keys() {
+        let _temp_home = TempHome::new();
+
+        // Two instances constructed against the same (empty) keys_file — each
+        // has its own independent in-memory `keys` map, exactly as two live
+        // processes would.
+        let instance_a = LlmState::from_config("http://localhost:8181/v1", "");
+        let instance_b = LlmState::from_config("http://localhost:8181/v1", "");
+
+        let key_a = instance_a.create_key("consumer-a", &[]).await;
+        let key_b = instance_b.create_key("consumer-b", &[]).await;
+
+        // Neither instance's own in-memory validate_key was affected by the
+        // other — that was never the bug. The bug is what's actually on disk.
+        let on_disk = load_keys_from_file(&instance_a.keys_file);
+        assert!(
+            on_disk.contains_key(&key_a),
+            "instance A's key must survive on disk after instance B's later write"
+        );
+        assert!(on_disk.contains_key(&key_b), "instance B's key must be on disk");
+        assert_eq!(on_disk.len(), 2, "both keys must coexist, neither overwritten");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- **#1128**: `LlmState::save_keys_to_file` blindly overwrote the shared keys file from its own in-memory map, silently dropping a concurrently-written key from another live process (e.g. two server instances, or this server plus a `b00t server key create` CLI invocation). Fixed via locked (`fs2`) read-merge-write + atomic rename, applied to both the server's write path (`b00t-mcp/src/server_llm.rs`) and the CLI's `KeyAction::Create` (`b00t-cli/src/commands/server.rs`), which writes the same file independently.
- **#1113**: investigated the flaky `test_key_create_and_validate` — could not reproduce the original report (352 prior attempts, zero failures — static analysis shows the code path is structurally immune to the hypothesized race), but found and reproduced the real underlying defect class: `test_key_created_externally_is_picked_up_without_restart` was missing the `TempHome` sandbox guard every other test in the module has, so it raced against the real `$HOME` whenever it overlapped a `TempHome`-guarded test on another thread. Fixed.
- **#998**: `kv_store.rs`'s `test_gate_cache_writes_keys` hardcoded `/tmp/...`, ignoring `TMPDIR` and false-negativing the pre-push gate under disk pressure. Now uses `tempfile::tempdir()`.
- **#934**: `lfmf`'s `auto_topic()` returned the full input verbatim as "topic" whenever a colon-free lesson already fit within `topic_max` tokens, so `"{topic}: {body}"` duplicated the whole lesson. Capped to a short word-prefix + ellipsis when that happens. Re-emitted the one `learn/` entry that was a genuine duplicate (`cargo-workspace-install.md`) — `guard-session-fixtures.md`'s topic was already a legitimate truncated summary, not corruption, confirmed by a prior investigation. Corrected `lfmf.tomllmd`'s tribal-knowledge comment, which had prematurely claimed both files were already fixed.

## Test plan
- [x] `server_llm` tests: 13/13, stable across 5 repeated runs
- [x] `lfmf_salvage_test` fixture test (including 2 new regression cases for #934)
- [x] `kv_store::tests::test_gate_cache_writes_keys` in isolation
- [x] Full workspace test run (b00t-c0re-lib + b00t-cli + b00t-mcp): 0 failures across all real test binaries
- [x] Pre-push gate: 1575 tests passed

Fixes #1128
Fixes #1113
Fixes #998
Fixes #934

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01TiJPJsZZDCoAGAhzkfkk3k