### PR TITLE
feat(b00t-cli): model the dispatch chain as round-trip-validated SysML v2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -300,6 +300,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ar_archive_writer"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73cd58deff2140a0a8eae87e417bd01db68a33e148aa93d1e8cd837e55e312b6"
+dependencies = [
+ "object",
+]
+
+[[package]]
 name = "arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1386,7 +1395,7 @@ dependencies = [
  "futures",
  "handlebars",
  "reqwest 0.12.28",
- "schemars",
+ "schemars 1.2.1",
  "serde",
  "serde_json",
  "tokio",
@@ -1427,7 +1436,7 @@ dependencies = [
  "futures",
  "reqwest 0.12.28",
  "rmcp",
- "schemars",
+ "schemars 1.2.1",
  "serde",
  "serde_json",
  "tokio",
@@ -1538,7 +1547,7 @@ dependencies = [
  "rhai",
  "rig-core",
  "rmcp",
- "schemars",
+ "schemars 1.2.1",
  "scraper",
  "serde",
  "serde_json",
@@ -1909,7 +1918,7 @@ dependencies = [
  "regex",
  "reqwest 0.12.28",
  "rmcp",
- "schemars",
+ "schemars 1.2.1",
  "serde",
  "serde_json",
  "shellexpand",
@@ -7476,7 +7485,7 @@ dependencies = [
  "jiff",
  "json-patch",
  "k8s-openapi",
- "schemars",
+ "schemars 1.2.1",
  "serde",
  "serde-value",
  "serde_json",
@@ -8802,6 +8811,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.39.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e5a6c098c7a3b6547378093f5cc30bc54fd361ce711e05293a5cc589562739b"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9946,6 +9964,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "psm"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dcd034599e63b970727f70d79e02d62390a4a84f7c6b827c27c46d5ac3fa622"
+dependencies = [
+ "ar_archive_writer",
+ "cc",
+]
+
+[[package]]
 name = "ptr_meta"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10813,7 +10841,7 @@ dependencies = [
  "ordered-float 5.3.0",
  "pin-project-lite",
  "reqwest 0.12.28",
- "schemars",
+ "schemars 1.2.1",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -10908,7 +10936,7 @@ dependencies = [
  "process-wrap",
  "rand 0.10.2",
  "rmcp-macros",
- "schemars",
+ "schemars 1.2.1",
  "serde",
  "serde_json",
  "sse-stream",
@@ -11313,6 +11341,18 @@ dependencies = [
 
 [[package]]
 name = "schemars"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
+dependencies = [
+ "dyn-clone",
+ "schemars_derive 0.8.22",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
@@ -11320,9 +11360,21 @@ dependencies = [
  "chrono",
  "dyn-clone",
  "ref-cast",
- "schemars_derive",
+ "schemars_derive 1.2.1",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -12507,6 +12559,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7386b49cb287f6fafbfd3bd604914bccb99fb8d53483f40e1ecfda5d45f3370"
 
 [[package]]
+name = "stacker"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707f49d46706bacf8a2b00d51dace3f9de527c13eec3778f570c411f89e69967"
+dependencies = [
+ "cc",
+ "cfg-if 1.0.4",
+ "libc",
+ "psm",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12762,6 +12827,18 @@ dependencies = [
  "objc2-core-foundation",
  "objc2-io-kit",
  "windows",
+]
+
+[[package]]
+name = "sysml-v2-parser"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5db89688b6bab9dacbf8150e3f32f636decd36e34fcb8aaacbdb52fe281a9134"
+dependencies = [
+ "log",
+ "nom 8.0.0",
+ "nom_locate",
+ "stacker",
 ]
 
 [[package]]
@@ -13890,12 +13967,14 @@ dependencies = [
 
 [[package]]
 name = "ufo-types"
-version = "0.10.2"
-source = "git+https://github.com/PromptExecution/ufo-types.git?tag=v0.10.2#443482ce04966c2d0ff41af56941d06c2687eeb7"
+version = "0.11.0"
+source = "git+https://github.com/PromptExecution/ufo-types.git?rev=19422ac1988f916c83e15260b1f1a8969ef8d65a#19422ac1988f916c83e15260b1f1a8969ef8d65a"
 dependencies = [
  "chrono",
+ "schemars 0.8.22",
  "serde",
  "serde_json",
+ "sysml-v2-parser",
  "thiserror 2.0.18",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,10 @@ diffy = "0.5"
 # It has no _b00t_-specific deps; pulling it via a plain crate-scoped git dep
 # avoids consumers of ufo-types (e.g. external repos like app4dog) needing to
 # clone this entire 34-submodule monorepo just to get a ~3k-line types crate.
-ufo-types = { git = "https://github.com/PromptExecution/ufo-types.git", tag = "v0.10.2" }
+# Pinned by rev, not the v0.10.2 tag: v0.10.2 predates the `sysml`/`mbse`/
+# `iso_ir` modules added right after it (b00t SysML v2 spine consolidation
+# epic, elasticdotventures/_b00t_#1177) — no tag covers them yet.
+ufo-types = { git = "https://github.com/PromptExecution/ufo-types.git", rev = "19422ac1988f916c83e15260b1f1a8969ef8d65a" }
 # Workspace members
 b00t-cli = { path = "b00t-cli" }
 b00t-c0re-lib = { path = "b00t-c0re-lib" }

--- a/b00t-c0re-lib/src/ai_artifact.rs
+++ b/b00t-c0re-lib/src/ai_artifact.rs
@@ -555,14 +555,11 @@ pub struct ArtifactExtractionConstraint {
 impl Satisfies<ArtifactExtractionConstraint> for ArtifactExtractionManifest {
     fn satisfies(&self, constraint: &ArtifactExtractionConstraint) -> SatisfiesResult {
         if self.artifacts.len() < constraint.min_artifacts {
-            return SatisfiesResult::violated(
-                format!(
-                    "artifact count {} below required {}",
-                    self.artifacts.len(),
-                    constraint.min_artifacts
-                ),
-                1.0,
-            );
+            return SatisfiesResult::violated(format!(
+                "artifact count {} below required {}",
+                self.artifacts.len(),
+                constraint.min_artifacts
+            ));
         }
 
         let below_threshold = self
@@ -571,13 +568,12 @@ impl Satisfies<ArtifactExtractionConstraint> for ArtifactExtractionManifest {
             .filter(|artifact| f64::from(artifact.confidence()) < constraint.min_confidence)
             .count();
         if below_threshold > 0 {
-            return SatisfiesResult::violated(
-                format!("{below_threshold} artifacts below confidence threshold"),
-                1.0,
-            );
+            return SatisfiesResult::violated(format!(
+                "{below_threshold} artifacts below confidence threshold"
+            ));
         }
 
-        SatisfiesResult::satisfied(1.0)
+        SatisfiesResult::satisfied(1.0, Vec::new())
     }
 }
 

--- a/b00t-cli/Cargo.toml
+++ b/b00t-cli/Cargo.toml
@@ -52,7 +52,10 @@ b00t-bouncer = { path = "../b00t-bouncer" }
 blessed = { path = "../blessed" }
 b00t-grok = { workspace = true }
 k0mmand3r = { workspace = true }
-ufo-types = { workspace = true }
+# "sysml" feature unlocks ufo_types::sysml::validate_sysml_v2 (real SysML v2
+# grammar validation, via sysml-v2-parser) for the dispatch-chain round-trip
+# test — see src/dispatch_sysml.rs.
+ufo-types = { workspace = true, features = ["sysml"] }
 duct = "1.0"
 shellexpand = "3.1"
 shlex = "1.3"

--- a/b00t-cli/src/commands/datum.rs
+++ b/b00t-cli/src/commands/datum.rs
@@ -1208,12 +1208,12 @@ impl Satisfies<BootDatumSchemaConstraint> for DatumTomlSubject<'_> {
     fn satisfies(&self, c: &BootDatumSchemaConstraint) -> SatisfiesResult {
         let outcome = compute_datum_validation(self.raw, self.filename, c.strict);
         if !outcome.errors.is_empty() {
-            return SatisfiesResult::violated(outcome.errors.join("; "), 1.0);
+            return SatisfiesResult::violated(outcome.errors.join("; "));
         }
         if outcome.extension_check_undecidable {
-            return SatisfiesResult::unknown(0.5);
+            return SatisfiesResult::unknown();
         }
-        SatisfiesResult::satisfied(1.0)
+        SatisfiesResult::satisfied(1.0, Vec::new())
     }
 }
 

--- a/b00t-cli/src/commands/ontology.rs
+++ b/b00t-cli/src/commands/ontology.rs
@@ -254,7 +254,7 @@ impl Satisfies<DatumValidateConstraint> for DatumMeta {
     ///     pass/fail, we did not determine it to be false)
     fn satisfies(&self, _c: &DatumValidateConstraint) -> SatisfiesResult {
         if self.validate.command.is_empty() {
-            return SatisfiesResult::unknown(0.0);
+            return SatisfiesResult::unknown();
         }
         // Expand ~ to the actual home directory so validate commands like
         // `git -C ~/.b00t cat-file -e <hash>` work without shell expansion.
@@ -264,7 +264,7 @@ impl Satisfies<DatumValidateConstraint> for DatumMeta {
         let expanded = self.validate.command.replace('~', &home);
         let parts: Vec<&str> = expanded.split_whitespace().collect();
         if parts.is_empty() {
-            return SatisfiesResult::unknown(0.0);
+            return SatisfiesResult::unknown();
         }
         match Command::new(parts[0]).args(&parts[1..]).output() {
             Ok(output) => {
@@ -275,25 +275,27 @@ impl Satisfies<DatumValidateConstraint> for DatumMeta {
                 );
                 if self.validate.regex.is_empty() {
                     if output.status.success() {
-                        SatisfiesResult::satisfied(1.0)
+                        SatisfiesResult::satisfied(1.0, Vec::new())
                     } else {
-                        SatisfiesResult::violated(
-                            format!("command exited {:?}", output.status.code()),
-                            1.0,
-                        )
+                        SatisfiesResult::violated(format!(
+                            "command exited {:?}",
+                            output.status.code()
+                        ))
                     }
                 } else {
                     match regex::Regex::new(&self.validate.regex) {
-                        Ok(re) if re.is_match(&combined) => SatisfiesResult::satisfied(1.0),
-                        Ok(_) => SatisfiesResult::violated(
-                            format!("output did not match /{}/", self.validate.regex),
-                            1.0,
-                        ),
-                        Err(_) => SatisfiesResult::unknown(0.0),
+                        Ok(re) if re.is_match(&combined) => {
+                            SatisfiesResult::satisfied(1.0, Vec::new())
+                        }
+                        Ok(_) => SatisfiesResult::violated(format!(
+                            "output did not match /{}/",
+                            self.validate.regex
+                        )),
+                        Err(_) => SatisfiesResult::unknown(),
                     }
                 }
             }
-            Err(_) => SatisfiesResult::unknown(0.0),
+            Err(_) => SatisfiesResult::unknown(),
         }
     }
 }

--- a/b00t-cli/src/dispatch.rs
+++ b/b00t-cli/src/dispatch.rs
@@ -37,7 +37,22 @@ pub enum DatumDispatch {
 // `result_is_implied_by` stereotype filter, so modes stay independent.
 
 /// A single resolution strategy for `b00t <name>` dispatch.
+///
+/// `name()` (b00t SysML v2 spine consolidation, `elasticdotventures/_b00t_#1177`)
+/// lets `dispatch_sysml` classify each mode as a node without a second registry
+/// naming them again by hand — its default body derives the name straight from
+/// `std::any::type_name::<Self>()`, so a new implementor gets a correct `name()`
+/// for free just by being a distinctly-named unit struct; override it only if a
+/// mode ever needs a display name that isn't its own Rust type name.
 pub trait DispatchMode {
+    /// Stable identifier for this mode — used by `dispatch_sysml` to name it as a
+    /// node in the chain's SysML v2 / iso-IR representation, not by dispatch itself.
+    fn name(&self) -> &'static str {
+        std::any::type_name::<Self>()
+            .rsplit("::")
+            .next()
+            .unwrap()
+    }
     /// Attempt to resolve `candidate` (looked up under `path`) into a dispatch action.
     fn try_resolve(&self, candidate: &str, path: &str) -> Option<DatumDispatch>;
 }

--- a/b00t-cli/src/dispatch_sysml.rs
+++ b/b00t-cli/src/dispatch_sysml.rs
@@ -1,0 +1,144 @@
+//! Represents `dispatch::default_dispatch_chain()` — the real, live router
+//! `b00t <name>` resolution walks — as a version-controlled, round-trip-validated
+//! SysML v2 model. First prototype of the b00t SysML v2 spine consolidation epic's
+//! P1 milestone (`elasticdotventures/_b00t_#1177`): a Rust type (`dyn DispatchMode`)
+//! becomes a compiled SysML v2 output, validated against the real `sysml-v2-parser`
+//! grammar via `ufo_types::sysml::validate_sysml_v2` — the same round-trip discipline
+//! `ledgrrr`'s `holon-viz::sysml_v2_roundtrip` tests use.
+//!
+//! Node/edge shape follows `systhread-core::iso_ir::extract_pipeline`'s "sequence"
+//! pattern exactly (each mode a node, consecutive modes in priority order joined by
+//! a `sequence` edge) — the dispatch chain genuinely is an ordered phase sequence,
+//! not a general graph, so no richer shape is needed for this first prototype.
+//!
+//! `DispatchMode` isn't `Stereotyped` — each mode's classification is derived here,
+//! directly from its own `name()`, rather than requiring every implementor to carry
+//! a hand-written `impl Stereotyped` block just to be exportable. A blanket
+//! `impl<T: DispatchMode> Stereotyped for T` doesn't work here even though it looks
+//! tempting: `Stereotyped` would need to be a supertrait for `dispatch.rs`'s own
+//! `mode.ufo_stereotype()` calls to typecheck, and a supertrait bound must already be
+//! satisfied before a type can implement the subtrait — circular.
+
+use ufo_types::iso_ir::{Edge, Node};
+use ufo_types::stereotype::UfoStereotype;
+
+use crate::dispatch::default_dispatch_chain;
+
+/// Build the `Node`/`Edge` iso-IR for the dispatch chain's current, real order.
+pub fn dispatch_chain_iso_ir() -> (Vec<Node>, Vec<Edge>) {
+    let chain = default_dispatch_chain();
+    let names: Vec<&'static str> = chain.iter().map(|mode| mode.name()).collect();
+
+    let nodes: Vec<Node> = names
+        .iter()
+        .map(|name| Node {
+            id: (*name).to_string(),
+            label: (*name).to_string(),
+            part_type: "DispatchMode".to_string(),
+        })
+        .collect();
+
+    let edges: Vec<Edge> = names
+        .windows(2)
+        .map(|pair| Edge {
+            id: format!("{}_next", pair[0]),
+            from: pair[0].to_string(),
+            to: pair[1].to_string(),
+            edge_type: "sequence".to_string(),
+            kind: None,
+        })
+        .collect();
+
+    (nodes, edges)
+}
+
+/// Export the dispatch chain as SysML v2 text: one `part def` per mode, each
+/// specializing (`:>`) the previous mode in priority order — the chain genuinely
+/// is a linear priority sequence, so each step's real predecessor becomes its
+/// SysML v2 base type, with a `UfoStereotype::Process` classification (derived
+/// straight from the mode's own `name()`) and the sequence relationship both
+/// recorded as comments (matching `critter-keeper::mesh_safety_gate`'s comment
+/// convention).
+///
+/// `holon-viz::SysmlV2Emitter`'s edge-emission shape (`part def X : Y`, plain
+/// `:` rather than `:>`) was the original model for this function, but that
+/// path turned out to be dead code in `holon-viz`'s own test fixture — its
+/// `CytoscapeGraph` never actually carries containment edges from
+/// `Holon::child`'s parent link, so `:` was never exercised against the real
+/// `sysml-v2-parser` grammar. This function's own round-trip test below is
+/// what caught that: SysML v2's specialization operator is `:>`, not `:`, and
+/// a `part def` name also cannot be redeclared once already emitted as a plain
+/// definition — hence chaining `:>` directly off each mode's own declaration
+/// instead of the original two-pass (all-nodes, then separately-named edges)
+/// shape.
+pub fn dispatch_chain_to_sysml_v2() -> String {
+    let chain = default_dispatch_chain();
+
+    let mut out = String::from("package B00tDispatchChain {\n");
+
+    for (i, mode) in chain.iter().enumerate() {
+        let stereotype = UfoStereotype::Process(mode.name().to_string());
+        if i == 0 {
+            out.push_str(&format!(
+                "    part def {} {{\n        // {stereotype}\n    }}\n",
+                mode.name()
+            ));
+        } else {
+            let prev = chain[i - 1].name();
+            out.push_str(&format!(
+                "    part def {} :> {} {{\n        // {stereotype}\n        // sequence: {} -> {}\n    }}\n",
+                mode.name(),
+                prev,
+                prev,
+                mode.name()
+            ));
+        }
+    }
+
+    out.push_str("}\n");
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn iso_ir_has_one_node_per_chain_entry_and_sequence_edges_between_consecutive_pairs() {
+        let (nodes, edges) = dispatch_chain_iso_ir();
+        let chain_len = default_dispatch_chain().len();
+
+        assert_eq!(nodes.len(), chain_len);
+        assert_eq!(edges.len(), chain_len - 1);
+        assert!(edges.iter().all(|e| e.edge_type == "sequence"));
+
+        assert_eq!(nodes[0].id, "RuntimeMode");
+        assert_eq!(nodes[1].id, "CliPassthroughMode");
+        assert_eq!(edges[0].from, "RuntimeMode");
+        assert_eq!(edges[0].to, "CliPassthroughMode");
+    }
+
+    #[test]
+    fn sysml_v2_export_contains_every_mode_and_every_sequence_edge() {
+        let sysml = dispatch_chain_to_sysml_v2();
+        for mode in &default_dispatch_chain() {
+            assert!(
+                sysml.contains(mode.name()),
+                "missing mode {} in:\n{sysml}",
+                mode.name()
+            );
+        }
+        assert!(sysml.contains("sequence: RuntimeMode -> CliPassthroughMode"));
+    }
+
+    #[test]
+    fn sysml_v2_export_round_trips_through_the_real_parser() {
+        let sysml = dispatch_chain_to_sysml_v2();
+        let result = ufo_types::sysml::validate_sysml_v2(&sysml);
+        assert!(
+            result.disposition.is_satisfied(),
+            "dispatch_chain_to_sysml_v2() output failed to parse as SysML v2: {:?}\n---\n{sysml}",
+            result.disposition
+        );
+    }
+}

--- a/b00t-cli/src/gates.rs
+++ b/b00t-cli/src/gates.rs
@@ -414,7 +414,7 @@ impl IsoAuditable for GatePreconditions<'_> {
 impl Satisfies<GatePreconditions<'_>> for crate::BootDatum {
     fn satisfies(&self, c: &GatePreconditions<'_>) -> SatisfiesResult {
         if c.gates.is_empty() {
-            return SatisfiesResult::satisfied(1.0);
+            return SatisfiesResult::satisfied(1.0, Vec::new());
         }
 
         let dispositions: Vec<Disposition> = c
@@ -431,17 +431,17 @@ impl Satisfies<GatePreconditions<'_>> for crate::BootDatum {
             })
             .collect();
         if !violated.is_empty() {
-            return SatisfiesResult::violated(violated.join("; "), 1.0);
+            return SatisfiesResult::violated(violated.join("; "));
         }
 
         if dispositions
             .iter()
             .any(|d| matches!(d, Disposition::Unknown))
         {
-            return SatisfiesResult::unknown(0.5);
+            return SatisfiesResult::unknown();
         }
 
-        SatisfiesResult::satisfied(1.0)
+        SatisfiesResult::satisfied(1.0, Vec::new())
     }
 }
 

--- a/b00t-cli/src/lib.rs
+++ b/b00t-cli/src/lib.rs
@@ -155,6 +155,7 @@ pub mod gates;
 pub mod checklist;
 pub mod hooks;
 pub mod dispatch;
+pub mod dispatch_sysml;
 pub mod lifecycle;
 
 pub use datum_types::*;


### PR DESCRIPTION
## Summary

P1 milestone, first prototype (`elasticdotventures/_b00t_#1177` — b00t SysML v2 spine consolidation epic): the real, live `default_dispatch_chain()` router `b00t-cli`'s `b00t <name>` dispatch walks is now representable as SysML v2 text, validated against the real `sysml-v2-parser` grammar via `ufo_types::sysml::validate_sysml_v2` (new `b00t-cli/src/dispatch_sysml.rs`, mirroring `ledgrrr`'s `holon-viz::sysml_v2_roundtrip` pattern).

- Each `DispatchMode` chains onto its predecessor via SysML v2's `:>` specialization operator. The round-trip test itself caught that plain `:` (not `:>`) is invalid syntax — a bug the emitter this was modeled on (`holon-viz::SysmlV2Emitter`) never actually exercised: its own containment-edge test never produces edges at all (`CytoscapeGraph::from_holons` doesn't carry `Holon::child`'s parent link as an edge), so that code path was dead.
- `DispatchMode::name()` is now a default trait method deriving from `std::any::type_name::<Self>()` rather than a hand-written override per implementor — adding a new dispatch mode needs only `try_resolve()`. Considered making each mode `Stereotyped` directly, but a blanket `impl<T: DispatchMode> Stereotyped for T` is circular through the supertrait bound; `dispatch_sysml.rs` derives the `UfoStereotype` classification from `name()` at its one use site instead.
- Bumped the workspace's `ufo-types` pin off `v0.10.2` (rev `19422ac`, unlocks the `sysml`/`mbse`/`iso_ir` modules this depends on) and enabled the `sysml` feature for `b00t-cli`.

That pin bump broke 3 call sites written against the old `ufo_types::satisfies::SatisfiesResult` API (`satisfied()` gained an `evidence_nodes` param, `violated()`/`unknown()` lost a `confidence` param) — fixed in `ai_artifact.rs`, `gates.rs`, `commands/datum.rs`, `commands/ontology.rs`.

Two follow-on oxidation opportunities spotted while working this (filed separately, not part of this PR): #1184, #1185.

## Test plan
- [x] `cargo test -p b00t-cli --lib dispatch` — 24/24 passed (existing `dispatch.rs` tests + 3 new `dispatch_sysml` tests including the `validate_sysml_v2` round-trip)
- [x] Full pre-push gate (1578 tests, 4 ignored) — passed