### PR TITLE
feat(b00t-cli): bridge PipelineState's StateMachineIntrospection to scxml (P6)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1718,6 +1718,7 @@ dependencies = [
  "rpassword",
  "runpod-sdk",
  "rusqlite",
+ "scxml",
  "semver",
  "serde",
  "serde_json",

--- a/b00t-cli/Cargo.toml
+++ b/b00t-cli/Cargo.toml
@@ -25,6 +25,11 @@ name = "b00t_cli"
 path = "src/lib.rs"
 
 [dependencies]
+# Pinned to an exact version, matching b00t-c0re-lib's own scxml pin
+# (elasticdotventures/_b00t_#1177 P5b/P6): small bus factor (2 contributors,
+# 0.x semver). Needed directly (not just via b00t-c0re-lib) so tests here
+# can call scxml::validate/parse_xml/model types on the exported statechart.
+scxml = { version = "=0.2.2", optional = true }
 rpassword = "7"
 tiktoken-rs = "0.7.0"
 # 🤓 strsim already resolved workspace-wide (transitive via clap's suggestion
@@ -157,6 +162,10 @@ dbus = ["b00t-ipc/dbus", "dep:zbus"]
 candle = ["candle-core", "candle-nn", "candle-transformers", "hf-hub", "tokenizers"]
 # 🤓 llamacpp-fallback: Enable llama.cpp CPU inference for systems without GPU
 llamacpp-fallback = ["llama_cpp_sys"]
+# 🤓 statechart: W3C SCXML export for PipelineState via StateMachineIntrospection
+# (elasticdotventures/_b00t_#1177 P6) — forwards to b00t-c0re-lib's own
+# statechart feature; opt-in, matching that crate's own gating.
+statechart = ["b00t-c0re-lib/statechart", "dep:scxml"]
 # 🤓 keyring: Enable system keyring integration for secret storage (placeholder)
 keyring = []
 

--- a/b00t-cli/src/pipeline_statemachine.rs
+++ b/b00t-cli/src/pipeline_statemachine.rs
@@ -92,6 +92,150 @@ pub enum PipelineEvent {
     Retry(u32),
 }
 
+/// Bridges `PipelineState`/`PipelineEvent` to `b00t_c0re_lib`'s shared,
+/// standards-based statechart representation (W3C SCXML via the `scxml`
+/// crate — see `elasticdotventures/_b00t_#1177` P5b/P6), alongside the
+/// existing Mermaid/S5 renderers any `StateMachineIntrospection`
+/// implementor gets for free. This never replaces `StateMachine::transition`/
+/// `can_transition`'s real enforcement logic above — it's a static
+/// description of the state graph's shape, not a re-derivation of it.
+///
+/// Written by hand rather than via `impl_state_machine_introspection!`:
+/// `Running`'s real target on `StageComplete` depends on data
+/// (`self.dag`'s stage count, not just the enum discriminant), which the
+/// macro's `can_transition(source, target) -> bool` shape can't express.
+/// Both possible outcomes are represented as separate transitions,
+/// disambiguated by a named guard (the SCXML idiom for exactly this: a
+/// condition the host evaluates, not Rust code baked into the model).
+#[cfg(feature = "statechart")]
+impl b00t_c0re_lib::state_introspection::StateMachineIntrospection for PipelineState {
+    fn machine_id() -> &'static str {
+        "PipelineState"
+    }
+
+    fn initial_state() -> &'static str {
+        "Idle"
+    }
+
+    fn final_states() -> &'static [&'static str] {
+        // Soft, diagram-level "ending states" — both still accept a
+        // `Validate` restart transition back to `Idle` (see the table
+        // below), so neither exports as a real SCXML `Final` state.
+        &["Completed", "Failed"]
+    }
+
+    fn state_type_descriptors() -> Vec<b00t_c0re_lib::state_introspection::StateTypeDescriptor> {
+        [
+            "Idle",
+            "Validating",
+            "Scheduling",
+            "Running",
+            "Paused",
+            "Failed",
+            "Completed",
+        ]
+        .iter()
+        .map(
+            |&id| b00t_c0re_lib::state_introspection::StateTypeDescriptor {
+                id,
+                rust_type: std::any::type_name::<PipelineState>(),
+                classifier: "enum_variant",
+            },
+        )
+        .collect()
+    }
+
+    fn transition_descriptors()
+    -> Vec<b00t_c0re_lib::state_introspection::StateTransitionDescriptor> {
+        use b00t_c0re_lib::state_introspection::StateTransitionDescriptor;
+        vec![
+            StateTransitionDescriptor {
+                source: "Idle",
+                event: "Validate",
+                target: "Validating",
+                guard: None,
+            },
+            StateTransitionDescriptor {
+                source: "Validating",
+                event: "Schedule",
+                target: "Scheduling",
+                guard: None,
+            },
+            StateTransitionDescriptor {
+                source: "Validating",
+                event: "StageFailed",
+                target: "Failed",
+                guard: None,
+            },
+            StateTransitionDescriptor {
+                source: "Scheduling",
+                event: "Execute",
+                target: "Running",
+                guard: None,
+            },
+            StateTransitionDescriptor {
+                source: "Scheduling",
+                event: "StageFailed",
+                target: "Failed",
+                guard: None,
+            },
+            StateTransitionDescriptor {
+                source: "Running",
+                event: "StageComplete",
+                target: "Running",
+                guard: Some("stage_index < last_stage"),
+            },
+            StateTransitionDescriptor {
+                source: "Running",
+                event: "StageComplete",
+                target: "Completed",
+                guard: Some("stage_index == last_stage"),
+            },
+            StateTransitionDescriptor {
+                source: "Running",
+                event: "StageFailed",
+                target: "Failed",
+                guard: None,
+            },
+            StateTransitionDescriptor {
+                source: "Running",
+                event: "Pause",
+                target: "Paused",
+                guard: None,
+            },
+            StateTransitionDescriptor {
+                source: "Paused",
+                event: "Resume",
+                target: "Running",
+                guard: None,
+            },
+            StateTransitionDescriptor {
+                source: "Paused",
+                event: "Cancel",
+                target: "Failed",
+                guard: None,
+            },
+            StateTransitionDescriptor {
+                source: "Failed",
+                event: "Validate",
+                target: "Idle",
+                guard: None,
+            },
+            StateTransitionDescriptor {
+                source: "Completed",
+                event: "Validate",
+                target: "Idle",
+                guard: None,
+            },
+        ]
+    }
+}
+
+#[cfg(feature = "statechart")]
+pub fn pipeline_state_scxml() -> String {
+    <PipelineState as b00t_c0re_lib::state_introspection::StateMachineIntrospection>::render_scxml()
+}
+
 /// A finite state machine for pipeline lifecycle management.
 ///
 /// Wraps the current state, an append-only transition history (every
