### PR TITLE
fix(scripts): stop auto-installing perl in bootstrap-build-toolchain.ps1

### DIFF
--- a/scripts/bootstrap-build-toolchain.ps1
+++ b/scripts/bootstrap-build-toolchain.ps1
@@ -358,22 +358,14 @@ Test-Requirement -Name "cmake" -Required $false -TestScript { Test-CommandExists
         }
     }
 
+# Detect-only, deliberately no FixScript: this operator prefers not to
+# provision Strawberry Perl (its winget installer also needs an interactive
+# prompt this script can't answer non-interactively — it self-cancelled
+# with exit 1602 the one time this ran unattended). Where a *-sys crate's
+# build.rs offers a choice of scripting interpreter, prefer python — it's
+# already required elsewhere in this toolchain — over installing perl here.
 Test-Requirement -Name "perl" -Required $false -TestScript { Test-CommandExists perl } `
-    -FixDescription "$(if ($OnWindows) {'winget install StrawberryPerl.StrawberryPerl'} elseif ($OnMacOS) {'ships with macOS'} else {'sudo apt-get install -y perl (or dnf/pacman equivalent)'})" `
-    -FixScript {
-        if ($OnWindows) {
-            if (-not $wingetOk) { throw "winget unavailable — see above" }
-            winget install --id StrawberryPerl.StrawberryPerl -e --accept-package-agreements --accept-source-agreements
-        } elseif (Test-CommandExists apt-get) {
-            sudo apt-get update; sudo apt-get install -y perl
-        } elseif (Test-CommandExists dnf) {
-            sudo dnf install -y perl
-        } elseif (Test-CommandExists pacman) {
-            sudo pacman -S --noconfirm perl
-        } else {
-            throw "no supported package manager found"
-        }
-    }
+    -ManualHint "not auto-installed by this script — prefer python where a *-sys crate's build allows a choice; only a handful of crates hard-require perl specifically"
 
 Test-Requirement -Name "nasm" -Required $false -TestScript { Test-CommandExists nasm } `
     -FixDescription "$(if ($OnWindows) {'winget install NASM.NASM'} elseif ($OnMacOS) {'brew install nasm'} else {'sudo apt-get install -y nasm (or dnf/pacman equivalent)'})" `


### PR DESCRIPTION
## Summary
Follow-up to #1213. Ran the script live (non-dry-run) on the real Windows dev machine outside WSL — it correctly installed LLVM/libclang (the real gap from the #1177 P4 report) and cmake, but the Strawberry Perl winget install self-cancelled (exit 1602 — needs an interactive prompt this script can't answer under `-Yes`).

Per operator preference: stop trying to auto-install perl at all. `perl` stays a detect-only, non-required check (some `*-sys` crates' `build.rs` do hard-require it), but this script no longer attempts to provision it — where a crate's build allows a choice of scripting interpreter, prefer python instead (already required elsewhere in this toolchain).

## Test plan
- [x] Parsed clean (`ParseFile`, no errors)
- [x] Dry-run re-exercised on WSL — `perl` still correctly reports pass/fail from `Test-CommandExists`, just with no install path now

🤖 Generated with [Claude Code](https://claude.com/claude-code)