### PR TITLE
fix(lfmf): stop salvage-path topic/body duplication + eliminate redundant colon re-split (#934)

### DIFF
--- a/_b00t_/learn/cargo-workspace-install.md
+++ b/_b00t_/learn/cargo-workspace-install.md
@@ -1,2 +1,2 @@
 ---
-Use-cargo-install---locked-for-workspace-path-binaries-to-preserve-the-repository-lockfile-and-MSRS-compatible-resolution: Use-cargo-install---locked-for-workspace-path-binaries-to-preserve-the-repository-lockfile-and-MSRS-compatible-resolution <!-- salvaged:no_colon -->
+cargo install --locked: use it for workspace path binaries to preserve the repository lockfile and MSRV-compatible resolution

--- a/_b00t_/learn/guard-session-fixtures.md
+++ b/_b00t_/learn/guard-session-fixtures.md
@@ -1,2 +1,2 @@
 ---
-Session guards a/b/c from June 27 b00t tests persisted in ~/.b00t/session-guards.json and blocked: Session guards a/b/c from June 27 b00t tests persisted in ~/.b00t/session-guards.json and blocked unrelated audited commands; tests MUST isolate or remove session guards on teardown. Operator checkpoint docs also use invalid rustc --edition without a value. <!-- salvaged:no_colon -->
+session guards must not leak across test runs: guards persisted in ~/.b00t/session-guards.json can block unrelated audited commands if not isolated or torn down; tests MUST clean up session guards on teardown

--- a/b00t-c0re-lib/src/lfmf.rs
+++ b/b00t-c0re-lib/src/lfmf.rs
@@ -212,12 +212,48 @@ impl LfmfSystem {
         tool_or_category.to_string()
     }
 
-    /// Record a lesson learned from failure
+    /// Record a lesson learned from failure.
+    ///
+    /// `lesson` is a raw "topic: body" string, independently re-split by
+    /// `parse_lesson` below. Callers that already hold a parsed topic/body
+    /// pair (e.g. the CLI's salvage-first parser) should call
+    /// `record_lesson_parts` instead to avoid a redundant, fragile second
+    /// parse of an already-formatted string (issue #934, defect 2).
     pub async fn record_lesson(&mut self, tool: &str, lesson: &str) -> Result<()> {
         // Resolve category (might be a datum name)
         let category = self.resolve_category(tool);
         let lesson_obj = self.parse_lesson(&category, lesson)?;
+        self.record_lesson_obj(lesson_obj).await
+    }
 
+    /// Record a lesson from an already-parsed topic/body pair — bypasses the
+    /// internal `split_once(':')` re-parse entirely. Use this whenever the
+    /// caller already knows topic and content separately (e.g. after
+    /// salvage-first parsing) instead of re-serializing into "topic: body"
+    /// and having it re-split here (issue #934, defect 2).
+    pub async fn record_lesson_parts(
+        &mut self,
+        tool: &str,
+        topic: &str,
+        content: &str,
+    ) -> Result<()> {
+        let category = self.resolve_category(tool);
+        let lesson_obj = Lesson {
+            tool: category.clone(),
+            topic: topic.to_string(),
+            content: content.to_string(),
+            timestamp: Utc::now(),
+            confidence: Some(1.0),
+            error_pattern: Some(topic.to_string()),
+            solution: Some(content.to_string()),
+            tags: vec![category, "lfmf".to_string()],
+        };
+        self.record_lesson_obj(lesson_obj).await
+    }
+
+    /// Shared post-parse recording logic: durable filesystem write first,
+    /// then best-effort vector-DB enrichment with circuit-breaker fallback.
+    async fn record_lesson_obj(&mut self, lesson_obj: Lesson) -> Result<()> {
         // 🤓 Durable-first: the filesystem write MUST precede vector enrichment.
         // A death between the two (SIGPIPE from a truncating pipe, ctrl-c, crash)
         // must never lose the payload — the cheap local store is the source of

--- a/b00t-cli/src/commands/lfmf.rs
+++ b/b00t-cli/src/commands/lfmf.rs
@@ -35,6 +35,11 @@ pub struct ParsedLesson {
     pub salvage: Option<String>,
 }
 
+/// Auto-derived topics (no real ':' topic supplied) are a SHORT stub label —
+/// capped well below topic_max so a lesson that fits entirely under budget
+/// doesn't get its whole body echoed back as "topic" (issue #934).
+const DERIVED_TOPIC_STUB_TOKENS: usize = 8;
+
 /// Longest word-prefix of `text` that fits within `topic_max` tokens (≥1 word).
 fn auto_topic(text: &str, count_tokens: &dyn Fn(&str) -> usize, topic_max: usize) -> String {
     let words: Vec<&str> = text.split_whitespace().collect();
@@ -58,7 +63,7 @@ pub fn parse_lesson_salvage(
     let Some((topic_part, body_part)) = raw.split_once(':') else {
         // No colon — derive topic from the lesson itself, keep full payload as body.
         return ParsedLesson {
-            topic: auto_topic(raw, count_tokens, topic_max),
+            topic: auto_topic(raw, count_tokens, topic_max.min(DERIVED_TOPIC_STUB_TOKENS)),
             body: raw.to_string(),
             salvage: Some("no_colon".to_string()),
         };
@@ -69,7 +74,7 @@ pub fn parse_lesson_salvage(
     // First colon belongs to a URL scheme (https://…) — not a topic separator.
     if body_part.starts_with("//") {
         return ParsedLesson {
-            topic: auto_topic(raw, count_tokens, topic_max),
+            topic: auto_topic(raw, count_tokens, topic_max.min(DERIVED_TOPIC_STUB_TOKENS)),
             body: raw.to_string(),
             salvage: Some("url_colon".to_string()),
         };
@@ -77,7 +82,7 @@ pub fn parse_lesson_salvage(
 
     if topic_part.is_empty() {
         return ParsedLesson {
-            topic: auto_topic(body_part, count_tokens, topic_max),
+            topic: auto_topic(body_part, count_tokens, topic_max.min(DERIVED_TOPIC_STUB_TOKENS)),
             body: body_part.to_string(),
             salvage: Some("empty_part".to_string()),
         };
@@ -111,6 +116,21 @@ pub fn parse_lesson_salvage(
         topic: topic_part.to_string(),
         body: body_part.to_string(),
         salvage: None,
+    }
+}
+
+/// Render a parsed lesson's body for storage, appending the salvage marker
+/// (if any) so entries stay greppable for the distillery (task #98).
+///
+/// Pure and separately testable — this used to be inlined into `handle_lfmf`
+/// as part of building a WHOLE "topic: body" string that then got re-parsed
+/// by `LfmfSystem::record_lesson`'s own `split_once(':')` (issue #934,
+/// defect 2). Callers now pass topic/body straight through
+/// `record_lesson_parts` and use this only for the stored body text.
+pub fn format_stored_content(parsed: &ParsedLesson) -> String {
+    match &parsed.salvage {
+        Some(kind) => format!("{} <!-- salvaged:{} -->", parsed.body, kind),
+        None => parsed.body.clone(),
     }
 }
 
@@ -213,16 +233,16 @@ pub async fn handle_lfmf(path: &str, tool: &str, lesson: &str, scope: &str) -> R
     // Scope handling: currently only memoized, extend LfmfSystem for future
     println!("Scope: {}", scope);
 
-    // Storage format is "topic: body" — topic must stay colon-free or the core
-    // parse_lesson re-split corrupts it (URL-derived topics contain ':').
+    // Topic must stay colon-free — it's stored as its own field now (no more
+    // "topic: body" re-serialize-then-re-split), but a stray ':' in a
+    // synthesized topic would still read oddly as a label.
     let safe_topic = parsed.topic.replace(':', "");
-    let stored = match &parsed.salvage {
-        // Salvage marker keeps entries greppable for the distillery (task #98).
-        Some(kind) => format!("{}: {} <!-- salvaged:{} -->", safe_topic, parsed.body, kind),
-        None => format!("{}: {}", safe_topic, parsed.body),
-    };
+    let stored_content = format_stored_content(&parsed);
 
-    if let Err(e) = lfmf_system.record_lesson(tool, &stored).await {
+    if let Err(e) = lfmf_system
+        .record_lesson_parts(tool, &safe_topic, &stored_content)
+        .await
+    {
         log_event(&LfmfTelemetryEvent::now(
             LfmfAction::Record,
             tool,

--- a/b00t-cli/tests/fixtures/lfmf_salvage_cases.json
+++ b/b00t-cli/tests/fixtures/lfmf_salvage_cases.json
@@ -51,6 +51,27 @@
       "topic": "just a body here",
       "body": "just a body here",
       "salvage": "empty_part"
+    },
+    {
+      "name": "colon_in_body",
+      "raw": "atomic commits: use 'a: b' style commit messages consistently",
+      "topic": "atomic commits",
+      "body": "use 'a: b' style commit messages consistently",
+      "salvage": null
+    },
+    {
+      "name": "unicode_no_colon",
+      "raw": "Ω café naïve 日本語 emoji 🎉 works fine today",
+      "topic": "Ω café naïve 日本語 emoji",
+      "body": "Ω café naïve 日本語 emoji 🎉 works fine today",
+      "salvage": "no_colon"
+    },
+    {
+      "name": "embedded_newline_well_formed",
+      "raw": "topic label: line one\nline two continues here",
+      "topic": "topic label",
+      "body": "line one\nline two continues here",
+      "salvage": null
     }
   ]
 }

--- a/b00t-cli/tests/fixtures/lfmf_writer_cases.json
+++ b/b00t-cli/tests/fixtures/lfmf_writer_cases.json
@@ -1,0 +1,33 @@
+{
+  "comment": "Production-scale (real o200k_base tiktoken, topic_max=25, body_max=250) regression fixtures for issue #934 — locks in the anti-duplication fix (DERIVED_TOPIC_STUB_TOKENS) and the redundant-second-parse elimination. The '_regression' cases mirror the two _b00t_/learn/*.md entries that were corrupted by the pre-fix code (whole colon-free lesson echoed back as both topic and body); '_well_formed' cases use the proper 'topic: body' syntax used to re-emit those same lessons cleanly.",
+  "topic_max": 25,
+  "body_max": 250,
+  "cases": [
+    {
+      "name": "cargo_workspace_install_regression",
+      "raw": "Use `cargo install --locked` for workspace path binaries to preserve the repository lockfile and MSRV-compatible resolution",
+      "expect_salvage": "no_colon",
+      "assert_anti_duplication": true
+    },
+    {
+      "name": "guard_session_fixtures_regression",
+      "raw": "Session guards persisted in ~/.b00t/session-guards.json can block unrelated audited commands if not isolated or torn down and tests must clean up session guards on teardown",
+      "expect_salvage": "no_colon",
+      "assert_anti_duplication": true
+    },
+    {
+      "name": "cargo_workspace_install_well_formed",
+      "raw": "cargo install --locked: use it for workspace path binaries to preserve the repository lockfile and MSRV-compatible resolution",
+      "expect_salvage": null,
+      "expect_topic": "cargo install --locked",
+      "expect_body": "use it for workspace path binaries to preserve the repository lockfile and MSRV-compatible resolution"
+    },
+    {
+      "name": "guard_session_fixtures_well_formed",
+      "raw": "session guards must not leak across test runs: guards persisted in ~/.b00t/session-guards.json can block unrelated audited commands if not isolated or torn down; tests MUST clean up session guards on teardown",
+      "expect_salvage": null,
+      "expect_topic": "session guards must not leak across test runs",
+      "expect_body": "guards persisted in ~/.b00t/session-guards.json can block unrelated audited commands if not isolated or torn down; tests MUST clean up session guards on teardown"
+    }
+  ]
+}

--- a/b00t-cli/tests/lfmf_writer_test.rs
+++ b/b00t-cli/tests/lfmf_writer_test.rs
@@ -1,0 +1,119 @@
+//! Production-scale salvage writer regression tests — issue #934.
+//!
+//! Cases in tests/fixtures/lfmf_writer_cases.json. Unlike
+//! lfmf_salvage_test.rs (word-count token stub, small topic_max), this uses
+//! the REAL o200k_base tiktoken counter and production topic_max=25 /
+//! body_max=250 to lock in two things at the scale that actually shipped a
+//! bug:
+//!
+//! 1. Anti-duplication: a colon-free lesson under body_max no longer gets
+//!    its entire text echoed back as "topic" (topic == body verbatim) —
+//!    auto_topic() for synthesized topics is now capped at
+//!    DERIVED_TOPIC_STUB_TOKENS (8), not the full topic_max (25).
+//! 2. format_stored_content() renders the stored body text exactly once —
+//!    no redundant re-parse of an already-formatted "topic: body" string
+//!    (that redundant split_once(':') lived in
+//!    LfmfSystem::record_lesson/parse_lesson; the CLI now calls
+//!    record_lesson_parts with topic/body already separated).
+
+use b00t_cli::commands::lfmf::{format_stored_content, parse_lesson_salvage};
+use serde::Deserialize;
+use std::path::PathBuf;
+use tiktoken_rs::o200k_base;
+
+#[derive(Deserialize)]
+struct Fixture {
+    topic_max: usize,
+    body_max: usize,
+    cases: Vec<Case>,
+}
+
+#[derive(Deserialize)]
+struct Case {
+    name: String,
+    raw: String,
+    expect_salvage: Option<String>,
+    #[serde(default)]
+    assert_anti_duplication: bool,
+    #[serde(default)]
+    expect_topic: Option<String>,
+    #[serde(default)]
+    expect_body: Option<String>,
+}
+
+#[test]
+fn writer_cases_from_fixture_production_scale() {
+    let path =
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/lfmf_writer_cases.json");
+    let fixture: Fixture =
+        serde_json::from_str(&std::fs::read_to_string(&path).expect("fixture readable"))
+            .expect("fixture parses");
+
+    let bpe = o200k_base().expect("tiktoken o200k_base loads");
+    let count_tokens = |s: &str| bpe.encode_with_special_tokens(s).len();
+
+    for case in &fixture.cases {
+        let parsed =
+            parse_lesson_salvage(&case.raw, &count_tokens, fixture.topic_max, fixture.body_max);
+
+        assert_eq!(
+            parsed.salvage, case.expect_salvage,
+            "salvage mismatch in case '{}'",
+            case.name
+        );
+
+        if case.assert_anti_duplication {
+            // The core regression this issue is about: a synthesized topic
+            // must never just BE the body (issue #934's "salvaged:no_colon"
+            // duplication) — it's a short derived stub, not an echo.
+            assert_ne!(
+                parsed.topic, parsed.body,
+                "topic duplicated body verbatim in case '{}' — issue #934 regression",
+                case.name
+            );
+            assert!(
+                parsed.topic.len() < parsed.body.len() / 2,
+                "topic not meaningfully shorter than body in case '{}': topic={:?} body={:?}",
+                case.name,
+                parsed.topic,
+                parsed.body
+            );
+            // Payload preservation still holds even with the capped stub.
+            for word in case.raw.split_whitespace() {
+                assert!(
+                    parsed.body.contains(word) || parsed.topic.contains(word),
+                    "payload word '{}' lost in case '{}'",
+                    word,
+                    case.name
+                );
+            }
+        }
+
+        if let Some(expect_topic) = &case.expect_topic {
+            assert_eq!(&parsed.topic, expect_topic, "topic mismatch in case '{}'", case.name);
+        }
+        if let Some(expect_body) = &case.expect_body {
+            assert_eq!(&parsed.body, expect_body, "body mismatch in case '{}'", case.name);
+        }
+
+        // Well-formed cases (no salvage) must round-trip through the stored
+        // content helper as an exact match to the parsed body — no marker,
+        // no re-formatting surprises.
+        if case.expect_salvage.is_none() {
+            assert_eq!(
+                format_stored_content(&parsed),
+                parsed.body,
+                "stored content mismatch (well-formed) in case '{}'",
+                case.name
+            );
+        } else {
+            let expected_kind = case.expect_salvage.as_ref().unwrap();
+            assert_eq!(
+                format_stored_content(&parsed),
+                format!("{} <!-- salvaged:{} -->", parsed.body, expected_kind),
+                "stored content mismatch (salvaged) in case '{}'",
+                case.name
+            );
+        }
+    }
+}

--- a/justfile
+++ b/justfile
@@ -543,6 +543,10 @@ test:
 test-b00t-mcp:
     cargo test -p b00t-mcp
 
+# Salvage-first lfmf writer round-trip — zero duplication, zero payload loss (issue #934).
+test-lfmf-roundtrip:
+    cargo test -p b00t-cli --test lfmf_salvage_test --test lfmf_writer_test
+
 # Format the b00t-mcp crate through the registered action surface.
 format-b00t-mcp:
     rustfmt --edition 2024 b00t-mcp/src/chat.rs b00t-mcp/src/mcp_server_rusty.rs b00t-mcp/src/mcp_tools.rs


### PR DESCRIPTION
## Summary

Fixes issue #934: the lfmf salvage path was duplicating topic/body content and doing a redundant colon re-split. Adds test fixtures and a dedicated `lfmf_writer_test.rs` covering the writer/salvage cases.

Recovered from a local-only branch during a repo-wide branch audit — original work predates this session.

Opened as draft — needs review before it's ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TiJPJsZZDCoAGAhzkfkk3k