### PR TITLE
fix(b00t-mcp-npm): correct install.js prebuilt-binary lookup and cargo fallback

### DIFF
--- a/b00t-mcp-npm/scripts/install.js
+++ b/b00t-mcp-npm/scripts/install.js
@@ -65,7 +65,7 @@ async function installFromGitHubReleases(target) {
   
   const extension = platform === 'win32' ? '.exe' : '';
   const binaryName = `b00t-mcp${extension}`;
-  const archiveName = `b00t-${target}.tar.gz`;
+  const archiveName = `b00t-mcp-${target}.tar.gz`;
   
   // 🤓 GitHub releases pattern following b00t conventions
   const releaseUrl = `https://github.com/elasticdotventures/dotfiles/releases/download/v${version}/${archiveName}`;
@@ -98,7 +98,7 @@ async function installFromGitHubReleases(target) {
       const tar = require('tar');
       const extractStream = tar.extract({
         cwd: path.join(__dirname, '..', 'bin'),
-        strip: 1
+        strip: 0
       });
       
       response.pipe(extractStream);
@@ -122,7 +122,7 @@ function extractLocalArchive(archivePath, binaryName) {
     const tar = require('tar');
     const extractStream = tar.extract({
       cwd: path.join(__dirname, '..', 'bin'),
-      strip: 1
+      strip: 0
     });
 
     const readStream = fs.createReadStream(archivePath);
@@ -172,7 +172,7 @@ async function installFromCargo() {
 
   // Install with timeout and resource limits
   try {
-    execSync('cargo install --git https://github.com/elasticdotventures/dotfiles --bin b00t-mcp --root .', {
+    execSync('cargo install --git https://github.com/elasticdotventures/dotfiles b00t-mcp --bin b00t-mcp --root .', {
       cwd: path.join(__dirname, '..'),
       stdio: 'inherit',
       env: cargoEnv,


### PR DESCRIPTION
## Summary

`npm ci` in the `b00t-mcp-npm-release.yml` npm-publish job fails every time (`preinstall` → `scripts/install.js` → all three install strategies fail). Three independent bugs were compounding:

- **Archive filename mismatch**: `install.js` looked for `b00t-<target>.tar.gz`, but the release workflow builds and organizes artifacts as `b00t-mcp-<target>.tar.gz` — so the prebuilt binary already staged in `releases/` a few steps earlier was never found, even though it was right there.
- **Broken tar extraction**: `tar.extract({ strip: 1 })` assumes a wrapping directory in the archive, but the workflow tars the bare binary with no wrapping dir (`cd target/<target>/release && tar -czf ...`). `strip: 1` silently drops the file — no error, empty output.
- **Ambiguous `cargo install --git`**: `--bin b00t-mcp` alone doesn't disambiguate a package in a multi-binary workspace when installing from a git source — cargo scans every `Cargo.toml` in the repo and needs the crate name passed positionally. This produced the observed `error: multiple packages with binaries found: b00t-admin, b00t-ast, ... b00t-mcp ...`.

All three were verified independently, not just read from source:
- Filename mismatch confirmed by diffing against the workflow's actual archive/artifact names.
- The `strip` bug reproduced with a real `tar` archive built the same way the workflow builds it (bare binary, no wrapping dir) — `strip=1` produced an empty output dir with no error; `strip=0` extracted correctly.
- The cargo ambiguity reproduced locally against a clone of this monorepo with `--bin` only (exact same error text as CI); adding the positional package name (`cargo install --git <url> b00t-mcp --bin b00t-mcp --root .`) resolved it and cargo proceeded to compile.

## Test plan

- [ ] `npm-publish` job's `npm ci` step (which runs `preinstall` → `install.js`) succeeds in CI using the prebuilt binary from `releases/`, without falling through to the cargo/source strategies
- [ ] `npm test` step still passes
- [ ] Manually verify `bin/b00t-mcp --version` works after install in a clean environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TiJPJsZZDCoAGAhzkfkk3k