### PR TITLE
feat(b00t-cli): agent-scoped token issuance (datum shard pilot)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,6 +85,23 @@ b00t-datum-core = { path = "b00t-datum-core" }
 b00t-zellij = { path = "b00t-zellij" }
 b00t-admin = { path = "b00t-admin" }
 b00t-reflect-types = { path = "vendor/ledgrrr/crates/b00t-reflect-types" }
+# ledger-core — used by b00t-cli's agent_token module to record agent-scoped
+# token issuance as a real double-entry accounting transaction (see
+# docs/superpowers/specs/2026-08-22-agent-scoped-token-issuance.md).
+ledger-core = { path = "vendor/ledgrrr/crates/ledger-core" }
+# Transitive `workspace = true` deps pulled in by ledger-core (and its own
+# path-dependency arc-kit-au) that b00t's workspace didn't previously
+# define — versions mirror vendor/ledgrrr/Cargo.toml's own
+# [workspace.dependencies] so ledger-core's code compiles against the same
+# API surface it was written/tested against.
+rust_xlsxwriter = "0.94.0"
+rust_decimal = { version = "1.41.0", features = ["serde"] }
+blake3 = "1.8.3"
+tempfile = "3"
+z3 = "0.8"
+kasuari = "0.4"
+statig = "0.4"
+ordered-float = { version = "4", features = ["serde"] }
 mti = "1.1.1"
 
 

--- a/b00t-cli/Cargo.toml
+++ b/b00t-cli/Cargo.toml
@@ -67,6 +67,7 @@ opentelemetry.workspace = true
 uuid = { version = "1.0", features = ["v4"] }
 mti.workspace = true
 b00t-reflect-types.workspace = true
+ledger-core.workspace = true
 fs2 = "0.4"
 confy = "2.0"
 libc = "0.2"

