### PR TITLE
feat(b00t-cli): express the dispatch chain's priority rule as a Rhai script

### DIFF
--- a/b00t-cli/src/dispatch_sysml.rs
+++ b/b00t-cli/src/dispatch_sysml.rs
@@ -148,6 +148,54 @@ pub fn dispatch_chain_to_mermaid() -> String {
     out
 }
 
+/// Export `resolve_datum_dispatch`'s priority/collapse rule as an executable
+/// Rhai script — P2's second prototype (`elasticdotventures/_b00t_#1177`).
+///
+/// Rhai stays strictly in its existing, proven role across this ecosystem
+/// (diagram/state-machine/guard-expression codegen — `ledger-core::workflow.rs`,
+/// `mdbook-rhai-mermaid`, `nem-poweragent-lab`'s `mission-engine`) — never MCP
+/// transport/dispatch. The fan-out itself (running every mode's `try_resolve`,
+/// real file I/O and TOML parsing) stays real Rust; this script only takes
+/// the resulting hit list (mode names that returned `Some(_)`) and expresses
+/// `resolve_datum_dispatch`'s preference rule — Runtime > CliPassthrough >
+/// Polyseme, else the first remaining hit — the same hand-maintained
+/// precedence `dispatch.rs`'s own `matches!` block encodes (not
+/// auto-derived from the chain, since that precedence isn't derivable from
+/// mode order either — this mirrors dispatch.rs by hand exactly as it does).
+///
+/// Follows `to_rhai()`'s own shape (`// GENERATED from ...` header) but its
+/// test, unlike `to_mermaid()`'s string-containment convention, actually
+/// executes the generated script inside a real `rhai::Engine` — proving the
+/// priority rule, not just its presence as text.
+///
+/// An if/return chain, not a `switch`: Rhai's `switch` matches a value
+/// against literal patterns (`switch x { 1 => ..., _ => ... }`) — it can't
+/// take an arbitrary boolean expression as a case, so `switch true { expr
+/// => ..., .. }` doesn't parse. An if/return chain expresses the same
+/// first-match-wins precedence and is valid Rhai.
+pub fn dispatch_chain_to_rhai() -> String {
+    "// GENERATED from dispatch::default_dispatch_chain()\n\
+     // Fan-out (running every mode's try_resolve) and its file I/O stay\n\
+     // real Rust — this only expresses resolve_datum_dispatch's\n\
+     // Runtime > CliPassthrough > Polyseme preference rule.\n\
+     fn resolve_dispatch(hits) {\n\
+     \x20   if hits.len() == 0 {\n\
+     \x20       return ();\n\
+     \x20   }\n\
+     \x20   if hits.contains(\"RuntimeMode\") {\n\
+     \x20       return \"RuntimeMode\";\n\
+     \x20   }\n\
+     \x20   if hits.contains(\"CliPassthroughMode\") {\n\
+     \x20       return \"CliPassthroughMode\";\n\
+     \x20   }\n\
+     \x20   if hits.contains(\"PolysemeMode\") {\n\
+     \x20       return \"PolysemeMode\";\n\
+     \x20   }\n\
+     \x20   hits[0]\n\
+     }\n"
+    .to_string()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -219,5 +267,66 @@ mod tests {
         }
         assert!(mermaid.contains("Collect"));
         assert!(mermaid.contains("prefer Runtime > CliPassthrough > Polyseme"));
+    }
+
+    #[test]
+    fn rhai_script_prefers_runtime_over_other_hits() {
+        let script = dispatch_chain_to_rhai();
+        let engine = rhai::Engine::new();
+        let ast = engine
+            .compile(&script)
+            .expect("generated rhai script failed to compile");
+
+        let hits: rhai::Array = vec![
+            "PolysemeMode".to_string().into(),
+            "RuntimeMode".to_string().into(),
+            "CliPassthroughMode".to_string().into(),
+        ];
+        let result: String = engine
+            .call_fn(&mut rhai::Scope::new(), &ast, "resolve_dispatch", (hits,))
+            .expect("resolve_dispatch call failed");
+        assert_eq!(result, "RuntimeMode");
+    }
+
+    #[test]
+    fn rhai_script_prefers_cli_passthrough_over_polyseme_when_runtime_absent() {
+        let script = dispatch_chain_to_rhai();
+        let engine = rhai::Engine::new();
+        let ast = engine.compile(&script).unwrap();
+
+        let hits: rhai::Array = vec![
+            "PolysemeMode".to_string().into(),
+            "CliPassthroughMode".to_string().into(),
+        ];
+        let result: String = engine
+            .call_fn(&mut rhai::Scope::new(), &ast, "resolve_dispatch", (hits,))
+            .unwrap();
+        assert_eq!(result, "CliPassthroughMode");
+    }
+
+    #[test]
+    fn rhai_script_falls_back_to_first_hit_for_an_unlisted_mode() {
+        let script = dispatch_chain_to_rhai();
+        let engine = rhai::Engine::new();
+        let ast = engine.compile(&script).unwrap();
+
+        let hits: rhai::Array = vec!["OodaMode".to_string().into()];
+        let result: String = engine
+            .call_fn(&mut rhai::Scope::new(), &ast, "resolve_dispatch", (hits,))
+            .unwrap();
+        assert_eq!(result, "OodaMode");
+    }
+
+    #[test]
+    fn rhai_script_returns_unit_when_no_hits() {
+        let script = dispatch_chain_to_rhai();
+        let engine = rhai::Engine::new();
+        let ast = engine.compile(&script).unwrap();
+
+        let hits: rhai::Array = vec![];
+        let result: () = engine
+            .call_fn(&mut rhai::Scope::new(), &ast, "resolve_dispatch", (hits,))
+            .unwrap();
+        let _ = result;
     }
 }


### PR DESCRIPTION
## Summary
- P2 milestone's second prototype of the b00t SysML v2 spine consolidation epic (#1177): `dispatch_chain_to_rhai()` expresses `resolve_datum_dispatch()`'s Runtime > CliPassthrough > Polyseme preference rule as an executable Rhai script, following `ledger-core`'s `WorkflowToml::to_rhai()` precedent — Rhai stays strictly in its existing, proven diagram/state-machine role, never MCP transport/dispatch.
- The fan-out itself (running every mode's `try_resolve`, real file I/O and TOML parsing) stays real Rust; the script only takes the resulting hit list and applies the same hand-maintained precedence `dispatch.rs`'s own `matches!` block encodes.
- Uses an if/return chain rather than `switch`: Rhai's `switch` matches a value against literal patterns, so `switch true { expr => ... }` doesn't parse — caught by the test itself, not assumed. An if/return chain expresses the same first-match-wins logic and is valid Rhai.
- Tests execute the generated script inside a real `rhai::Engine` (unlike `to_mermaid()`'s string-containment convention) — proving the priority rule itself, not just its presence as text.

## Test plan
- [x] `cargo test -p b00t-cli --lib dispatch_sysml::` — 9/9 passed (4 new Rhai-execution tests + 5 pre-existing)
- [x] Full pre-push gate (1584/1588 workspace tests, 4 ignored) passed on push

Part of #1177 (P2 milestone — not closing the epic, this is its second prototype)