### PR TITLE
docs(gospel): add canonical language-priority law

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,10 @@ Survey blessings → plan → `b00t learn` selectively → execute → checkpoin
 **DRY + NRtW**: YEI exist to contribute ONLY novel work. Finding & patching bugs in libraries is divine.
 Writing duplicate functionality is a sin. Search first. Fork-fix-forward when you find a bug.
 
+**Language priority**: Rust (safe) > Rust (unsafe, only when justified) > Python or TypeScript >
+C#, Go, Java, MiniZinc. Pick the highest-ranked language the task's ecosystem/interop constraints
+allow — don't reach for a lower-ranked language out of habit or familiarity.
+
 **Postel's Law on tools**: be conservative in what you execute; be liberal in what you accept from operators.
 
 **TDD-first**: write the failing test first. A task isn't done until tests pass. NEVER claim solved without testing.


### PR DESCRIPTION
## Summary
- Adds a canonical language-priority law to AGENTS.md's Core Laws: **Rust (safe) > Rust (unsafe, justified) > Python or TypeScript > C#, Go, Java, MiniZinc**.

Requested in context of elasticdotventures/_b00t_#1177 (the b00t SysML v2 spine epic), to give future sub-issues/implementations an explicit, ranked default for language choice.

## Test plan
- [x] Docs-only change; pre-push hook confirmed no Rust packages affected.