### PR TITLE
fix(ci): aarch64 cross-toolchain apt sources + Windows cfg(unix) gaps (#1164)

### DIFF
--- a/.github/workflows/b00t-mcp-npm-release.yml
+++ b/.github/workflows/b00t-mcp-npm-release.yml
@@ -77,7 +77,26 @@ jobs:
       - name: 🔧 Install cross-compilation toolchain
         if: matrix.target == 'aarch64-unknown-linux-gnu'
         run: |
+          # 🤓 Ubuntu splits arm64 packages onto ports.ubuntu.com — the
+          # runner's default sources (archive/security.ubuntu.com) only
+          # host amd64/i386. Once `dpkg --add-architecture arm64` enables
+          # the arch, an unrestricted `apt-get update` tries (and 404s)
+          # fetching arm64 Packages indices from those amd64-only mirrors,
+          # exiting 100 before ever reaching `apt-get install`. Restrict
+          # the existing sources to amd64 (handling both the deb822
+          # ubuntu.sources format Ubuntu 24.04 runners default to, and the
+          # classic one-line sources.list some images still use) and add a
+          # dedicated ports.ubuntu.com source for arm64.
           sudo dpkg --add-architecture arm64
+          CODENAME=$(. /etc/os-release && echo "$VERSION_CODENAME")
+          if [ -f /etc/apt/sources.list.d/ubuntu.sources ]; then
+            sudo sed -i '/^Types: deb$/a Architectures: amd64' /etc/apt/sources.list.d/ubuntu.sources
+          fi
+          if [ -s /etc/apt/sources.list ]; then
+            sudo sed -i -E 's/^deb(-src)? /deb\1 [arch=amd64] /' /etc/apt/sources.list
+          fi
+          printf 'deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports %s main universe restricted multiverse\ndeb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports %s-updates main universe restricted multiverse\ndeb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports %s-security main universe restricted multiverse\n' \
+            "$CODENAME" "$CODENAME" "$CODENAME" | sudo tee /etc/apt/sources.list.d/arm64-ports.list
           sudo apt-get update
           sudo apt-get install -y \
             gcc-aarch64-linux-gnu \

--- a/b00t-cli/src/commands/hive.rs
+++ b/b00t-cli/src/commands/hive.rs
@@ -553,7 +553,7 @@ pub fn handle_hive_command(cmd: &HiveCommands, path: &str) -> Result<()> {
 fn handle_cyber_command(cmd: &HiveCyberCommands) -> Result<()> {
     match cmd {
         HiveCyberCommands::RingFence { json } => {
-            let is_root = unsafe { libc::geteuid() == 0 };
+            let is_root = crate::commands::ringfence_cmd::is_root();
             let mode = if is_root { "OS_ROOT" } else { "OS_GUEST" };
 
             if *json {

--- a/b00t-cli/src/commands/init.rs
+++ b/b00t-cli/src/commands/init.rs
@@ -99,6 +99,7 @@ primary_stack = "{primary_stack}"
 
         // Symlink into _b00t_/ for visibility
         let b00t_boot = b00t_dir.join("🥾.tomllmd");
+        #[cfg(unix)]
         std::os::unix::fs::symlink(&git_boot, &b00t_boot).ok();
         println!("  🔗 linked {}", b00t_boot.display());
     }

--- a/b00t-cli/src/commands/ringfence_cmd.rs
+++ b/b00t-cli/src/commands/ringfence_cmd.rs
@@ -25,9 +25,19 @@ pub fn handle_ringfence_command(cmd: &RingFenceCommands) -> Result<()> {
 }
 
 /// Check if we are running as root (UID 0).
-fn is_root() -> bool {
+#[cfg(unix)]
+pub(crate) fn is_root() -> bool {
     // SAFETY: geteuid(2) is a trivial syscall with no side effects.
     unsafe { libc::geteuid() == 0 }
+}
+
+/// Non-unix: no UID 0 concept, and `has_cap_sys_admin` below already reads
+/// Linux's /proc/self/status — this whole ring-fence trust-boundary model
+/// is inherently Linux-specific, so non-unix just reports "not root"
+/// rather than failing to compile.
+#[cfg(not(unix))]
+pub(crate) fn is_root() -> bool {
+    false
 }
 
 /// Check if the process has CAP_SYS_ADMIN by reading /proc/self/status.

--- a/b00t-cli/src/commands/up.rs
+++ b/b00t-cli/src/commands/up.rs
@@ -582,8 +582,14 @@ fn up_repo(path: &str, dry_run: bool) -> Result<()> {
             }
         }
 
+        #[cfg(unix)]
         std::os::unix::fs::symlink(src, &link_path)
             .with_context(|| format!("Cannot create symlink: {}", link_path.display()))?;
+        #[cfg(not(unix))]
+        anyhow::bail!(
+            "Cannot register datum {}: symlink-based registration is not supported on this platform yet",
+            link_path.display()
+        );
         println!("   → {}", link_name);
         registered += 1;
     }


### PR DESCRIPTION
## Summary
Two fixes, both discovered/verified against real `b00t-mcp-npm-release.yml` `workflow_dispatch` runs (publish disabled) rather than guessed:

**1. `aarch64-unknown-linux-gnu`: apt-get 404 on arm64 indices**
`sudo dpkg --add-architecture arm64` followed by an unrestricted `sudo apt-get update` tries fetching arm64 Packages indices from `archive`/`security.ubuntu.com` — those mirrors only host amd64/i386, arm64 lives on `ports.ubuntu.com`. Confirmed against run 33060585846 (job 98478076483): `E: Failed to fetch https://security.ubuntu.com/.../binary-arm64/Packages 404 Not Found`, exit code 100, before ever reaching `apt-get install`.

Fix: restrict the runner's existing sources to amd64 (handles both the deb822 `ubuntu.sources` format Ubuntu 24.04 runners default to, and classic `sources.list`), and add a dedicated `ports.ubuntu.com` source for arm64.

**2. Windows (`x86_64`/`aarch64-pc-windows-msvc`): 4 more `#[cfg(unix)]` gaps in `b00t-cli`**
Once fix #1 unblocked `aarch64-unknown-linux-gnu`, both Windows targets — for the first time ever actually reaching `cargo build` for `b00t-cli` — hit `error[E0433]: cannot find \`unix\` in \`os\`` / `error[E0425]: cannot find function \`geteuid\` in crate \`libc\``, `could not compile \`b00t-cli\` (lib)`. Same bug class as #1166/#1168/#1169 (Unix-only API used unconditionally), four call sites, never previously caught because nothing in this workflow got this far before:

- `ringfence_cmd.rs::is_root()` — `#[cfg(unix)]` real `geteuid(2)` check + `#[cfg(not(unix))]` `false` fallback (the whole ring-fence trust-boundary feature is already Linux-specific in practice — `has_cap_sys_admin()` reads `/proc/self/status`).
- `hive.rs`'s `handle_cyber_command` duplicated that exact `geteuid()` logic inline instead of calling `ringfence_cmd::is_root()` — fixed the Windows build and the duplication together by making `is_root()` `pub(crate)` and reusing it.
- `init.rs`'s best-effort `.ok()`-discarded symlink → `#[cfg(unix)]` only, same effective non-unix behavior (silently skipped, as any failed unix symlink already was).
- `up.rs`'s datum-registration symlink (result IS propagated via `?`) → `#[cfg(unix)]` real symlink, `#[cfg(not(unix))]` a clear runtime `bail!` rather than inventing untested copy-fallback semantics.

## Verification
- `cargo check -p b00t-cli` — clean, exit 0, native Linux (exercises the `#[cfg(unix)]` branches).
- Full workspace `cargo test` via the pre-push gate — 1575 + 69 passed, 0 failed.
- **Real CI, twice**: first `workflow_dispatch` run (33179613112) confirmed the apt-sources fix alone — `aarch64-unknown-linux-gnu` went green, both Windows targets then failed on the new `#[cfg(unix)]` errors above. Second `workflow_dispatch` run (33182327765), after fix #2, all 6 `build-binaries` matrix jobs (`x86_64`/`aarch64` × `linux-gnu`/`apple-darwin`/`pc-windows-msvc`) passed.

## Note: separate, pre-existing bug surfaced (not fixed here, out of scope)
That same second run's downstream `📦 Publish to NPM` job failed — `npm ci`: `b00t-mcp-npm/package-lock.json` doesn't exist in the repo. This has nothing to do with either fix above; it was simply never reachable before because `build-binaries` always failed first. Filing separately, not fixing here — different bug class (npm lockfile, not Rust cross-compilation), and this PR is already touching two distinct things.

## Test plan
- [x] `workflow_dispatch` run 33182327765: all 6 build-binaries jobs green
- [ ] CI green on this PR itself once opened

Fixes the aarch64/Windows-build-matrix half of #1164 — the npm-publish lockfile issue needs its own follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TiJPJsZZDCoAGAhzkfkk3k