### PR TITLE
feat(dev-env): standby cloud build server (GCP dstack dev-environment)

### DIFF
--- a/dev-env/b00t-build-cache.volume.yaml
+++ b/dev-env/b00t-build-cache.volume.yaml
@@ -1,0 +1,26 @@
+# b00t standby cloud build server — persistent cache volume.
+# See docs/superpowers/specs/2026-08-10-cloud-build-server-design.md.
+#
+# Holds the git checkout + `target/` at /data/b00t, mounted by
+# b00t-build.dev-environment.yaml. Its lifecycle is independent of the
+# dev-environment's VM: `dstack stop`/idle-timeout on the fleet tears down
+# compute, not this volume, so the cargo cache is warm again the moment the
+# box resumes. Apply once via `just remote-provision` (idempotent, matches
+# how DstackProvider::ensure_volume treats a `type: volume` re-apply).
+#
+# Size: this session's own target/ reached ~2GB partway through a single
+# crate's build; the full workspace dependency tree (Qdrant, candle, kube,
+# OpenTelemetry, etc.) is plausibly 10-50GB. 100GB leaves headroom at GCP
+# persistent-disk pricing that's cheap relative to the time this saves.
+type: volume
+name: b00t-build-cache
+backend: gcp
+# 🤓 Only field in this design that hardcodes a region — dstack's `type:
+# volume` schema requires one (network volumes are region-bound), unlike
+# the fleet/dev-environment configs below, which deliberately omit a
+# `regions:` restriction per this repo's existing fleet-YAML convention
+# (see 2026-07-23-b00t-dstack-gcp-backend-design.md) of not hardcoding
+# scope beyond what's actually required. Adjust freely — no other config
+# here depends on this specific value.
+region: us-central1
+size: 100GB

--- a/dev-env/b00t-build-fleet.yaml
+++ b/dev-env/b00t-build-fleet.yaml
@@ -1,0 +1,24 @@
+# b00t standby cloud build server — backing fleet.
+# See docs/superpowers/specs/2026-08-10-cloud-build-server-design.md.
+#
+# 🤓 Not in that design doc's original "Components" list — added here
+# because dstack requires a fleet to already exist before a dev-environment
+# can be provisioned against it ("Before running a dev environment, make
+# sure you've... created a fleet" — dstack's own dev-environments docs).
+# `idle_duration` also belongs here, not on the dev-environment: verified
+# against dstack's real fleet/dev-environment reference docs before writing
+# this (the design doc's own idle_duration placement, on the
+# dev-environment, doesn't match dstack's actual schema — this fleet is
+# where dstack actually enforces it, deprovisioning instances above `min`
+# once idle past this duration).
+type: fleet
+name: b00t-build-fleet
+# min 0 (costs nothing while nothing's running), max 1 — a single-box build
+# server, not a pool. Matches DstackProvider::ensure_fleet's own 0..1
+# philosophy for on-demand capacity.
+nodes: 0..1
+# No GPU — this is a CPU/disk/network build server, not an ML job. Matches
+# the design doc's explicit non-goal ("No GPU, no RunPod backend").
+resources:
+  gpu: 0
+idle_duration: 30m

--- a/dev-env/b00t-build.dev-environment.yaml
+++ b/dev-env/b00t-build.dev-environment.yaml
@@ -1,0 +1,14 @@
+# b00t standby cloud build server.
+# See docs/superpowers/specs/2026-08-10-cloud-build-server-design.md.
+#
+# SSH-only by design (no `ide:` property) — this is a build server accessed
+# via `just remote-build`/`remote-test` over SSH, not an interactive desktop
+# IDE target. `dstack apply` provisions it against b00t-build-fleet.yaml
+# (must be applied first — see justfile's `remote-provision` recipe) and
+# mounts b00t-build-cache.volume.yaml at /data/b00t.
+type: dev-environment
+name: b00t-build
+
+volumes:
+  - name: b00t-build-cache
+    path: /data/b00t

