### PR TITLE
docs(agents): make CARGO_TARGET_DIR coordination explicit in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -244,6 +244,25 @@ edges (submodule init, shared target-dir, tmpfs contention), and fixes all live 
 datum — MUST `b00t learn worktree` before the first `git`/`cargo` command against any
 bare/worktree-layout repo rather than rediscovering them the hard way.
 
+**CARGO_TARGET_DIR is not optional (amended 2026-08-28):** every worktree defaults to
+its own `target/`, and this workspace's cold-build cost is ~10-20GB per worktree (gemm,
+embed-anything, and friends are huge). Two agents building in two worktrees without
+this shares nothing and burns disk twice for identical dependency artifacts — caught
+live: two concurrent fix worktrees for elasticdotventures/_b00t_#1164 each cold-built
+their own `target/` (21GB + 18GB) because neither set the var before its first `cargo`
+call. Before any `cargo check`/`build`/`test` in a worktree:
+```
+export CARGO_TARGET_DIR="$HOME/.cache/b00t-cargo-target"
+```
+(or source `scripts/lib/worktree-env.sh` and call `b00t_shared_cargo_target_dir` — same
+default, already wired for hive tooling). Every worktree of this repo then reuses one
+shared, already-compiled dependency cache instead of paying the cold-build cost again.
+Coordinating agents (parallel sub-agents, hive peers) MUST use this same shared path,
+not a per-worktree or per-agent one — that's the whole point: one cache, not N. Stays a
+per-shell env var, never a checked-in `.cargo/config.toml` — CI runs as a different user
+with no writable `$HOME/.cache`, and a committed absolute `target-dir` breaks its build
+(hit in elasticdotventures/_b00t_#964).
+
 ## SeaORM Migration Sharp Edges (recorded 2026-08-07)
 
 TLDR: before writing a SeaORM Postgres migration that does `CREATE EXTENSION`/


### PR DESCRIPTION
## Summary
- `AGENTS.md`'s "Worktree Discipline" section already pointed at `b00t learn worktree` for the "shared target-dir" detail — but that pointer was too easy to skip in practice.
- Caught live this session: two concurrent fix worktrees for #1164 each ran their first `cargo check` without setting `CARGO_TARGET_DIR`, so each cold-built its own `target/` from scratch — 21GB + 18GB, ~39GB of duplicated, byte-identical dependency artifacts (gemm, embed-anything, etc. are huge in this workspace) for no reason other than the shared-cache step being buried in a datum rather than stated in AGENTS.md itself.
- Fix: promote the actual `export CARGO_TARGET_DIR="$HOME/.cache/b00t-cargo-target"` line (and the `b00t_shared_cargo_target_dir` helper in `scripts/lib/worktree-env.sh`, which already existed and already does exactly this) directly into AGENTS.md's Worktree Discipline section, so it's impossible for a fast-moving or parallel agent to miss.
- Explicitly calls out that coordinating/parallel agents MUST use the *same* shared path — the whole point is one cache, not one per agent — and repeats the existing warning that this must stay a per-shell env var, never a checked-in `.cargo/config.toml` (CI runs as a different user with no writable `$HOME/.cache`; a committed absolute path broke CI once already, #964).

Docs-only change, no code touched.

## Test plan
- [x] Dogfooded the new instruction while preparing this PR itself: set `CARGO_TARGET_DIR` before `git commit`/`git push`, pre-push gate correctly reported "no Rust packages affected — skipping test gate" for this docs-only diff.
- [ ] Next worktree-based agent session confirms it reuses `~/.cache/b00t-cargo-target` instead of cold-building its own `target/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TiJPJsZZDCoAGAhzkfkk3k