### PR TITLE
fix: thread resolved --path into bootstrap command

### DIFF
--- a/b00t-cli/src/commands/bootstrap.rs
+++ b/b00t-cli/src/commands/bootstrap.rs
@@ -49,7 +49,7 @@ pub enum BootstrapCommands {
 }
 
 /// Handle bootstrap commands
-pub async fn handle_bootstrap_command(cmd: BootstrapCommands) -> Result<()> {
+pub async fn handle_bootstrap_command(cmd: BootstrapCommands, path: &str) -> Result<()> {
     match cmd {
         BootstrapCommands::Run {
             skip_dirs,
@@ -57,13 +57,14 @@ pub async fn handle_bootstrap_command(cmd: BootstrapCommands) -> Result<()> {
             skip_services,
             output,
             print,
-        } => run_bootstrap(skip_dirs, skip_install, skip_services, output, print).await,
-        BootstrapCommands::Check => check_only().await,
-        BootstrapCommands::Skeleton => skeleton_only().await,
+        } => run_bootstrap(path, skip_dirs, skip_install, skip_services, output, print).await,
+        BootstrapCommands::Check => check_only(path).await,
+        BootstrapCommands::Skeleton => skeleton_only(path).await,
     }
 }
 
 async fn run_bootstrap(
+    path: &str,
     skip_dirs: bool,
     skip_install: bool,
     skip_services: bool,
@@ -74,7 +75,7 @@ async fn run_bootstrap(
     println!();
 
     // Locate bootstrap.toml
-    let config_path = PathBuf::from("_b00t_/bootstrap.toml");
+    let config_path = PathBuf::from(shellexpand::tilde(path).to_string()).join("bootstrap.toml");
     if !config_path.exists() {
         anyhow::bail!(
             "Bootstrap config not found: {}\nRun from dotfiles root directory",
@@ -157,8 +158,8 @@ async fn run_bootstrap(
     Ok(())
 }
 
-async fn check_only() -> Result<()> {
-    let config_path = PathBuf::from("_b00t_/bootstrap.toml");
+async fn check_only(path: &str) -> Result<()> {
+    let config_path = PathBuf::from(shellexpand::tilde(path).to_string()).join("bootstrap.toml");
     if !config_path.exists() {
         anyhow::bail!("Bootstrap config not found: {}", config_path.display());
     }
@@ -181,8 +182,8 @@ async fn check_only() -> Result<()> {
     Ok(())
 }
 
-async fn skeleton_only() -> Result<()> {
-    let config_path = PathBuf::from("_b00t_/bootstrap.toml");
+async fn skeleton_only(path: &str) -> Result<()> {
+    let config_path = PathBuf::from(shellexpand::tilde(path).to_string()).join("bootstrap.toml");
     if !config_path.exists() {
         anyhow::bail!("Bootstrap config not found: {}", config_path.display());
     }

--- a/b00t-cli/src/main.rs
+++ b/b00t-cli/src/main.rs
@@ -2942,7 +2942,7 @@ async fn main() {
         Some(Commands::Bootstrap { bootstrap_command }) => {
             use b00t_cli::commands::bootstrap::handle_bootstrap_command;
 
-            if let Err(e) = handle_bootstrap_command(bootstrap_command.clone()).await {
+            if let Err(e) = handle_bootstrap_command(bootstrap_command.clone(), &cli.path).await {
                 eprintln!("Error: {}", e);
                 std::process::exit(1);
             }


### PR DESCRIPTION
## Summary
- `b00t bootstrap` previously hardcoded `PathBuf::from("_b00t_/bootstrap.toml")` in `run_bootstrap`, `check_only`, and `skeleton_only`, so it only worked when `cwd` happened to be the repo root — it ignored the already-resolved `--path`/`_B00T_Path` datum path used by every other subcommand.
- Threads `cli.path` from `main.rs` through `handle_bootstrap_command` into all three functions, replacing the hardcoded relative path with `shellexpand::tilde(path).join("bootstrap.toml")` (matching the existing pattern in `b00t-cli/src/bootstrap/report.rs`).

## Test plan
- [x] `cargo build -p b00t-cli` succeeds
- [x] `b00t-cli --path /bogus/dir bootstrap check` run from outside the repo fails with the bogus path in the error message (`Bootstrap config not found: /bogus/dir/bootstrap.toml`)
- [x] `b00t-cli --path <repo>/_b00t_ bootstrap check` run from `/tmp` (cwd outside repo root) correctly locates and parses `bootstrap.toml` and runs the prerequisite check
- [x] Default `--path` (`~/.dotfiles/_b00t_` / `_B00T_Path` env) still resolves correctly

Refs: b00t task #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)