### PR TITLE
fix(b00t-cli): restore pub visibility on non-linux quit fns (#1164)

### DIFF
--- a/b00t-cli/src/commands/quit.rs
+++ b/b00t-cli/src/commands/quit.rs
@@ -153,7 +153,7 @@ pub fn proc_name(pid: u32) -> Result<String> {
 }
 
 #[cfg(not(target_os = "linux"))]
-fn resolve_agent_pid() -> Result<u32> {
+pub fn resolve_agent_pid() -> Result<u32> {
     bail!("b00t quit: unsupported platform (Linux-only command)");
 }
 
@@ -168,7 +168,7 @@ pub fn libc_kill(pid: i32, sig: i32) -> i32 {
 }
 
 #[cfg(not(target_os = "linux"))]
-fn libc_kill(_pid: i32, _sig: i32) -> i32 {
+pub fn libc_kill(_pid: i32, _sig: i32) -> i32 {
     eprintln!("b00t quit: unsupported platform (linux only)");
     -1
 }


### PR DESCRIPTION
## Summary
- `b00t-cli/src/commands/quit.rs` defines `resolve_agent_pid()`/`libc_kill()` twice, split by `#[cfg(target_os = "linux")]`. The Linux branch is `pub`; the non-Linux fallback branch was a plain (private) `fn`.
- Both are called from outside the module — `b00t-cli/src/commands/mcp.rs:418,421,424` and `b00t-cli/src/main.rs:3404,3409,3412` — and neither call site is itself Linux-gated. On macOS the fallback branch is what actually compiles, so those calls hit `E0603: function is private`.
- Fix: add `pub` to the two `#[cfg(not(target_os = "linux"))]` fallback definitions, matching their Linux counterparts. Two-line diff, no logic changes.

Confirmed against real CI: `error[E0603]` on both `x86_64-apple-darwin` and `aarch64-apple-darwin` in `b00t-mcp-npm-release.yml` run 33060585846 (jobs 98478076391, 98478076429), on `origin/main` @ 8d1b260b. Full details in the #1164 update comment: https://github.com/elasticdotventures/_b00t_/issues/1164#issuecomment-5452291740

## Verification
- `cargo check -p b00t-cli` — clean, exit 0 (native Linux build exercises the already-`pub` Linux branch, so this alone can't prove the non-Linux branch compiles — the actual macOS compile can only be confirmed by CI running this PR).
- Full workspace `cargo test` via the pre-push gate — 1575 + 69 passed, 0 failed.

## Test plan
- [ ] CI green on this PR
- [ ] `b00t-mcp-npm-release.yml`'s `Build x86_64-apple-darwin` / `Build aarch64-apple-darwin` jobs pass once merged

Fixes #1164 (macOS half of it — the Windows UnixListener/UnixStream half is a separate PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TiJPJsZZDCoAGAhzkfkk3k