--- a/b00t-cli/src/agent_token.rs
+++ b/b00t-cli/src/agent_token.rs
@@ -1,0 +1,611 @@
+//! Agent-scoped token issuance — pilot, `datum` shard-type only.
+//!
+//! See `docs/superpowers/specs/2026-08-22-agent-scoped-token-issuance.md`
+//! for the full design. Orchestrates: check cake/budget → ensure a k8s
+//! ServiceAccount+RoleBinding exist → mint a scoped token via k8s
+//! TokenRequest → record the issuance as a ledger-core double-entry
+//! accounting transaction → return the token.
+//!
+//! Enforcement (Component 4) lives in `crate::commands::datum` via the
+//! `--as-agent-token` flag, which calls [`authorize_datum_shard_token`].
+
+use anyhow::{Context, Result, bail};
+use k8s_openapi::api::authentication::v1::{TokenRequest, TokenRequestSpec, TokenReview, TokenReviewSpec};
+use k8s_openapi::api::core::v1::{Namespace, ServiceAccount};
+use k8s_openapi::api::rbac::v1::{ClusterRole, RoleBinding, RoleRef, Subject};
+use kube::Client;
+use kube::api::{Api, ObjectMeta, PostParams};
+use std::path::PathBuf;
+
+use crate::cake_ledger::CakeLedger;
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/// Namespace all agent ServiceAccounts/RoleBindings live in.
+pub const AGENTS_NAMESPACE: &str = "b00t-agents";
+
+/// Marker ClusterRole name — Component 4's TokenReview check looks for a
+/// RoleBinding naming this Role, it grants no real k8s API access itself.
+pub const ROLE_SHARD_DATUM: &str = "role-shard-datum";
+
+/// Token lifetime for minted agent tokens (15 minutes).
+pub const TOKEN_TTL_SECONDS: i64 = 15 * 60;
+
+/// Embedded YAML for the `role-shard-datum` marker ClusterRole. Since
+/// datum data is not migrated into k8s-native resources (deliberate scope
+/// decision — the datum store stays wherever it already lives), this
+/// Role's `rules` grant no meaningful k8s API access; its real job is
+/// being *bound to* via RoleBinding, not granting access itself. Applied
+/// (idempotent create-if-missing) by [`request_agent_token`] the first
+/// time it's needed — no manual `kubectl apply` step required.
+pub const ROLE_SHARD_DATUM_YAML: &str = r#"
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: role-shard-datum
+  labels:
+    app.kubernetes.io/managed-by: b00t
+    b00t.elastic.ventures/shard-type: datum
+rules:
+  # Harmless, self-referential permission — this Role's real job is being
+  # *bound to*, not granting k8s API access.
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources: ["clusterroles"]
+    resourceNames: ["role-shard-datum"]
+    verbs: ["get"]
+"#;
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/// Request parameters for [`request_agent_token`].
+#[derive(Debug, Clone)]
+pub struct AgentTokenRequest {
+    pub agent_id: String,
+    /// e.g. `"datum:some-datum-id"` — only the `datum` shard-type is
+    /// supported by this pilot; other shard-type prefixes are rejected.
+    pub shard_ref: String,
+    pub cost: i64,
+}
+
+/// Successful issuance result.
+#[derive(Debug, Clone)]
+pub struct AgentTokenIssuance {
+    pub token: String,
+    pub tx_id: String,
+    pub expires_in_seconds: i64,
+    pub remaining_balance: i64,
+}
+
+/// Identity + authorization result from [`authorize_datum_shard_token`].
+#[derive(Debug, Clone)]
+pub struct AuthorizedIdentity {
+    pub username: String,
+    pub namespace: String,
+    pub service_account_name: String,
+}
+
+// ---------------------------------------------------------------------------
+// Ledger path
+// ---------------------------------------------------------------------------
+
+/// Dedicated journal file for agent-token issuance — deliberately separate
+/// from any real tax-ledger data (never mix pilot/test data with real
+/// financial records).
+pub fn default_ledger_path() -> Result<PathBuf> {
+    let home = dirs::home_dir().context("resolve home directory")?;
+    Ok(home.join(".b00t").join("ledger").join("agent-tokens.beancount"))
+}
+
+// ---------------------------------------------------------------------------
+// Component 1: issuance flow
+// ---------------------------------------------------------------------------
+
+/// Full issuance flow (Components 1 + 2 + 3).
+///
+/// **Fail-before-privilege ordering is load-bearing**: the cake balance
+/// check happens strictly before any k8s client is constructed or any k8s
+/// API call is made. Only the `datum` shard-type is supported in this
+/// pilot.
+pub async fn request_agent_token(req: AgentTokenRequest) -> Result<AgentTokenIssuance> {
+    anyhow::ensure!(req.cost >= 0, "cost must be non-negative, got {}", req.cost);
+    anyhow::ensure!(
+        req.shard_ref.starts_with("datum:"),
+        "only the 'datum' shard-type is supported by this pilot; got shard-ref '{}'",
+        req.shard_ref
+    );
+
+    // --- 1. Budget check — MUST happen before any k8s API interaction. ---
+    let ledger = CakeLedger::open().context("open cake ledger")?;
+    let balance = ledger.balance(&req.agent_id).context("check cake balance")?;
+    if balance < req.cost {
+        bail!(
+            "insufficient budget for agent '{}': have {} cake, need {}",
+            req.agent_id,
+            balance,
+            req.cost
+        );
+    }
+
+    // --- 2. k8s client (only reached once budget is confirmed). ---
+    let client = Client::try_default().await.context("connect to k8s cluster")?;
+
+    // --- 3. Ensure namespace + ServiceAccount. ---
+    ensure_namespace(&client, AGENTS_NAMESPACE).await?;
+    let sa_name = service_account_name(&req.agent_id);
+    ensure_service_account(&client, AGENTS_NAMESPACE, &sa_name).await?;
+
+    // --- 4. Ensure the marker ClusterRole exists. ---
+    ensure_role_shard_datum(&client).await?;
+
+    // --- 5. Ensure the RoleBinding. ---
+    ensure_role_binding(&client, AGENTS_NAMESPACE, &sa_name).await?;
+
+    // --- 6. Mint a short-lived, scoped token. ---
+    let token = mint_token(&client, AGENTS_NAMESPACE, &sa_name).await?;
+
+    // --- 7. Record the issuance in ledger-core; debit cake. ---
+    let tx_id = format!("agent-token-{}", uuid::Uuid::new_v4());
+    let date = chrono::Utc::now().format("%Y-%m-%d").to_string();
+    let entry = ledger_core::journal::JournalTransaction::from_agent_token_issuance(
+        &req.agent_id,
+        &req.shard_ref,
+        &req.cost.to_string(),
+        tx_id.clone(),
+        date,
+    );
+    let ledger_path = default_ledger_path()?;
+    if let Some(parent) = ledger_path.parent() {
+        std::fs::create_dir_all(parent).context("create ledger directory")?;
+    }
+    ledger_core::journal::append_entries(&ledger_path, std::slice::from_ref(&entry))
+        .context("append agent-token journal entry")?;
+
+    let remaining_balance = ledger
+        .debit(&req.agent_id, req.cost)
+        .context("debit cake balance")?;
+
+    Ok(AgentTokenIssuance {
+        token,
+        tx_id,
+        expires_in_seconds: TOKEN_TTL_SECONDS,
+        remaining_balance,
+    })
+}
+
+pub fn service_account_name(agent_id: &str) -> String {
+    format!("agent-{}", agent_id)
+}
+
+fn role_binding_name(sa_name: &str) -> String {
+    format!("{}-role-shard-datum", sa_name)
+}
+
+// ---------------------------------------------------------------------------
+// k8s helpers — idempotent create-if-missing
+// ---------------------------------------------------------------------------
+
+fn is_conflict(err: &kube::Error) -> bool {
+    matches!(err, kube::Error::Api(e) if e.code == 409)
+}
+
+async fn ensure_namespace(client: &Client, namespace: &str) -> Result<()> {
+    let api: Api<Namespace> = Api::all(client.clone());
+    if api.get(namespace).await.is_ok() {
+        return Ok(());
+    }
+    let ns = Namespace {
+        metadata: ObjectMeta {
+            name: Some(namespace.to_string()),
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    match api.create(&PostParams::default(), &ns).await {
+        Ok(_) => Ok(()),
+        Err(e) if is_conflict(&e) => Ok(()),
+        Err(e) => Err(e).context("create b00t-agents namespace"),
+    }
+}
+
+async fn ensure_service_account(client: &Client, namespace: &str, name: &str) -> Result<()> {
+    let api: Api<ServiceAccount> = Api::namespaced(client.clone(), namespace);
+    if api.get(name).await.is_ok() {
+        return Ok(());
+    }
+    let sa = ServiceAccount {
+        metadata: ObjectMeta {
+            name: Some(name.to_string()),
+            namespace: Some(namespace.to_string()),
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    match api.create(&PostParams::default(), &sa).await {
+        Ok(_) => Ok(()),
+        Err(e) if is_conflict(&e) => Ok(()),
+        Err(e) => Err(e).context("create agent ServiceAccount"),
+    }
+}
+
+async fn ensure_role_shard_datum(client: &Client) -> Result<()> {
+    let api: Api<ClusterRole> = Api::all(client.clone());
+    if api.get(ROLE_SHARD_DATUM).await.is_ok() {
+        return Ok(());
+    }
+    let role: ClusterRole =
+        serde_yaml::from_str(ROLE_SHARD_DATUM_YAML).context("parse embedded role-shard-datum YAML")?;
+    match api.create(&PostParams::default(), &role).await {
+        Ok(_) => Ok(()),
+        Err(e) if is_conflict(&e) => Ok(()),
+        Err(e) => Err(e).context("create role-shard-datum ClusterRole"),
+    }
+}
+
+async fn ensure_role_binding(client: &Client, namespace: &str, sa_name: &str) -> Result<()> {
+    let api: Api<RoleBinding> = Api::namespaced(client.clone(), namespace);
+    let rb_name = role_binding_name(sa_name);
+    if api.get(&rb_name).await.is_ok() {
+        return Ok(());
+    }
+    let rb = RoleBinding {
+        metadata: ObjectMeta {
+            name: Some(rb_name),
+            namespace: Some(namespace.to_string()),
+            ..Default::default()
+        },
+        role_ref: RoleRef {
+            api_group: "rbac.authorization.k8s.io".to_string(),
+            kind: "ClusterRole".to_string(),
+            name: ROLE_SHARD_DATUM.to_string(),
+        },
+        subjects: Some(vec![Subject {
+            kind: "ServiceAccount".to_string(),
+            name: sa_name.to_string(),
+            namespace: Some(namespace.to_string()),
+            ..Default::default()
+        }]),
+    };
+    match api.create(&PostParams::default(), &rb).await {
+        Ok(_) => Ok(()),
+        Err(e) if is_conflict(&e) => Ok(()),
+        Err(e) => Err(e).context("create role-shard-datum RoleBinding"),
+    }
+}
+
+async fn mint_token(client: &Client, namespace: &str, sa_name: &str) -> Result<String> {
+    let api: Api<ServiceAccount> = Api::namespaced(client.clone(), namespace);
+    let tr = TokenRequest {
+        spec: TokenRequestSpec {
+            expiration_seconds: Some(TOKEN_TTL_SECONDS),
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let data = serde_json::to_vec(&tr).context("serialize TokenRequest")?;
+    let result: TokenRequest = api
+        .create_subresource("token", sa_name, &PostParams::default(), &data)
+        .await
+        .context("k8s TokenRequest")?;
+    result
+        .status
+        .map(|s| s.token)
+        .context("TokenRequest response missing status.token")
+}
+
+// ---------------------------------------------------------------------------
+// Component 4: TokenReview-based enforcement
+// ---------------------------------------------------------------------------
+
+/// Validate `token` via k8s's TokenReview API, then confirm the resulting
+/// ServiceAccount identity has a RoleBinding to [`ROLE_SHARD_DATUM`].
+/// Returns a clear "not authorized for this shard" error (distinct from a
+/// generic/connection error) on either failure.
+pub async fn authorize_datum_shard_token(token: &str) -> Result<AuthorizedIdentity> {
+    let client = Client::try_default().await.context("connect to k8s cluster")?;
+
+    let api: Api<TokenReview> = Api::all(client.clone());
+    let review = TokenReview {
+        spec: TokenReviewSpec {
+            token: Some(token.to_string()),
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let result = api
+        .create(&PostParams::default(), &review)
+        .await
+        .context("k8s TokenReview")?;
+
+    let status = result
+        .status
+        .ok_or_else(|| anyhow::anyhow!("not authorized for this shard: empty TokenReview status"))?;
+
+    if !status.authenticated.unwrap_or(false) {
+        bail!(
+            "not authorized for this shard: token not authenticated ({})",
+            status.error.unwrap_or_else(|| "unknown reason".to_string())
+        );
+    }
+
+    let username = status
+        .user
+        .and_then(|u| u.username)
+        .ok_or_else(|| anyhow::anyhow!("not authorized for this shard: TokenReview response missing user info"))?;
+
+    let (namespace, sa_name) = parse_service_account_username(&username).ok_or_else(|| {
+        anyhow::anyhow!(
+            "not authorized for this shard: '{}' is not a ServiceAccount identity",
+            username
+        )
+    })?;
+
+    let bound = role_binding_exists_for(&client, &namespace, &sa_name).await?;
+    if !bound {
+        bail!(
+            "not authorized for this shard: ServiceAccount '{}/{}' has no role-shard-datum RoleBinding",
+            namespace,
+            sa_name
+        );
+    }
+
+    Ok(AuthorizedIdentity {
+        username,
+        namespace,
+        service_account_name: sa_name,
+    })
+}
+
+/// Parse Kubernetes' standard ServiceAccount username format:
+/// `system:serviceaccount:<namespace>:<name>`.
+fn parse_service_account_username(username: &str) -> Option<(String, String)> {
+    let mut parts = username.splitn(4, ':');
+    match (parts.next(), parts.next(), parts.next(), parts.next()) {
+        (Some("system"), Some("serviceaccount"), Some(ns), Some(name)) if !ns.is_empty() && !name.is_empty() => {
+            Some((ns.to_string(), name.to_string()))
+        }
+        _ => None,
+    }
+}
+
+async fn role_binding_exists_for(client: &Client, namespace: &str, sa_name: &str) -> Result<bool> {
+    let api: Api<RoleBinding> = Api::namespaced(client.clone(), namespace);
+    let list = api.list(&Default::default()).await.context("list RoleBindings")?;
+    Ok(list.items.iter().any(|rb| {
+        rb.role_ref.name == ROLE_SHARD_DATUM
+            && rb
+                .subjects
+                .as_ref()
+                .is_some_and(|subs| subs.iter().any(|s| s.kind == "ServiceAccount" && s.name == sa_name))
+    }))
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Serializes tests in this module that mutate process-wide env vars
+    /// (HOME/XDG_DATA_HOME), since `cargo test` runs tests in parallel
+    /// threads within one process by default.
+    static ENV_GUARD: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    /// Soft-skip helper: probes whether a k8s cluster is actually
+    /// reachable (not just that *some* kubeconfig/in-cluster config
+    /// exists) via a real API call. Returns the connected client if so.
+    async fn live_cluster() -> Option<Client> {
+        let client = Client::try_default().await.ok()?;
+        let ns_api: Api<Namespace> = Api::all(client.clone());
+        ns_api.list(&Default::default()).await.ok()?;
+        Some(client)
+    }
+
+    #[test]
+    fn test_service_account_name() {
+        assert_eq!(service_account_name("claude-worker-7"), "agent-claude-worker-7");
+    }
+
+    #[test]
+    fn test_role_binding_name() {
+        assert_eq!(
+            role_binding_name("agent-claude-worker-7"),
+            "agent-claude-worker-7-role-shard-datum"
+        );
+    }
+
+    #[test]
+    fn test_parse_service_account_username_valid() {
+        let parsed = parse_service_account_username("system:serviceaccount:b00t-agents:agent-foo");
+        assert_eq!(
+            parsed,
+            Some(("b00t-agents".to_string(), "agent-foo".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_parse_service_account_username_invalid() {
+        assert_eq!(parse_service_account_username("operator"), None);
+        assert_eq!(parse_service_account_username("system:anonymous"), None);
+        assert_eq!(parse_service_account_username(""), None);
+    }
+
+    #[test]
+    fn test_role_shard_datum_yaml_parses() {
+        let role: ClusterRole =
+            serde_yaml::from_str(ROLE_SHARD_DATUM_YAML).expect("embedded YAML must parse");
+        assert_eq!(role.metadata.name.as_deref(), Some(ROLE_SHARD_DATUM));
+    }
+
+    /// Fail-before-privilege: with an agent that has no seeded cake
+    /// balance (0), the request must be denied with the budget error —
+    /// without ever attempting a k8s API call. This test runs with no
+    /// reachable k8s cluster (no kubeconfig / in-cluster config assumed in
+    /// this environment); if the code attempted a k8s call before the
+    /// budget check, this would instead surface as a connection/config
+    /// error, not this specific message — that distinction is exactly
+    /// what this test verifies.
+    #[tokio::test]
+    async fn test_insufficient_budget_denied_before_any_k8s_call() {
+        let _guard = ENV_GUARD.lock().unwrap();
+
+        // Isolate HOME so CakeLedger::open() (which uses dirs::data_dir())
+        // resolves to a fresh, empty scheduler DB with a guaranteed-zero
+        // balance for this never-before-seen agent id.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        // SAFETY: guarded by ENV_GUARD above — no other test in this
+        // module mutates HOME/XDG_DATA_HOME concurrently.
+        unsafe {
+            std::env::set_var("XDG_DATA_HOME", tmp.path());
+            std::env::set_var("HOME", tmp.path());
+        }
+
+        let req = AgentTokenRequest {
+            agent_id: format!("never-funded-{}", uuid::Uuid::new_v4()),
+            shard_ref: "datum:some-datum-id".to_string(),
+            cost: 5,
+        };
+
+        let result = request_agent_token(req).await;
+        let err = result.expect_err("expected insufficient-budget denial");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("insufficient budget"),
+            "expected insufficient-budget error, got: {msg}"
+        );
+    }
+
+    /// Full positive flow (Components 1-3 + the positive half of
+    /// Component 4) against a real k8s cluster, when one is reachable.
+    /// Soft-skips (prints a notice, doesn't fail) when no cluster is
+    /// configured — e.g. in CI, or a sandbox with no KUBECONFIG pointing
+    /// at a live cluster.
+    #[tokio::test]
+    async fn test_full_issuance_flow_against_live_cluster_if_reachable() {
+        let _guard = ENV_GUARD.lock().unwrap();
+
+        if live_cluster().await.is_none() {
+            eprintln!(
+                "SKIP test_full_issuance_flow_against_live_cluster_if_reachable: \
+                 no k8s cluster reachable in this environment (set KUBECONFIG to \
+                 test against a live cluster)"
+            );
+            return;
+        }
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        // SAFETY: guarded by ENV_GUARD above.
+        unsafe {
+            std::env::set_var("XDG_DATA_HOME", tmp.path());
+            std::env::set_var("HOME", tmp.path());
+        }
+
+        let agent_id = format!("test-agent-{}", uuid::Uuid::new_v4());
+        let ledger = CakeLedger::open().expect("open cake ledger");
+        crate::cake_ledger::seed_balance_for_test(&ledger, &agent_id, 10);
+
+        let issuance = request_agent_token(AgentTokenRequest {
+            agent_id: agent_id.clone(),
+            shard_ref: "datum:integration-test-datum".to_string(),
+            cost: 3,
+        })
+        .await
+        .expect("request_agent_token should succeed against a live cluster");
+
+        assert!(!issuance.token.is_empty(), "minted token must be non-empty");
+        assert_eq!(issuance.remaining_balance, 7);
+        assert_eq!(ledger.balance(&agent_id).expect("balance"), 7);
+
+        // Journal entry actually appended to the dedicated ledger file.
+        let ledger_path = default_ledger_path().expect("ledger path");
+        let contents = std::fs::read_to_string(&ledger_path).expect("read journal file");
+        assert!(contents.contains(&issuance.tx_id), "journal must contain this issuance's tx_id");
+        assert!(
+            contents.contains("datum:integration-test-datum"),
+            "journal must reference the shard"
+        );
+        assert!(
+            contents.contains(&format!("Assets:Cake:{agent_id}")),
+            "journal must debit the agent's cake account"
+        );
+
+        // Positive half of Component 4: the freshly-minted token IS
+        // authorized for the datum shard (it has the RoleBinding
+        // request_agent_token just ensured).
+        let identity = authorize_datum_shard_token(&issuance.token)
+            .await
+            .expect("freshly-minted token should be authorized for the datum shard");
+        assert_eq!(identity.namespace, AGENTS_NAMESPACE);
+        assert_eq!(identity.service_account_name, service_account_name(&agent_id));
+    }
+
+    /// Negative half of Component 4: a token for a ServiceAccount that has
+    /// no `role-shard-datum` RoleBinding must be denied with the specific
+    /// "not authorized for this shard" error — not a crash, not a generic
+    /// error. Soft-skips when no cluster is reachable.
+    #[tokio::test]
+    async fn test_datum_shard_authorization_denied_for_unbound_service_account() {
+        let _guard = ENV_GUARD.lock().unwrap();
+
+        let Some(client) = live_cluster().await else {
+            eprintln!(
+                "SKIP test_datum_shard_authorization_denied_for_unbound_service_account: \
+                 no k8s cluster reachable in this environment"
+            );
+            return;
+        };
+
+        // A bare ServiceAccount with NO RoleBinding to role-shard-datum, in
+        // a throwaway namespace kept separate from b00t-agents on purpose.
+        let ns = "default";
+        let sa_name = format!("unbound-test-sa-{}", uuid::Uuid::new_v4());
+        let sa_api: Api<ServiceAccount> = Api::namespaced(client.clone(), ns);
+        let sa = ServiceAccount {
+            metadata: ObjectMeta {
+                name: Some(sa_name.clone()),
+                namespace: Some(ns.to_string()),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        sa_api
+            .create(&PostParams::default(), &sa)
+            .await
+            .expect("create throwaway ServiceAccount");
+
+        // Mint a token for it directly — bypassing request_agent_token,
+        // which would create the RoleBinding; this test specifically needs
+        // a token WITHOUT one.
+        let tr = TokenRequest {
+            spec: TokenRequestSpec {
+                expiration_seconds: Some(300),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let data = serde_json::to_vec(&tr).expect("serialize TokenRequest");
+        let result: TokenRequest = sa_api
+            .create_subresource("token", &sa_name, &PostParams::default(), &data)
+            .await
+            .expect("mint token for unbound ServiceAccount");
+        let token = result.status.expect("TokenRequest status").token;
+
+        let err = authorize_datum_shard_token(&token)
+            .await
+            .expect_err("unbound ServiceAccount token must be denied");
+        assert!(
+            err.to_string().contains("not authorized for this shard"),
+            "expected 'not authorized for this shard' error, got: {err}"
+        );
+
+        // Best-effort cleanup — not asserted, this is a throwaway resource.
+        let _ = sa_api
+            .delete(&sa_name, &kube::api::DeleteParams::default())
+            .await;
+    }
+}

--- a/b00t-cli/src/cake_ledger.rs
+++ b/b00t-cli/src/cake_ledger.rs
@@ -324,6 +324,37 @@ impl CakeLedger {
         }
     }
 
+    /// Debit an agent's cake balance by `amount` (must be >= 0).
+    ///
+    /// Callers (e.g. `agent_token::request_agent_token`) are expected to
+    /// have already checked `balance()` before doing anything privileged —
+    /// this is a second, belt-and-suspenders guard against races, not the
+    /// primary fail-before-privilege check. Returns the resulting balance.
+    pub fn debit(&self, agent: &str, amount: i64) -> Result<i64> {
+        anyhow::ensure!(amount >= 0, "debit amount must be non-negative, got {amount}");
+
+        let conn = self.connect()?;
+        let now = chrono_now_utc();
+
+        let current = self.balance(agent)?;
+        anyhow::ensure!(
+            current >= amount,
+            "insufficient cake balance for '{agent}': have {current}, need {amount}"
+        );
+
+        conn.execute(
+            "INSERT INTO cake_balance (agent, balance, updated_at)
+             VALUES (?1, -?2, ?3)
+             ON CONFLICT(agent) DO UPDATE SET
+                 balance    = balance - ?2,
+                 updated_at = ?3",
+            params![agent, amount, now],
+        )
+        .context("debit cake balance")?;
+
+        Ok(current - amount)
+    }
+
     /// Recent ticket history for an agent, newest first.
     pub fn history(&self, agent: &str, limit: usize) -> Result<Vec<CakeTicket>> {
         let conn = self.connect()?;
@@ -411,6 +442,21 @@ fn map_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<CakeTicket> {
 
 fn chrono_now_utc() -> String {
     chrono::Utc::now().format("%Y-%m-%d %H:%M:%S").to_string()
+}
+
+/// Test-only: directly seed a balance, bypassing the probabilistic lottery.
+/// Exposed crate-wide (`pub`, `#[cfg(test)]`) rather than kept private to
+/// this module's own `tests`, so other modules' tests (e.g.
+/// `agent_token`'s live-cluster integration tests) can set up deterministic
+/// starting balances without needing the lottery flow.
+#[cfg(test)]
+pub fn seed_balance_for_test(ledger: &CakeLedger, agent: &str, balance: i64) {
+    let conn = ledger.connect().expect("connect");
+    conn.execute(
+        "INSERT INTO cake_balance (agent, balance, updated_at) VALUES (?1, ?2, ?3)",
+        params![agent, balance, "2026-01-01 00:00:00"],
+    )
+    .expect("seed balance");
 }
 
 // ---------------------------------------------------------------------------
@@ -538,5 +584,58 @@ mod tests {
             "p_cake={}",
             outcome.p_cake
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // debit() — used by agent_token::request_agent_token
+    // -----------------------------------------------------------------------
+
+    /// Seed a deterministic balance directly (bypassing the probabilistic
+    /// lottery) so debit tests aren't flaky.
+    fn seed_balance(ledger: &CakeLedger, agent: &str, balance: i64) {
+        super::seed_balance_for_test(ledger, agent, balance);
+    }
+
+    #[test]
+    fn test_debit_reduces_balance() {
+        let (ledger, _dir) = temp_ledger();
+        seed_balance(&ledger, "debit-agent", 10);
+
+        let remaining = ledger.debit("debit-agent", 3).expect("debit");
+        assert_eq!(remaining, 7);
+        assert_eq!(ledger.balance("debit-agent").expect("balance"), 7);
+    }
+
+    #[test]
+    fn test_debit_insufficient_balance_rejected() {
+        let (ledger, _dir) = temp_ledger();
+        seed_balance(&ledger, "poor-agent", 2);
+
+        let result = ledger.debit("poor-agent", 5);
+        assert!(result.is_err());
+        // Balance must be unchanged after a rejected debit.
+        assert_eq!(ledger.balance("poor-agent").expect("balance"), 2);
+    }
+
+    #[test]
+    fn test_debit_unknown_agent_zero_balance_rejected() {
+        let (ledger, _dir) = temp_ledger();
+        let result = ledger.debit("never-seen-agent", 1);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_debit_negative_amount_rejected() {
+        let (ledger, _dir) = temp_ledger();
+        let result = ledger.debit("any-agent", -1);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_debit_zero_amount_is_noop_ok() {
+        let (ledger, _dir) = temp_ledger();
+        seed_balance(&ledger, "zero-agent", 5);
+        let remaining = ledger.debit("zero-agent", 0).expect("debit zero");
+        assert_eq!(remaining, 5);
     }
 }

--- a/b00t-cli/src/commands/ai.rs
+++ b/b00t-cli/src/commands/ai.rs
@@ -41,10 +41,40 @@ pub enum AiCommands {
         #[clap(help = "Comma-separated list of AI provider names to output")]
         providers: String,
     },
+    #[clap(about = "Agent identity & scoped token operations")]
+    Agent {
+        #[clap(subcommand)]
+        cmd: AgentSubcommand,
+    },
+}
+
+#[derive(Parser)]
+pub enum AgentSubcommand {
+    #[clap(about = "Agent-scoped token operations")]
+    Token {
+        #[clap(subcommand)]
+        cmd: AgentTokenSubcommand,
+    },
+}
+
+#[derive(Parser)]
+pub enum AgentTokenSubcommand {
+    #[clap(
+        about = "Request a scoped, budget-checked agent token (datum shard-type pilot)",
+        long_about = "Check cake budget, ensure a k8s ServiceAccount+RoleBinding exist, mint a short-lived (15m) scoped token via k8s TokenRequest, and record the issuance as a ledger-core double-entry transaction.\n\nOnly the 'datum' shard-type is supported by this pilot (e.g. --shard datum:some-datum-id).\n\nExample:\n  b00t-cli ai agent token request --agent claude-worker-7 --shard datum:my-datum --cost 3"
+    )]
+    Request {
+        #[clap(long, help = "Requesting agent's identity")]
+        agent: String,
+        #[clap(long, help = "Shard reference, e.g. datum:<datum-id>")]
+        shard: String,
+        #[clap(long, help = "Cake cost to debit for this issuance")]
+        cost: i64,
+    },
 }
 
 impl AiCommands {
-    pub fn execute(&self, _path: &str) -> Result<()> {
+    pub async fn execute(&self, _path: &str) -> Result<()> {
         match self {
             AiCommands::Add { .. } => {
                 println!("🤖 AI add functionality coming soon...");
@@ -87,6 +117,27 @@ impl AiCommands {
                 println!("📤 AI output functionality coming soon...");
                 Ok(())
             }
+            AiCommands::Agent { cmd } => match cmd {
+                AgentSubcommand::Token { cmd } => match cmd {
+                    AgentTokenSubcommand::Request { agent, shard, cost } => {
+                        use crate::agent_token::{AgentTokenRequest, request_agent_token};
+
+                        let issuance = request_agent_token(AgentTokenRequest {
+                            agent_id: agent.clone(),
+                            shard_ref: shard.clone(),
+                            cost: *cost,
+                        })
+                        .await?;
+
+                        println!("🔑 Agent token issued for '{agent}' (shard: {shard})");
+                        println!("   token:      {}", issuance.token);
+                        println!("   tx_id:      {}", issuance.tx_id);
+                        println!("   expires_in: {}s", issuance.expires_in_seconds);
+                        println!("   balance:    {}", issuance.remaining_balance);
+                        Ok(())
+                    }
+                },
+            },
         }
     }
 }
@@ -95,12 +146,12 @@ impl AiCommands {
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_ai_commands_exist() {
+    #[tokio::test]
+    async fn test_ai_commands_exist() {
         let add_cmd = AiCommands::Add {
             file: "test.toml".to_string(),
         };
 
-        assert!(add_cmd.execute("test").is_ok());
+        assert!(add_cmd.execute("test").await.is_ok());
     }
 }

--- a/b00t-cli/src/commands/datum.rs
+++ b/b00t-cli/src/commands/datum.rs
@@ -12,6 +12,11 @@ pub enum DatumCommands {
     Show {
         #[clap(help = "Datum name to show (e.g., just, rust, docker)")]
         name: String,
+        #[clap(
+            long,
+            help = "Authorize via a scoped agent token (k8s TokenReview + role-shard-datum RoleBinding check) instead of ambient trust"
+        )]
+        as_agent_token: Option<String>,
     },
 
     #[clap(about = "Generate JSTree-compatible JSON from datums")]
@@ -216,9 +221,11 @@ pub enum DatumCommands {
     },
 }
 
-pub fn handle_datum_command(path: &str, datum_command: &DatumCommands) -> Result<()> {
+pub async fn handle_datum_command(path: &str, datum_command: &DatumCommands) -> Result<()> {
     match datum_command {
-        DatumCommands::Show { name } => handle_show(path, name),
+        DatumCommands::Show { name, as_agent_token } => {
+            handle_show(path, name, as_agent_token.as_deref()).await
+        }
         DatumCommands::Tree {
             output,
             group_by_type,
@@ -327,7 +334,17 @@ pub fn handle_datum_command(path: &str, datum_command: &DatumCommands) -> Result
     }
 }
 
-fn handle_show(b00t_path: &str, datum_name: &str) -> Result<()> {
+async fn handle_show(b00t_path: &str, datum_name: &str, as_agent_token: Option<&str>) -> Result<()> {
+    // Component 4 (agent-scoped token pilot): when --as-agent-token is
+    // given, gate the read path on a k8s TokenReview + role-shard-datum
+    // RoleBinding check rather than ambient trust. See
+    // docs/superpowers/specs/2026-08-22-agent-scoped-token-issuance.md.
+    if let Some(token) = as_agent_token {
+        crate::agent_token::authorize_datum_shard_token(token)
+            .await
+            .context("datum show --as-agent-token")?;
+    }
+
     // Find the datum
     let datum = datum_utils::find_datum_by_pattern(b00t_path, datum_name)?
         .ok_or_else(|| anyhow::anyhow!("Datum '{}' not found", datum_name))?;

--- a/b00t-cli/src/lib.rs
+++ b/b00t-cli/src/lib.rs
@@ -37,6 +37,7 @@ pub mod exit_code {
     pub const NETWORK: i32 = 30;
 }
 
+pub mod agent_token;
 pub mod agentic_role;
 pub mod ansible;
 pub mod blessing;

--- a/b00t-cli/src/main.rs
+++ b/b00t-cli/src/main.rs
@@ -2296,7 +2296,7 @@ async fn main() {
             }
         }
         Some(Commands::Ai { ai_command }) => {
-            if let Err(e) = ai_command.execute(&cli.path) {
+            if let Err(e) = ai_command.execute(&cli.path).await {
                 eprintln!("Error: {}", e);
                 std::process::exit(1);
             }
@@ -2569,7 +2569,7 @@ async fn main() {
         }
         Some(Commands::Datum { datum_command }) => {
             use b00t_cli::commands::datum::handle_datum_command;
-            if let Err(e) = handle_datum_command(&cli.path, datum_command) {
+            if let Err(e) = handle_datum_command(&cli.path, datum_command).await {
                 eprintln!("Error: {}", e);
                 std::process::exit(1);
             }

--- a/docs/superpowers/specs/2026-08-22-agent-scoped-token-issuance.md
+++ b/docs/superpowers/specs/2026-08-22-agent-scoped-token-issuance.md
@@ -1,0 +1,171 @@
+# Agent-Scoped Token Issuance (datum shard pilot)
+
+**Date:** 2026-08-22
+**Status:** Implemented (pilot — `datum` shard-type only)
+**Context:** Follow-on to
+`docs/superpowers/specs/2026-08-22-k0s-agent-identity-control-plane-design.md`
+(the k0s control plane + AWS OIDC federation prerequisites work). Implements
+the "ledgrrr provides authorization and releases credentials" flow from
+elasticdotventures/_b00t_#1104, scoped to the taxonomy in #1102, for exactly
+one shard-type (`datum`) end-to-end. The other four shard-types (system,
+repo-superproject, agent, skill) are mechanical extensions of this same
+pattern and are explicitly out of scope (YAGNI) for this pilot.
+
+## Goal
+
+Give individual AI agents their own scoped, revocable identity/tokens
+instead of one shared blanket credential, with memory-shard access (RBAC)
+and cost tracking (cake/budget) unified under one issuance flow — proven
+end-to-end for the `datum` shard-type before generalizing.
+
+## Architecture
+
+```
+b00t ai agent token request --agent <id> --shard datum:<datum-id> --cost <N>
+        │
+        ▼
+1. cake balance check (CakeLedger::balance, reused — fail before privilege)
+        │  insufficient → deny immediately, no k8s calls, no journal entry
+        ▼
+2. ensure ServiceAccount "agent-<id>" in namespace "b00t-agents" (idempotent)
+        ▼
+3. ensure ClusterRole "role-shard-datum" exists (idempotent, embedded YAML)
+        ▼
+4. ensure RoleBinding: ServiceAccount → role-shard-datum (idempotent)
+        ▼
+5. k8s TokenRequest API → short-lived (15 min) SA token
+        ▼
+6. record issuance as a double-entry transaction in ledger-core,
+   appended to ~/.b00t/ledger/agent-tokens.beancount (dedicated file,
+   never mixed with real financial records) — this debits the agent's
+   cake balance for `cost`
+        ▼
+7. print/return the minted token
+```
+
+Enforcement (this pilot only) is via k8s's TokenReview API, wired directly
+into the existing `b00t-cli datum show` command via a new
+`--as-agent-token <token>` flag — not a new standalone proxy service.
+
+## Components
+
+### 1. `b00t-cli/src/agent_token.rs` — issuance module
+
+New module implementing the 7-step flow above, exposed as
+`b00t ai agent token request --agent <id> --shard datum:<datum-id> --cost <N>`
+(wired via `AiCommands::Agent { Token { Request { .. } } }` in
+`b00t-cli/src/commands/ai.rs`). Uses the existing `kube`/`k8s-openapi`
+dependency already present in `b00t-cli/Cargo.toml` and the existing
+`crate::k8s::K8sClient` wrapper pattern (`b00t-cli/src/k8s/`) where
+convenient; adds direct `kube::Api<ServiceAccount>` /
+`Api<ClusterRole>` / `Api<RoleBinding>` calls for the RBAC-object
+lifecycle and a raw `TokenRequest` subresource call for minting.
+
+Budget check happens strictly before any k8s API call or client
+construction — verified by a test that runs with no reachable cluster and
+asserts the error returned is the budget error, not a connection error.
+
+### 2. `role-shard-datum` ClusterRole — embedded marker Role
+
+Since datum data is not migrated into k8s-native resources (deliberate
+scope decision — the datum store stays wherever it already lives), this
+Role's `rules:` are intentionally minimal (no real API access granted). Its
+only job is to exist as a RoleBinding target that Component 4's TokenReview
+check looks for. Defined as an embedded YAML string constant in
+`agent_token.rs` and applied (idempotent create-if-missing) by the
+issuance flow itself the first time it's needed — no manual `kubectl
+apply` step, no separate manifest-distribution story.
+
+### 3. `ledger-core::JournalTransaction::from_agent_token_issuance`
+
+New constructor in `vendor/ledgrrr/crates/ledger-core/src/journal.rs`,
+alongside the existing `from_input` (tax-import) constructor — does not
+modify `from_input` or its behavior. Does not depend on
+`TransactionInput`/`deterministic_tx_id` (those are tax-import-specific);
+takes `agent_id`, `shard_ref`, `cost`, a caller-supplied `tx_id`, and
+`date` directly. Produces a balanced double-entry beancount transaction:
+
+- `Assets:Cake:<agent_id>` debited by `cost`
+- `Expenses:AgentTokens:<shard-type>` credited by `cost` (shard-type is the
+  part of `shard_ref` before the first `:`, e.g. `datum` from
+  `datum:some-id`)
+
+Entries are appended (via the existing `append_entries` function, reused
+unmodified) to a **dedicated** file, `~/.b00t/ledger/agent-tokens.beancount`
+— separate from any real tax-ledger data. This lives in a companion PR
+against `PromptExecution/ledgrrr` (the submodule's own upstream repo):
+https://github.com/PromptExecution/ledgrrr/pull/192.
+
+### 4. TokenReview enforcement in `datum show`
+
+New `--as-agent-token <token>` flag on `b00t-cli datum show`
+(`b00t-cli/src/commands/datum.rs`). When present:
+
+1. Calls k8s's TokenReview API with the provided token.
+2. If not authenticated/expired → "not authorized for this shard" error
+   (distinct from a generic error).
+3. Confirms the token's ServiceAccount (from the TokenReview response
+   `status.user.username`, format `system:serviceaccount:<ns>:<name>`) has
+   a RoleBinding to `role-shard-datum` in `b00t-agents`.
+4. If not bound → same "not authorized" error.
+5. Otherwise, proceeds with normal `datum show` behavior.
+
+Only `datum show` (the read path) is gated in this pilot — proving the
+pattern once, not gating every datum subcommand.
+
+## Design decisions not fully specified in the brief
+
+- **`b00t-agents` namespace creation:** ensured (create-if-missing) as part
+  of the ServiceAccount-ensure step, using the same idempotent-create
+  pattern as the rest of the flow, rather than assuming it pre-exists.
+- **cake debit mechanism:** `CakeLedger` (`b00t-cli/src/cake_ledger.rs`)
+  previously had no spend/debit path (only lottery-win credits). Added a
+  new `CakeLedger::debit(agent, amount)` method following the existing
+  `ON CONFLICT ... DO UPDATE` upsert style used by `resolve_ticket`, with
+  an explicit insufficient-balance guard (belt-and-suspenders — the
+  primary check is the pre-flight `balance()` read in `agent_token.rs`,
+  fail-before-privilege).
+- **tx_id generation:** the ledger-core constructor takes `tx_id` as a
+  caller-supplied `String` (per the brief) rather than deriving it via
+  `deterministic_tx_id` (that helper is tax-import-specific and hashes
+  `TransactionInput` fields that don't apply here). `agent_token.rs`
+  generates a `uuid::Uuid::new_v4()`-based id, since each token issuance is
+  a distinct event, not an idempotent re-import of the same source data.
+- **Async wiring:** `b00t-cli`'s `main()` is already `#[tokio::main]`.
+  Rather than follow the existing (pre-existing, separately-noted-risky)
+  `commands/k8s.rs` pattern of spinning up a nested `tokio::runtime::Runtime`
+  and calling `.block_on()` from inside an already-running runtime,
+  `AiCommands::execute` and `handle_datum_command`/`handle_show` were
+  changed to `async fn` (all previously-sync branches are trivially
+  compatible — none of them awaited anything before, they just don't now
+  either) and their call sites in `main.rs` were updated to `.await`.
+- **TokenReview → RoleBinding lookup:** the TokenReview response's
+  `status.user.username` is parsed as `system:serviceaccount:<namespace>:<name>`
+  per Kubernetes' standard ServiceAccount username format; RoleBindings are
+  then listed in that namespace and checked for a `roleRef` naming
+  `role-shard-datum`.
+- **Cross-repo submodule change:** since `vendor/ledgrrr` is a real
+  submodule of a separate repo (`PromptExecution/ledgrrr`), Component 3's
+  change was committed and pushed there directly
+  (https://github.com/PromptExecution/ledgrrr/pull/192), and this PR's
+  submodule pointer bump references that branch's tip commit.
+
+## Testing
+
+- Unit tests for `JournalTransaction::from_agent_token_issuance`: field
+  correctness, and that `to_beancount_entry()` produces a debit/credit pair
+  that are exact inverses via the existing `invert_amount` helper.
+- Unit test for the fail-before-privilege ordering: an agent with
+  insufficient cake balance is denied with the budget error specifically
+  (not a k8s connection error), runnable with **no reachable cluster** —
+  this is what actually proves the ordering, since a real k8s call
+  attempted first would surface as a connection failure in this
+  environment, not the budget message.
+- `CakeLedger::debit` unit tests (insufficient balance rejected, balance
+  decremented correctly on success).
+- k8s-dependent integration tests (ServiceAccount/RoleBinding/ClusterRole
+  ensure, TokenRequest mint, TokenReview enforcement in `datum show`) use a
+  soft-skip pattern: they attempt a real cluster connection first and, if
+  unavailable, print a skip notice and return early rather than failing —
+  see the PR description for what was/wasn't verified against a live
+  cluster in this session.


### PR DESCRIPTION
## Summary

Pilot for agent-scoped token issuance against the datum shard system — new `agent_token.rs` module, `cake_ledger.rs` (cake accounting integration), and wiring into `ai`/`datum` commands.

Design doc: `docs/superpowers/specs/2026-08-22-agent-scoped-token-issuance.md`

Opened as draft — this was discovered as an unmerged local branch during a repo-wide cleanup and pushed for the first time now; needs review before it's ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TiJPJsZZDCoAGAhzkfkk3k