### PR TITLE
fix(b00t-chat): gate UnixListener/UnixStream behind #[cfg(unix)] (#1164)

### DIFF
--- a/b00t-cli/src/commands/chat.rs
+++ b/b00t-cli/src/commands/chat.rs
@@ -130,20 +130,35 @@ impl ChatCommands {
         println!("📡 Available transports: local, nats (stub)");
         // Check if socket exists and whether a listener is active
         if socket.exists() {
-            // Attempt a probe connect (0.2s timeout) to distinguish live vs stale
-            let probe = tokio::time::timeout(
-                std::time::Duration::from_millis(200),
-                tokio::net::UnixStream::connect(&socket),
-            )
-            .await;
-            match probe {
-                Ok(Ok(_)) => println!("✅ Socket active — listener is running"),
-                Ok(Err(_)) | Err(_) => {
-                    println!(
-                        "⚠️  Socket file exists but no listener responds. \
-                         Run `b00t-mcp` or `b00t hive activate` to start one."
-                    );
+            // 🤓 `tokio::net::UnixStream` is #[cfg(unix)]-gated upstream — this
+            // probe previously called it unconditionally, which never actually
+            // compiled on Windows. Local-socket chat has no equivalent there,
+            // so the non-unix branch skips the live-probe and just reports the
+            // stat result (NATS transport is unaffected on any platform).
+            #[cfg(unix)]
+            {
+                // Attempt a probe connect (0.2s timeout) to distinguish live vs stale
+                let probe = tokio::time::timeout(
+                    std::time::Duration::from_millis(200),
+                    tokio::net::UnixStream::connect(&socket),
+                )
+                .await;
+                match probe {
+                    Ok(Ok(_)) => println!("✅ Socket active — listener is running"),
+                    Ok(Err(_)) | Err(_) => {
+                        println!(
+                            "⚠️  Socket file exists but no listener responds. \
+                             Run `b00t-mcp` or `b00t hive activate` to start one."
+                        );
+                    }
                 }
+            }
+            #[cfg(not(unix))]
+            {
+                println!(
+                    "⚠️  Local-socket chat transport is not supported on this platform. \
+                     Use `--transport nats` instead."
+                );
             }
         } else {
             println!("ℹ️  Socket does not exist yet (no b00t-mcp process started)");

--- a/b00t-lib-chat/src/server.rs
+++ b/b00t-lib-chat/src/server.rs
@@ -6,15 +6,29 @@ use std::{
     sync::Arc,
 };
 
-use chrono::Utc;
-use tokio::{
-    io::{AsyncBufReadExt, BufReader},
-    net::{UnixListener, UnixStream},
-    sync::Mutex,
-};
-use tracing::{debug, error, info};
+use tokio::sync::Mutex;
 
-use crate::{error::ChatResult, message::ChatMessage, transport::default_socket_path};
+use crate::{error::ChatResult, message::ChatMessage};
+
+// 🤓 `tokio::net::UnixListener`/`UnixStream` are #[cfg(unix)]-gated upstream —
+// this crate previously imported them unconditionally, which never actually
+// compiled on Windows. Unlike agent_manager.rs's optional side-channel
+// listener, this local chat server is a real accept loop with real socket
+// I/O, so there's no meaningful unit-type placeholder to hand back on
+// non-unix; the accept loop, connection handler, and bind itself are all
+// gated `#[cfg(unix)]` and callers get a runtime error instead (see the
+// `#[cfg(not(unix))]` twin of `spawn_local_server` below).
+// `ChatTransportKind::Nats` remains fully functional on all platforms.
+#[cfg(unix)]
+use chrono::Utc;
+#[cfg(unix)]
+use tokio::io::{AsyncBufReadExt, BufReader};
+#[cfg(unix)]
+use tokio::net::{UnixListener, UnixStream};
+#[cfg(unix)]
+use tracing::{debug, error, info};
+#[cfg(unix)]
+use crate::transport::default_socket_path;
 
 /// Shared inbox that stores unread chat messages.
 #[derive(Debug, Clone)]
@@ -58,6 +72,7 @@ impl LocalChatServer {
 }
 
 /// Spawn the async listener for the default socket path.
+#[cfg(unix)]
 pub async fn spawn_local_server(inbox: ChatInbox) -> ChatResult<LocalChatServer> {
     let socket_path = default_socket_path()?;
     if socket_path.exists() {
@@ -78,6 +93,18 @@ pub async fn spawn_local_server(inbox: ChatInbox) -> ChatResult<LocalChatServer>
     Ok(LocalChatServer { socket_path })
 }
 
+/// Non-unix twin: local Unix-socket chat transport has no equivalent on this
+/// platform, so this returns a runtime error rather than binding anything.
+/// Callers that need cross-platform chat should use `ChatTransportKind::Nats`.
+#[cfg(not(unix))]
+pub async fn spawn_local_server(_inbox: ChatInbox) -> ChatResult<LocalChatServer> {
+    Err(crate::error::ChatError::Other(
+        "local Unix-socket chat transport is not supported on this platform; use NATS transport instead"
+            .to_string(),
+    ))
+}
+
+#[cfg(unix)]
 async fn run_accept_loop(listener: UnixListener, inbox: ChatInbox) {
     loop {
         match listener.accept().await {
@@ -97,6 +124,7 @@ async fn run_accept_loop(listener: UnixListener, inbox: ChatInbox) {
     }
 }
 
+#[cfg(unix)]
 async fn handle_connection(stream: UnixStream, inbox: ChatInbox) -> ChatResult<()> {
     let reader = BufReader::new(stream);
     let mut lines = reader.lines();

--- a/b00t-lib-chat/src/transport.rs
+++ b/b00t-lib-chat/src/transport.rs
@@ -7,8 +7,17 @@ use std::{
 
 use async_nats::ConnectOptions;
 use futures::StreamExt;
-use tokio::{fs, io::AsyncWriteExt, net::UnixStream, time::timeout};
 use tracing::{debug, info, warn};
+
+// 🤓 `tokio::net::UnixStream` is #[cfg(unix)]-gated upstream — this crate
+// previously imported it unconditionally, which never actually compiled on
+// Windows. `LocalSocketTransport::send` does real socket I/O over it (no
+// meaningful placeholder value like agent_manager.rs's optional listener),
+// so it gets a `#[cfg(not(unix))]` twin that returns a runtime `ChatError`
+// instead. `ChatTransportKind::Nats` remains fully functional on all
+// platforms — only the `LocalSocket` path is affected.
+#[cfg(unix)]
+use tokio::{fs, io::AsyncWriteExt, net::UnixStream, time::timeout};
 
 use crate::{
     error::{ChatError, ChatResult},
@@ -191,6 +200,7 @@ impl LocalSocketTransport {
         Ok(Self { socket_path })
     }
 
+    #[cfg(unix)]
     async fn ensure_parent_dir(path: &Path) -> ChatResult<()> {
         if let Some(parent) = path.parent() {
             if !parent.exists() {
@@ -200,6 +210,7 @@ impl LocalSocketTransport {
         Ok(())
     }
 
+    #[cfg(unix)]
     pub async fn send(&self, message: &ChatMessage) -> ChatResult<()> {
         Self::ensure_parent_dir(&self.socket_path).await?;
         let payload = serde_json::to_vec(message)?;
@@ -220,6 +231,18 @@ impl LocalSocketTransport {
         stream.write_all(b"\n").await?;
         stream.flush().await?;
         Ok(())
+    }
+
+    /// Non-unix twin: no Unix-domain-socket equivalent exists on this
+    /// platform, so sending over the local socket transport fails at
+    /// runtime rather than at compile time. Use `ChatTransportKind::Nats`
+    /// for cross-platform chat delivery.
+    #[cfg(not(unix))]
+    pub async fn send(&self, _message: &ChatMessage) -> ChatResult<()> {
+        Err(ChatError::Other(
+            "local Unix-socket chat transport is not supported on this platform; use NATS transport instead"
+                .to_string(),
+        ))
     }
 
     pub fn socket_path(&self) -> &Path {


### PR DESCRIPTION
## Summary
PR #1166 fixed the `tokio::net::UnixListener` #[cfg(unix)]-gating bug in `b00t-c0re-lib/src/agent_manager.rs`, but the same bug class was left in a separate crate: `b00t-lib-chat` (Cargo package `b00t-chat`) and `b00t-cli/src/commands/chat.rs` both imported `tokio::net::UnixListener`/`UnixStream` unconditionally — those types are `#[cfg(unix)]`-gated upstream in tokio, so `b00t-chat` never compiled on Windows.

Confirmed against real CI: `error[E0432]: unresolved imports` / `could not compile \`b00t-chat\` (lib)` on both `x86_64-pc-windows-msvc` and `aarch64-pc-windows-msvc` in `b00t-mcp-npm-release.yml` run 33060585846 (jobs 98478076510, 98478076624), on `origin/main` @ 8d1b260b. Full details in the #1164 update comment: https://github.com/elasticdotventures/_b00t_/issues/1164#issuecomment-5452291740

## Fix
Unlike `agent_manager.rs`'s optional side-channel listener (which could use an inert `type UnixListener = ();` placeholder), `b00t-lib-chat` is a real local chat transport doing real socket I/O — no placeholder value makes sense. Instead, the local-socket path is split `#[cfg(unix)]`/`#[cfg(not(unix))]`, with the non-unix branch returning a runtime error rather than failing to compile:

- **`server.rs`** — `spawn_local_server`, `run_accept_loop`, `handle_connection`, and their imports are `#[cfg(unix)]`; a `#[cfg(not(unix))]` twin of `spawn_local_server` returns `ChatError::Other("local Unix-socket chat transport is not supported on this platform; use NATS transport instead")`.
- **`transport.rs`** — `LocalSocketTransport::send`/`ensure_parent_dir` get the same split; the non-unix `send` twin returns the same runtime error.
- **`chat.rs`** — the live-socket probe in `show_info()` is wrapped in `#[cfg(unix)]`/`#[cfg(not(unix))]`, the latter skipping the probe and printing a one-line platform note.

`ChatTransportKind::Nats`/`RealNatsTransport` are completely untouched and remain fully functional on every platform — only the `LocalSocket` path needed gating.

## Verification
- `cargo check -p b00t-chat -p b00t-cli` — clean, exit 0 (native Linux build exercises the `#[cfg(unix)]` branch, proving the unix path is unchanged and still compiles; can't itself prove the Windows branch compiles — only real Windows CI can confirm that, same caveat as PR #1166).
- `cargo test -p b00t-chat` — all pass (including the real `two_node_mesh_discovers_and_exchanges` NATS integration test and doctests).
- Full workspace `cargo test` via the pre-push gate — 1575 + 69 passed, 0 failed.

## Test plan
- [ ] CI green on this PR
- [ ] `b00t-mcp-npm-release.yml`'s `Build x86_64-pc-windows-msvc` / `Build aarch64-pc-windows-msvc` jobs pass once merged

Fixes #1164 (Windows half of it — the macOS `quit.rs` half is #1168).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TiJPJsZZDCoAGAhzkfkk3k