### PR TITLE
chore(b00t-cli): stringify!() the self-referential SubKind name literals

### DIFF
--- a/b00t-cli/src/datum_types.rs
+++ b/b00t-cli/src/datum_types.rs
@@ -275,39 +275,39 @@ impl Stereotyped for DatumType {
         match self {
             // ── container/orchestration engines — SubKind of abstract ContainerRuntime ──
             Self::Docker => UfoStereotype::SubKind {
-                name: "Docker".into(),
+                name: stringify!(Docker).into(),
                 parent: "ContainerRuntime".into(),
             },
             Self::Podman => UfoStereotype::SubKind {
-                name: "Podman".into(),
+                name: stringify!(Podman).into(),
                 parent: "ContainerRuntime".into(),
             },
             Self::K8s => UfoStereotype::SubKind {
-                name: "K8s".into(),
+                name: stringify!(K8s).into(),
                 parent: "ContainerRuntime".into(),
             },
 
             // ── executable surface — SubKind of abstract Executable ─────────────────────
             Self::Cli => UfoStereotype::SubKind {
-                name: "Cli".into(),
+                name: stringify!(Cli).into(),
                 parent: "Executable".into(),
             },
             Self::Bash => UfoStereotype::SubKind {
-                name: "Bash".into(),
+                name: stringify!(Bash).into(),
                 parent: "Executable".into(),
             },
             Self::Justfile => UfoStereotype::SubKind {
-                name: "Justfile".into(),
+                name: stringify!(Justfile).into(),
                 parent: "Executable".into(),
             },
 
             // ── package managers — SubKind of abstract PackageManager ───────────────────
             Self::Apt => UfoStereotype::SubKind {
-                name: "Apt".into(),
+                name: stringify!(Apt).into(),
                 parent: "PackageManager".into(),
             },
             Self::Nix => UfoStereotype::SubKind {
-                name: "Nix".into(),
+                name: stringify!(Nix).into(),
                 parent: "PackageManager".into(),
             },
 
@@ -317,7 +317,7 @@ impl Stereotyped for DatumType {
             // a third parallel label would duplicate it (see #905's warning against
             // parallel vocabularies).
             Self::McpServer => UfoStereotype::SubKind {
-                name: "McpServer".into(),
+                name: stringify!(McpServer).into(),
                 parent: "Mcp".into(),
             },
 


### PR DESCRIPTION
## Summary
- `DatumType::ufo_stereotype`'s `SubKind` arms hand-typed each variant's own name as a string literal (`name: "Docker".into()`) that had to be kept in sync with the match arm's identifier by hand.
- Replaces each self-referential literal with `stringify!(Variant).into()` so the compiler derives it — a rename can no longer silently desync `name` from the arm.
- Parent literals (e.g. `parent: "ContainerRuntime".into()`) are left untouched — they name a different, non-variant abstract label, not the arm's own type.

## Test plan
- [x] `cargo test -p b00t-cli --lib datum_types::` — 6/6 passed, confirming no behavior change (stringify!() produces identical string output to the prior literals)
- [x] Full pre-push gate (1575/1575 workspace tests, 4 ignored) passed on push

Closes #1185