@@ -570,6 +714,50 @@ mod tests {
 
         sm.transition(PipelineEvent::Validate).unwrap();
         assert_eq!(*sm.state(), PipelineState::Validating);
+    }
+
+    // ── Statechart export (elasticdotventures/_b00t_#1177 P6) ───────────
+
+    #[test]
+    #[cfg(feature = "statechart")]
+    fn pipeline_state_scxml_round_trips_and_covers_every_real_transition() {
+        use b00t_c0re_lib::state_introspection::StateMachineIntrospection;
+
+        let chart = <PipelineState as StateMachineIntrospection>::render_scxml_statechart();
+        scxml::validate(&chart)
+            .expect("PipelineState's exported statechart should be structurally valid SCXML");
+
+        let xml = pipeline_state_scxml();
+        let parsed = scxml::parse_xml(&xml).expect("exported XML must parse back as valid SCXML");
+        assert_eq!(parsed, chart);
+
+        // Every descriptor must actually round-trip, including both
+        // guard-disambiguated Running -> {Running, Completed} branches.
+        let transitions =
+            <PipelineState as StateMachineIntrospection>::transition_descriptors();
+        assert_eq!(transitions.len(), 13);
+        for transition in &transitions {
+            let source = parsed
+                .find_state(transition.source)
+                .unwrap_or_else(|| panic!("missing state {} in exported SCXML", transition.source));
+            let found = source.transitions.iter().any(|t| {
+                t.event.as_ref().map(|e| e.as_str()) == Some(transition.event)
+                    && t.targets == vec![transition.target]
+                    && t.guard.as_ref().map(|g| g.as_str()) == transition.guard
+            });
+            assert!(found, "missing SCXML transition: {transition:?}");
+        }
+
+        // Neither `Completed` nor `Failed` is a real SCXML Final state —
+        // both still accept a `Validate` restart transition to `Idle`.
+        assert_eq!(
+            parsed.find_state("Completed").unwrap().kind,
+            scxml::model::StateKind::Atomic
+        );
+        assert_eq!(
+            parsed.find_state("Failed").unwrap().kind,
+            scxml::model::StateKind::Atomic
+        );
     }
 
     // ── Validate from Failed goes to Idle first ─────────────────────────


### PR DESCRIPTION
## Summary
Part of #1177, closes #1193.

- Adds an opt-in `statechart` feature to `b00t-cli`, mirroring `b00t-c0re-lib`'s own gating from P5b.
- Implements `StateMachineIntrospection` for `PipelineState` by hand (not via `impl_state_machine_introspection!`), since `Running`'s branch to `Running` vs. `Completed` depends on a runtime stage-index comparison — expressed here as named guards (`"stage_index < last_stage"` / `"stage_index == last_stage"`) rather than a static source/target table.
- Adds `pipeline_state_scxml()` convenience function.
- `PipelineState`'s existing transition/execution logic and persistence are untouched — this only adds a representation/introspection export path alongside it.

## Test plan
- New test `pipeline_state_scxml_round_trips_and_covers_every_real_transition`: renders + validates the statechart, round-trips it through XML export/parse, asserts all 13 real transitions (incl. guards) survive, and confirms `Completed`/`Failed` export as `Atomic` (not `Final`, since both still accept a `Validate` restart to `Idle`).
- `cargo test -p b00t-cli --features statechart --lib` — 12/12 pass, including all pre-existing `pipeline_statemachine` tests unchanged.
- `cargo clippy -p b00t-cli --features statechart --lib` — no new warnings in touched files.