--- a/docs/superpowers/specs/2026-08-10-cloud-build-server-design.md
+++ b/docs/superpowers/specs/2026-08-10-cloud-build-server-design.md
@@ -1,0 +1,131 @@
+# Design: Standby Cloud Build Server (GCP dstack dev-environment)
+
+**Status**: Proposed
+**Motivated by**: this local machine's build times — a cold `cargo build` for `b00t-c0re-lib`
+alone took 13+ minutes, and `cargo run` on `b00t-cli` appeared to trigger a full
+dependency-tree rebuild on effectively every invocation (Qdrant, embed-anything, candle,
+kube, OpenTelemetry, and more), turning a single integration test run into a
+multi-minute-to-tens-of-minutes wait.
+
+## Context
+
+b00t already has a working multi-backend cloud compute layer: `DstackProvider`
+(`b00t-cli/src/commands/provider.rs`, PR #857) implements the `ComputeProvider` trait —
+`submit_batch_job`, `submit_training_job`, `job_status`, `cancel_job`, `list_jobs` — by
+shelling out to the `dstack` CLI and generating fleet/task YAML without hardcoding a
+backend. GCP was added as a second backend (`docs/superpowers/specs/2026-07-23-b00t-dstack-gcp-backend-design.md`)
+using ambient Application Default Credentials already configured on this host — no
+secrets to manage.
+
+**Verified directly against the code before designing** (not assumed): `ensure_fleet`
+generates a `type: fleet` config (`nodes: 0..1`, autoscaling to zero on idle) and
+`dstack_task_yaml` generates a `type: task` config that runs a fixed Docker `image:` to
+completion. This is entirely batch-job shaped — there is no persistent, SSH-connectable
+"dev box" capability anywhere in b00t's dstack integration today. dstack itself supports
+that mode natively (`type: dev-environment`), but b00t never generates that config type.
+This design adds it, as static config + `just` recipes — no new Rust code.
+
+## Goals
+
+1. A GCP-backed dstack dev-environment that stays SSH-reachable, auto-stops after an
+   idle period (no GPU — this is a CPU/disk/network build server, not an ML job), and
+   resumes without losing its build cache.
+2. Sync via `git push` to a scratch branch on the existing `origin` (GitHub) remote —
+   the box fetches and checks it out. No rsync, no reverse-SSH into a NAT'd local
+   machine.
+3. Day-to-day invocation via `just` recipes wrapping raw `dstack`/`ssh`/`git` calls —
+   deliberately no new `b00t-cli` subcommand (YAGNI: this is ops tooling, not a feature).
+4. The actual point: a persistent `type: volume` backs `/data/b00t` (checkout +
+   `target/`), so idle-stop/resume does not force a cold rebuild. Without this, the
+   design would just relocate today's pain to a faster machine, not solve it.
+
+## Non-goals
+
+- No new `b00t-cli` command surface (explicit choice — `just` recipes only).
+- Not routed through the existing `ComputeProvider`/batch-job path (`submit_batch_job`,
+  `job_status` polling, PASS/FAIL contract parsing) — that machinery is for discrete,
+  container-image-shaped jobs with no persistent state; this is an interactive box you
+  build/test against directly over SSH. Building a `type: dev-environment` generator
+  into `DstackProvider` itself was considered and explicitly declined in favor of static
+  YAML + `just`, to keep this out of Rust entirely.
+- No GPU, no RunPod backend (GCP chosen: ambient ADC already configured, no secrets).
+- No automatic multi-user/multi-branch concurrency handling — one box, one active
+  checkout, one scratch branch at a time. If that becomes a real need, it's a follow-up.
+
+## Architecture
+
+One dstack `type: dev-environment` (`name: b00t-build`) on the GCP backend, no GPU, with
+an `idle_duration: 30m` that auto-stops the VM after 30 idle minutes (long enough to
+survive a short break mid-iteration, short enough not to burn cost overnight if
+forgotten). A dstack `type: volume`
+(`b00t-build-cache`, GCP persistent disk) is mounted at `/data/b00t` and holds both the
+git checkout and `target/`. The volume's lifecycle is independent of the VM's — auto-stop
+kills compute, not the disk, so the cargo cache is warm again the moment the box resumes.
+
+Sync is git-native: `just remote-push <branch>` pushes local HEAD to
+`refs/heads/scratch/<branch>` on the same `origin` GitHub remote already used for
+everything else. `just remote-build <branch>` / `just remote-test <branch>` SSH in
+synchronously (`ssh b00t-build "cd /data/b00t && git fetch origin && git checkout
+scratch/<branch> && cargo build|test"`), streaming output live to the local terminal
+over the SSH session itself — no polling, no separate result-fetch step, no PASS/FAIL
+contract to parse (that machinery belongs to the batch-job path this design deliberately
+avoids).
+
+## Components
+
+- `_b00t_/dev-env/b00t-build-cache.volume.yaml` — `type: volume`, GCP, 100GB (this
+  session's `target/` alone reached ~2GB partway through a single crate's build; the
+  full workspace dependency tree — Qdrant, candle, kube, OpenTelemetry, etc. — is
+  plausibly 10-50GB; 100GB leaves headroom at GCP persistent-disk pricing that's cheap
+  relative to the time this design saves).
+- `_b00t_/dev-env/b00t-build.dev-environment.yaml` — `type: dev-environment`,
+  `name: b00t-build`, no `resources: gpu:` field, `idle_duration: 30m`,
+  `volumes: [{name: b00t-build-cache, path: /data/b00t}]`. No `backends:`/`regions:`
+  restriction beyond GCP being the only backend this design targets (matches the
+  existing fleet/task YAML's own "don't hardcode more than necessary" convention).
+- `justfile` recipes (new):
+  - `remote-provision` — idempotent `dstack apply -f <volume yaml> -y` then
+    `dstack apply -f <dev-env yaml> -y`.
+  - `remote-push <branch>` — `git push origin HEAD:refs/heads/scratch/<branch>`.
+  - `remote-build <branch>` / `remote-test <branch>` — SSH in, fetch, checkout, run.
+  - `remote-stop` — manual `dstack stop b00t-build`, on top of the automatic
+    idle-duration stop (belt and suspenders — explicit stop for "I'm done for the day"
+    vs. the idle timer for "forgot to").
+
+## Data flow
+
+```
+just remote-provision                 (one-time / idempotent)
+just remote-push my-branch            → origin:refs/heads/scratch/my-branch
+just remote-test my-branch            → ssh b00t-build:
+                                           cd /data/b00t
+                                           git fetch origin
+                                           git checkout scratch/my-branch
+                                           cargo test
+                                         (streamed live to local terminal)
+```
+
+## Error handling
+
+The very first `remote-build`/`remote-test` after `remote-provision` is genuinely cold —
+a real full dependency compile, several minutes, expected and unavoidable exactly once.
+Every subsequent call is warm (only actually-changed crates recompile) because
+`/data/b00t` persists on the volume independent of VM stop/start. If `remote-build` runs
+while the box is idle-stopped, `dstack apply`/`ssh`'s own resume handling brings it back
+up — no bespoke wake logic needed in the recipes. If the volume is ever deleted and
+recreated, the next build is cold again by construction; this is a documented, accepted
+cost, not a failure mode to engineer around.
+
+## Testing
+
+This is ops tooling, not application code — the acceptance criterion is a manual
+end-to-end smoke test, not a unit-test suite:
+
+1. `just remote-provision` succeeds, `b00t-build` is SSH-reachable.
+2. `just remote-push test-branch` then `just remote-test test-branch` succeeds and shows
+   real `cargo test` output over the SSH session.
+3. Let the box idle-stop (wait past `idle_duration`), then run `just remote-test
+   test-branch` again. **This is the real proof**: confirm it does *not* trigger a full
+   dependency rebuild — the warm-cache-across-stop/resume behavior is the entire point
+   of this design, and the design is not proven until this specific step is observed to
+   work.

--- a/docs/superpowers/specs/2026-08-10-cloud-build-server-design.md
+++ b/docs/superpowers/specs/2026-08-10-cloud-build-server-design.md
@@ -1,6 +1,6 @@
 # Design: Standby Cloud Build Server (GCP dstack dev-environment)
 
-**Status**: Proposed
+**Status**: Implemented (`dev-env/*.yaml` + `just remote-*` recipes) — not yet applied to real GCP infra; that's an explicit operator decision (cost/backend/region), not something implementing the config itself commits to.
 **Motivated by**: this local machine's build times — a cold `cargo build` for `b00t-c0re-lib`
 alone took 13+ minutes, and `cargo run` on `b00t-cli` appeared to trigger a full
 dependency-tree rebuild on effectively every invocation (Qdrant, embed-anything, candle,
@@ -54,13 +54,19 @@ This design adds it, as static config + `just` recipes — no new Rust code.
 
 ## Architecture
 
-One dstack `type: dev-environment` (`name: b00t-build`) on the GCP backend, no GPU, with
-an `idle_duration: 30m` that auto-stops the VM after 30 idle minutes (long enough to
-survive a short break mid-iteration, short enough not to burn cost overnight if
-forgotten). A dstack `type: volume`
-(`b00t-build-cache`, GCP persistent disk) is mounted at `/data/b00t` and holds both the
-git checkout and `target/`. The volume's lifecycle is independent of the VM's — auto-stop
-kills compute, not the disk, so the cargo cache is warm again the moment the box resumes.
+One dstack `type: dev-environment` (`name: b00t-build`) provisioned against a backing
+`type: fleet` (`b00t-build-fleet`) on the GCP backend, no GPU. **Correction from this
+design's first draft, made while implementing it**: `idle_duration` belongs on the
+*fleet*, not the dev-environment — verified against dstack's real fleet/dev-environment
+reference docs, not assumed. dstack also requires a fleet to exist before a
+dev-environment can be provisioned against it at all, which the original draft didn't
+account for; `b00t-build-fleet.yaml` (`nodes: 0..1`, `idle_duration: 30m`) is new since
+that draft. The 30-minute idle window auto-stops the instance (long enough to survive a
+short break mid-iteration, short enough not to burn cost overnight if forgotten). A
+dstack `type: volume` (`b00t-build-cache`, GCP persistent disk) is mounted at
+`/data/b00t` and holds both the git checkout and `target/`. The volume's lifecycle is
+independent of the fleet's — idle-stop kills compute, not the disk, so the cargo cache
+is warm again the moment the box resumes.
 
 Sync is git-native: `just remote-push <branch>` pushes local HEAD to
 `refs/heads/scratch/<branch>` on the same `origin` GitHub remote already used for
@@ -78,14 +84,17 @@ avoids).
   full workspace dependency tree — Qdrant, candle, kube, OpenTelemetry, etc. — is
   plausibly 10-50GB; 100GB leaves headroom at GCP persistent-disk pricing that's cheap
   relative to the time this design saves).
+- `_b00t_/dev-env/b00t-build-fleet.yaml` — `type: fleet`, `nodes: 0..1`,
+  `resources: gpu: 0`, `idle_duration: 30m`. No `regions:` restriction (matches the
+  existing fleet/task YAML's own "don't hardcode more than necessary" convention) — GCP
+  scoping comes from `b00t-build-cache`'s own `backend: gcp`, which only a GCP-scheduled
+  instance can attach.
 - `_b00t_/dev-env/b00t-build.dev-environment.yaml` — `type: dev-environment`,
-  `name: b00t-build`, no `resources: gpu:` field, `idle_duration: 30m`,
-  `volumes: [{name: b00t-build-cache, path: /data/b00t}]`. No `backends:`/`regions:`
-  restriction beyond GCP being the only backend this design targets (matches the
-  existing fleet/task YAML's own "don't hardcode more than necessary" convention).
-- `justfile` recipes (new):
-  - `remote-provision` — idempotent `dstack apply -f <volume yaml> -y` then
-    `dstack apply -f <dev-env yaml> -y`.
+  `name: b00t-build`, no `ide:` (SSH-only), no `resources:` override (inherits the
+  fleet's), `volumes: [{name: b00t-build-cache, path: /data/b00t}]`.
+- `justfile` recipes (implemented):
+  - `remote-provision` — idempotent `dstack apply -y` for the fleet, then the volume,
+    then the dev-environment (fleet must exist first).
   - `remote-push <branch>` — `git push origin HEAD:refs/heads/scratch/<branch>`.
   - `remote-build <branch>` / `remote-test <branch>` — SSH in, fetch, checkout, run.
   - `remote-stop` — manual `dstack stop b00t-build`, on top of the automatic

--- a/justfile
+++ b/justfile
@@ -1454,3 +1454,47 @@ frigate-status:
     systemctl --user status frigate.service --no-pager || true
     echo "🔍 detector log (looking for teflon_tfl, watching for 'No NPU was detected'):"
     journalctl --user -u frigate.service --no-pager -n 100 | grep -iE "teflon_tfl|No NPU was detected" || echo "  (no matching lines yet)"
+
+# 🥾 Standby cloud build server (GCP dstack dev-environment) — recipes only,
+# deliberately no new b00t-cli subcommand (YAGNI, ops tooling not a
+# feature). See docs/superpowers/specs/2026-08-10-cloud-build-server-design.md
+# for the full design and dev-env/*.yaml for the actual dstack configs.
+# Requires the `dstack` CLI on PATH and a GCP backend already configured in
+# its config.yml (ambient Application Default Credentials — no secrets to
+# manage here).
+
+# Idempotent: applies the fleet then the volume then the dev-environment.
+# Run once before the first remote-push/remote-build/remote-test.
+remote-provision:
+    #!/bin/bash
+    set -euo pipefail
+    echo "🥾 provisioning b00t-build-fleet..."
+    dstack apply -f dev-env/b00t-build-fleet.yaml -y
+    echo "🥾 provisioning b00t-build-cache volume..."
+    dstack apply -f dev-env/b00t-build-cache.volume.yaml -y
+    echo "🥾 provisioning b00t-build dev-environment..."
+    dstack apply -f dev-env/b00t-build.dev-environment.yaml -y
+    echo "✅ b00t-build ready — ssh b00t-build, or: just remote-push <branch> && just remote-test <branch>"
+
+# Pushes local HEAD to a scratch branch on origin for the build box to fetch.
+# Git-native sync — no rsync, no reverse-SSH into a NAT'd local machine.
+remote-push branch:
+    git push origin HEAD:refs/heads/scratch/{{branch}}
+
+# SSHes into b00t-build, fetches + checks out the scratch branch, and runs
+# `cargo build`. Streams live over the SSH session — no polling, no
+# separate result-fetch step. First run after remote-provision is cold
+# (real full compile); every run after is warm because /data/b00t persists
+# on the volume independent of the dev-environment's own stop/resume.
+remote-build branch:
+    ssh b00t-build "cd /data/b00t && git fetch origin && git checkout scratch/{{branch}} && cargo build"
+
+# Same as remote-build, but `cargo test` instead.
+remote-test branch:
+    ssh b00t-build "cd /data/b00t && git fetch origin && git checkout scratch/{{branch}} && cargo test"
+
+# Manual stop — belt-and-suspenders alongside the fleet's own 30m
+# idle_duration auto-stop (explicit "I'm done for the day" vs. the idle
+# timer catching "forgot to").
+remote-stop:
+    dstack stop b00t-build -y


### PR DESCRIPTION
## Summary

Was doc-only (design doc recovered from a local-only branch, predates this session). Now implements what that doc already fully specified — `dev-env/*.yaml` + `just remote-*` recipes — per the design's own "Components" section. No new design decisions made here, just encoding what was already written.

**One real correction made while implementing, not assumed**: `idle_duration` belongs on `type: fleet`, not `type: dev-environment` as the original draft had it — verified against dstack's actual reference docs before writing any YAML. dstack also requires a fleet to exist before a dev-environment can be provisioned against it at all, which the original draft's "Components" list didn't include — added `b00t-build-fleet.yaml` to cover that. Design doc updated to match and flag the correction explicitly.

- `dev-env/b00t-build-fleet.yaml` — `type: fleet`, `nodes: 0..1`, no GPU, `idle_duration: 30m`
- `dev-env/b00t-build-cache.volume.yaml` — `type: volume`, GCP, 100GB, persists independent of the fleet's idle-stop
- `dev-env/b00t-build.dev-environment.yaml` — `type: dev-environment`, SSH-only, mounts the cache volume at `/data/b00t`
- `justfile`: `remote-provision`, `remote-push <branch>`, `remote-build <branch>`, `remote-test <branch>`, `remote-stop`

**This PR does not provision anything or spend any budget** — it's config + recipes, inert until an operator runs `just remote-provision` with `dstack` on PATH and a GCP backend configured. That's a deliberate, separate decision left to whoever chooses to actually stand this up.

## Test plan

- [x] All 3 YAML files parse (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] `justfile` recipes parse and interpolate correctly (`just --list`, `just --dry-run remote-provision/remote-push/remote-build`)
- [x] YAML schema (`type: volume` requiring `backend`+`region`, `type: fleet`'s `idle_duration`, the `volumes:` attach syntax) verified against dstack's real docs (raw.githubusercontent.com/dstackai/dstack), not guessed — matches this repo's own existing `DstackProvider` YAML-generation conventions (`b00t-cli/src/commands/provider.rs`) where they overlap
- [ ] End-to-end smoke test (the design doc's own acceptance criteria: provision succeeds, remote-test succeeds, and the real proof — idle-stop then resume does *not* trigger a cold rebuild) requires actually running this against GCP, which is exactly the step being left to the operator's discretion rather than done unilaterally in this session

🤖 Generated with [Claude Code](https://claude.com/claude-code)