### PR TITLE
feat(b00t): soul scoped shards — project/system/agent/skill/tool/datum

### DIFF
--- a/_b00t_/datums/PRD-DATAFRAMERR.prd.tomllmd
+++ b/_b00t_/datums/PRD-DATAFRAMERR.prd.tomllmd
@@ -144,16 +144,23 @@ b00t soul token decode <b64xor:...>             # decode ObfuscatedStr to plaint
 
 [mcp_tools]
 tools = """
-soul_dataframerr_create(name: str, columns: list[str])        → { table: str, ok: bool }
-soul_row_insert(table: str, fields: dict)             → { frame_id: int }
-soul_row_query(table: str, filter?: str)              → { frames: list[dict] }
-soul_cursor_create(name: str, table: str)               → { cursor: str, frame_id: int }
-soul_cursor_next(name: str)                             → { frame: dict | null, at_eof: bool }
-soul_cursor_reset(name: str)                            → { ok: bool }
-soul_alarm_set(name, table, col, cond, emit)            → { alarm: str }
-soul_alarm_check(table: str)                            → { fired: list[str] }
+soul_dataframerr_create(name: str, columns: list[str], scope?: str) → { table: str, ok: bool }
+soul_row_insert(table: str, fields: dict, scope?: str)  → { frame_id: int }
+soul_row_query(table: str, filter?: str, scope?: str)   → { frames: list[dict] }
+soul_cursor_create(name: str, table: str, scope?: str)  → { cursor: str, frame_id: int }
+soul_cursor_next(name: str, scope?: str)                → { frame: dict | null, at_eof: bool }
+soul_cursor_reset(name: str, scope?: str)               → { ok: bool }
+soul_alarm_set(name, table, col, cond, emit, scope?: str) → { alarm: str }
+soul_alarm_check(table: str, scope?: str)               → { fired: list[str] }
 soul_token_encode(plaintext: str)                       → { token: str }  # "b64xor:..."
 soul_token_decode(token: str)                           → { plaintext: str }
+
+# #1102: every tool above except token_encode/decode (which don't touch
+# storage) accepts an optional `scope` param, "<kind>:<id>" e.g. "agent:pi".
+# kinds: project | system | agent | skill | tool | datum. Omitted = the
+# legacy/default shard (pre-#1102 unscoped data, unchanged behavior).
+# New shard-management CLI surface (not yet MCP-exposed): `b00t soul
+# shard-list`, `shard-export <scope>`, `shard-delete <scope>`.
 """
 
 # ═══════════════════════════════════════════════════════════════════════════════

--- a/b00t-cli/src/commands/soul.rs
+++ b/b00t-cli/src/commands/soul.rs
@@ -26,8 +26,9 @@ use b00t_c0re_lib::soul_dataframerr::{
 use clap::Parser;
 
 use crate::memory_provider::{
-    FileMemory, MemoryProvider, active_soul_path, detect_provider, soul_path,
+    FileMemory, MemoryProvider, detect_provider, soul_path, soul_path_for,
 };
+use crate::soul_scope::{ShardKind, SoulScope};
 use crate::soul_writer::{SoulMemoryWriter, active_soul_dir, global_soul_dir, local_soul_dir};
 
 #[derive(Parser)]
@@ -151,13 +152,24 @@ pub enum SoulCommands {
             help = "Column definitions: 'name:type' or 'name:type?' (nullable). Types: text int float cake bool timestamp token json"
         )]
         columns: Vec<String>,
+        #[clap(
+            long,
+            help = "#1102 shard scope 'kind:id', e.g. 'agent:pi' — kinds: project system agent skill tool datum. Omit for the legacy/default shard."
+        )]
+        scope: Option<String>,
     },
 
     #[clap(
         name = "table-list",
         about = "List all DataFramerr tables in active soul"
     )]
-    TableList,
+    TableList {
+        #[clap(
+            long,
+            help = "#1102 shard scope 'kind:id', e.g. 'agent:pi' — kinds: project system agent skill tool datum. Omit for the legacy/default shard."
+        )]
+        scope: Option<String>,
+    },
 
     #[clap(name = "table-show", about = "Show schema + row count for a table")]
     TableShow { name: String },
@@ -174,29 +186,69 @@ pub enum SoulCommands {
         table: String,
         #[clap(help = "Field values as 'key=value' pairs")]
         fields: Vec<String>,
+        #[clap(
+            long,
+            help = "#1102 shard scope 'kind:id', e.g. 'agent:pi' — kinds: project system agent skill tool datum. Omit for the legacy/default shard."
+        )]
+        scope: Option<String>,
     },
 
     #[clap(name = "frame-get", about = "Fetch a single row by id")]
-    FrameGet { table: String, id: u64 },
+    FrameGet {
+        table: String,
+        id: u64,
+        #[clap(
+            long,
+            help = "#1102 shard scope 'kind:id', e.g. 'agent:pi' — kinds: project system agent skill tool datum. Omit for the legacy/default shard."
+        )]
+        scope: Option<String>,
+    },
 
     #[clap(name = "frame-dump", about = "Dump rows in tabular format")]
     FrameDump {
         table: String,
         #[clap(long, help = "Show only last N rows")]
         last: Option<usize>,
+        #[clap(
+            long,
+            help = "#1102 shard scope 'kind:id', e.g. 'agent:pi' — kinds: project system agent skill tool datum. Omit for the legacy/default shard."
+        )]
+        scope: Option<String>,
     },
 
     #[clap(name = "cursor-create", about = "Create a durable cursor on a table")]
-    CursorCreate { name: String, table: String },
+    CursorCreate {
+        name: String,
+        table: String,
+        #[clap(
+            long,
+            help = "#1102 shard scope 'kind:id', e.g. 'agent:pi' — kinds: project system agent skill tool datum. Omit for the legacy/default shard."
+        )]
+        scope: Option<String>,
+    },
 
     #[clap(
         name = "cursor-next",
         about = "Advance cursor and print next row (exit 1 at EOF)"
     )]
-    CursorNext { name: String },
+    CursorNext {
+        name: String,
+        #[clap(
+            long,
+            help = "#1102 shard scope 'kind:id', e.g. 'agent:pi' — kinds: project system agent skill tool datum. Omit for the legacy/default shard."
+        )]
+        scope: Option<String>,
+    },
 
     #[clap(name = "cursor-reset", about = "Rewind cursor to frame 0")]
-    CursorReset { name: String },
+    CursorReset {
+        name: String,
+        #[clap(
+            long,
+            help = "#1102 shard scope 'kind:id', e.g. 'agent:pi' — kinds: project system agent skill tool datum. Omit for the legacy/default shard."
+        )]
+        scope: Option<String>,
+    },
 
     #[clap(name = "cursor-list", about = "List all cursors and positions")]
     CursorList,
@@ -215,13 +267,25 @@ pub enum SoulCommands {
         aggregate: String,
         #[clap(long, help = "Event name to emit when alarm fires")]
         emit: String,
+        #[clap(
+            long,
+            help = "#1102 shard scope 'kind:id', e.g. 'agent:pi' — kinds: project system agent skill tool datum. Omit for the legacy/default shard."
+        )]
+        scope: Option<String>,
     },
 
     #[clap(
         name = "alarm-check",
         about = "Evaluate all alarms on a table; print fired events"
     )]
-    AlarmCheck { table: String },
+    AlarmCheck {
+        table: String,
+        #[clap(
+            long,
+            help = "#1102 shard scope 'kind:id', e.g. 'agent:pi' — kinds: project system agent skill tool datum. Omit for the legacy/default shard."
+        )]
+        scope: Option<String>,
+    },
 
     #[clap(name = "alarm-list", about = "List all registered alarms")]
     AlarmList,
@@ -244,6 +308,25 @@ pub enum SoulCommands {
         token: String,
         #[clap(long, default_value = "", help = "Context key used during encode")]
         context: String,
+    },
+
+    // ── #1102 shard management ──────────────────────────────────────────────
+    #[clap(
+        name = "shard-list",
+        about = "List known #1102 soul shards (project/system/agent/skill/tool/datum) that have on-disk data"
+    )]
+    ShardList,
+
+    #[clap(name = "shard-export", about = "Print a shard's full TOML document to stdout")]
+    ShardExport {
+        #[clap(help = "'<kind>:<id>', e.g. 'agent:pi'")]
+        scope: String,
+    },
+
+    #[clap(name = "shard-delete", about = "Delete a shard's on-disk data (irreversible)")]
+    ShardDelete {
+        #[clap(help = "'<kind>:<id>', e.g. 'agent:pi'")]
+        scope: String,
     },
 }
 
@@ -383,18 +466,18 @@ pub fn handle_soul_command(cmd: &SoulCommands) -> Result<()> {
         ),
 
         // ── DataFramerr ───────────────────────────────────────────────────────
-        SoulCommands::TableCreate { name, columns } => df_table_create(name, columns),
-        SoulCommands::TableList => df_table_list(),
+        SoulCommands::TableCreate { name, columns, scope } => df_table_create(name, columns, parse_scope(scope)?),
+        SoulCommands::TableList { scope } => df_table_list(parse_scope(scope)?),
         SoulCommands::TableShow { name } => df_table_show(name),
         SoulCommands::TableDrop { name } => df_table_drop(name),
 
-        SoulCommands::FrameInsert { table, fields } => df_frame_insert(table, fields),
-        SoulCommands::FrameGet { table, id } => df_frame_get(table, *id),
-        SoulCommands::FrameDump { table, last } => df_frame_dump(table, *last),
+        SoulCommands::FrameInsert { table, fields, scope } => df_frame_insert(table, fields, parse_scope(scope)?),
+        SoulCommands::FrameGet { table, id, scope } => df_frame_get(table, *id, parse_scope(scope)?),
+        SoulCommands::FrameDump { table, last, scope } => df_frame_dump(table, *last, parse_scope(scope)?),
 
-        SoulCommands::CursorCreate { name, table } => df_cursor_create(name, table),
-        SoulCommands::CursorNext { name } => df_cursor_next(name),
-        SoulCommands::CursorReset { name } => df_cursor_reset(name),
+        SoulCommands::CursorCreate { name, table, scope } => df_cursor_create(name, table, parse_scope(scope)?),
+        SoulCommands::CursorNext { name, scope } => df_cursor_next(name, parse_scope(scope)?),
+        SoulCommands::CursorReset { name, scope } => df_cursor_reset(name, parse_scope(scope)?),
         SoulCommands::CursorList => df_cursor_list(),
 
         SoulCommands::AlarmSet {
@@ -404,13 +487,18 @@ pub fn handle_soul_command(cmd: &SoulCommands) -> Result<()> {
             condition,
             aggregate,
             emit,
-        } => df_alarm_set(name, table, column, condition, aggregate, emit),
-        SoulCommands::AlarmCheck { table } => df_alarm_check(table),
+            scope,
+        } => df_alarm_set(name, table, column, condition, aggregate, emit, parse_scope(scope)?),
+        SoulCommands::AlarmCheck { table, scope } => df_alarm_check(table, parse_scope(scope)?),
         SoulCommands::AlarmList => df_alarm_list(),
         SoulCommands::AlarmRm { name } => df_alarm_rm(name),
 
         SoulCommands::TokenEncode { plaintext, context } => df_token_encode(plaintext, context),
         SoulCommands::TokenDecode { token, context } => df_token_decode(token, context),
+
+        SoulCommands::ShardList => df_shard_list(),
+        SoulCommands::ShardExport { scope } => df_shard_export(&SoulScope::parse_flag(scope)?),
+        SoulCommands::ShardDelete { scope } => df_shard_delete(&SoulScope::parse_flag(scope)?),
     }
 }
 
@@ -1020,9 +1108,15 @@ async fn serve_soul_kv(host: &str, port: u16) -> Result<()> {
 
 // ── DataFramerr registry I/O ──────────────────────────────────────────────────
 
-/// Load the full TOML document from the active soul file.
+/// Load the full TOML document from the active (legacy/default) soul file.
 pub fn load_soul_doc() -> Result<toml::Table> {
-    let path = active_soul_path();
+    load_soul_doc_scoped(None)
+}
+
+/// #1102: scope-aware variant of `load_soul_doc`. `scope = None` is byte-for-
+/// byte identical to `load_soul_doc()` — the legacy/default shard.
+pub fn load_soul_doc_scoped(scope: Option<&SoulScope>) -> Result<toml::Table> {
+    let path = soul_path_for(scope);
     if !path.exists() {
         return Ok(toml::Table::new());
     }
@@ -1043,9 +1137,18 @@ pub fn load_registry(doc: &toml::Table) -> Result<SoulDataFramerrRegistry> {
     }
 }
 
-/// Serialize registry back into doc["soul"] and write the file.
-pub fn save_registry(mut doc: toml::Table, reg: &SoulDataFramerrRegistry) -> Result<()> {
-    let path = active_soul_path();
+/// Serialize registry back into doc["soul"] and write the legacy/default file.
+pub fn save_registry(doc: toml::Table, reg: &SoulDataFramerrRegistry) -> Result<()> {
+    save_registry_scoped(doc, reg, None)
+}
+
+/// #1102: scope-aware variant of `save_registry`.
+pub fn save_registry_scoped(
+    mut doc: toml::Table,
+    reg: &SoulDataFramerrRegistry,
+    scope: Option<&SoulScope>,
+) -> Result<()> {
+    let path = soul_path_for(scope);
     // Create parent dir if missing
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)?;
@@ -1057,15 +1160,28 @@ pub fn save_registry(mut doc: toml::Table, reg: &SoulDataFramerrRegistry) -> Res
         .with_context(|| format!("write {}", path.display()))
 }
 
-/// Read-modify-write helper.
+/// Read-modify-write helper against the legacy/default shard.
 pub fn with_registry<F>(f: F) -> Result<()>
 where
     F: FnOnce(&mut SoulDataFramerrRegistry) -> Result<()>,
 {
-    let doc = load_soul_doc()?;
+    with_registry_scoped(None, f)
+}
+
+/// #1102: scope-aware variant of `with_registry`.
+pub fn with_registry_scoped<F>(scope: Option<&SoulScope>, f: F) -> Result<()>
+where
+    F: FnOnce(&mut SoulDataFramerrRegistry) -> Result<()>,
+{
+    let doc = load_soul_doc_scoped(scope)?;
     let mut reg = load_registry(&doc)?;
     f(&mut reg)?;
-    save_registry(doc, &reg)
+    save_registry_scoped(doc, &reg, scope)
+}
+
+/// Parse an optional `<kind>:<id>` scope flag value into a `SoulScope`.
+fn parse_scope(scope: &Option<String>) -> Result<Option<SoulScope>> {
+    scope.as_deref().map(SoulScope::parse_flag).transpose()
 }
 
 /// Parse "key=value" field args into a BTreeMap<String, SoulValue>.
@@ -1101,12 +1217,12 @@ fn agent_id() -> String {
 
 // ── table commands ────────────────────────────────────────────────────────────
 
-fn df_table_create(name: &str, columns: &[String]) -> Result<()> {
+fn df_table_create(name: &str, columns: &[String], scope: Option<SoulScope>) -> Result<()> {
     let cols: Vec<SoulColumn> = columns
         .iter()
         .map(|s| SoulColumn::parse(s))
         .collect::<Result<_>>()?;
-    with_registry(|reg| {
+    with_registry_scoped(scope.as_ref(), |reg| {
         if reg.tables.contains_key(name) {
             bail!("table '{name}' already exists; use frame-insert to add rows");
         }
@@ -1117,8 +1233,8 @@ fn df_table_create(name: &str, columns: &[String]) -> Result<()> {
     })
 }
 
-fn df_table_list() -> Result<()> {
-    let doc = load_soul_doc()?;
+fn df_table_list(scope: Option<SoulScope>) -> Result<()> {
+    let doc = load_soul_doc_scoped(scope.as_ref())?;
     let reg = load_registry(&doc)?;
     if reg.tables.is_empty() {
         println!("(no tables)");
@@ -1187,9 +1303,9 @@ fn df_table_drop(name: &str) -> Result<()> {
 
 // ── frame commands ────────────────────────────────────────────────────────────
 
-fn df_frame_insert(table: &str, fields: &[String]) -> Result<()> {
+fn df_frame_insert(table: &str, fields: &[String], scope: Option<SoulScope>) -> Result<()> {
     let field_map = parse_fields(fields)?;
-    with_registry(|reg| {
+    with_registry_scoped(scope.as_ref(), |reg| {
         let df = reg.tables.get_mut(table).ok_or_else(|| {
             anyhow::anyhow!("no table '{table}' — run: b00t soul table-create {table}")
         })?;
@@ -1199,8 +1315,8 @@ fn df_frame_insert(table: &str, fields: &[String]) -> Result<()> {
     })
 }
 
-fn df_frame_get(table: &str, id: u64) -> Result<()> {
-    let doc = load_soul_doc()?;
+fn df_frame_get(table: &str, id: u64, scope: Option<SoulScope>) -> Result<()> {
+    let doc = load_soul_doc_scoped(scope.as_ref())?;
     let reg = load_registry(&doc)?;
     let df = reg
         .tables
@@ -1220,8 +1336,8 @@ fn df_frame_get(table: &str, id: u64) -> Result<()> {
     Ok(())
 }
 
-fn df_frame_dump(table: &str, last: Option<usize>) -> Result<()> {
-    let doc = load_soul_doc()?;
+fn df_frame_dump(table: &str, last: Option<usize>, scope: Option<SoulScope>) -> Result<()> {
+    let doc = load_soul_doc_scoped(scope.as_ref())?;
     let reg = load_registry(&doc)?;
     let df = reg
         .tables
@@ -1265,8 +1381,8 @@ fn df_frame_dump(table: &str, last: Option<usize>) -> Result<()> {
 
 // ── cursor commands ───────────────────────────────────────────────────────────
 
-fn df_cursor_create(name: &str, table: &str) -> Result<()> {
-    with_registry(|reg| {
+fn df_cursor_create(name: &str, table: &str, scope: Option<SoulScope>) -> Result<()> {
+    with_registry_scoped(scope.as_ref(), |reg| {
         if !reg.tables.contains_key(table) {
             bail!("no table '{table}'");
         }
@@ -1277,8 +1393,8 @@ fn df_cursor_create(name: &str, table: &str) -> Result<()> {
     })
 }
 
-fn df_cursor_next(name: &str) -> Result<()> {
-    let doc = load_soul_doc()?;
+fn df_cursor_next(name: &str, scope: Option<SoulScope>) -> Result<()> {
+    let doc = load_soul_doc_scoped(scope.as_ref())?;
     let mut reg = load_registry(&doc)?;
     let cursor = reg.cursors.get_mut(name).ok_or_else(|| {
         anyhow::anyhow!("no cursor '{name}' — run: b00t soul cursor-create {name} <table>")
@@ -1298,7 +1414,7 @@ fn df_cursor_next(name: &str) -> Result<()> {
             for (k, v) in &row.fields {
                 println!("  {} = {:?}", k, v);
             }
-            save_registry(doc, &reg)
+            save_registry_scoped(doc, &reg, scope.as_ref())
         }
         None => {
             println!("EOF: cursor '{name}' at end of '{table_name}'");
@@ -1307,8 +1423,8 @@ fn df_cursor_next(name: &str) -> Result<()> {
     }
 }
 
-fn df_cursor_reset(name: &str) -> Result<()> {
-    with_registry(|reg| {
+fn df_cursor_reset(name: &str, scope: Option<SoulScope>) -> Result<()> {
+    with_registry_scoped(scope.as_ref(), |reg| {
         let cursor = reg
             .cursors
             .get_mut(name)
@@ -1343,6 +1459,7 @@ fn df_alarm_set(
     condition: &str,
     aggregate: &str,
     emit: &str,
+    scope: Option<SoulScope>,
 ) -> Result<()> {
     let agg = match aggregate {
         "sum" => AlarmAggregate::Sum,
@@ -1351,7 +1468,7 @@ fn df_alarm_set(
         "per_frame" => AlarmAggregate::PerFrame,
         other => bail!("unknown aggregate '{other}'; valid: sum avg count per_frame"),
     };
-    with_registry(|reg| {
+    with_registry_scoped(scope.as_ref(), |reg| {
         reg.alarms.retain(|a| a.name != name);
         reg.alarms.push(SoulAlarm {
             name: name.to_string(),
@@ -1366,8 +1483,8 @@ fn df_alarm_set(
     })
 }
 
-fn df_alarm_check(table: &str) -> Result<()> {
-    let doc = load_soul_doc()?;
+fn df_alarm_check(table: &str, scope: Option<SoulScope>) -> Result<()> {
+    let doc = load_soul_doc_scoped(scope.as_ref())?;
     let reg = load_registry(&doc)?;
     let fired: Vec<_> = reg
         .alarms
@@ -1438,4 +1555,164 @@ fn df_token_decode(token: &str, context: &str) -> Result<()> {
     let plain = enc.decode(&id, context)?;
     println!("{}", plain);
     Ok(())
+}
+
+// ── #1102 shard management ──────────────────────────────────────────────────
+
+/// Enumerates on-disk shards under both the local-workspace and global
+/// `._b00t_/shards/<kind>/<id>/` roots (whichever exist), independent of
+/// today's local-vs-global "active" selection — this command is explicitly
+/// about seeing everything, not just what the current cwd would resolve to.
+fn shard_roots() -> Vec<std::path::PathBuf> {
+    let mut roots = Vec::new();
+    if let Some(home) = dirs::home_dir() {
+        roots.push(home.join("._b00t_").join("shards"));
+    }
+    if let Ok(cwd) = std::env::current_dir() {
+        let local = cwd.join("._b00t_").join("shards");
+        if local.is_dir() {
+            roots.push(local);
+        }
+    }
+    roots
+}
+
+fn df_shard_list() -> Result<()> {
+    let mut found: Vec<SoulScope> = Vec::new();
+    for shards_root in shard_roots() {
+        if !shards_root.is_dir() {
+            continue;
+        }
+        let Ok(kind_entries) = std::fs::read_dir(&shards_root) else {
+            continue;
+        };
+        for kind_entry in kind_entries.flatten() {
+            let Some(kind) = kind_entry
+                .file_name()
+                .to_str()
+                .and_then(ShardKind::parse)
+            else {
+                continue;
+            };
+            let Ok(id_entries) = std::fs::read_dir(kind_entry.path()) else {
+                continue;
+            };
+            for id_entry in id_entries.flatten() {
+                if let Some(id) = id_entry.file_name().to_str() {
+                    let scope = SoulScope::new(kind, id);
+                    if !found.contains(&scope) {
+                        found.push(scope);
+                    }
+                }
+            }
+        }
+    }
+    if found.is_empty() {
+        println!("(no shards — all soul data lives in the legacy/default shard)");
+        return Ok(());
+    }
+    found.sort_by(|a, b| (a.kind.as_str(), &a.id).cmp(&(b.kind.as_str(), &b.id)));
+    for scope in &found {
+        println!("{scope}");
+    }
+    Ok(())
+}
+
+fn df_shard_export(scope: &SoulScope) -> Result<()> {
+    let doc = load_soul_doc_scoped(Some(scope))?;
+    println!("{}", toml::to_string_pretty(&doc)?);
+    Ok(())
+}
+
+fn df_shard_delete(scope: &SoulScope) -> Result<()> {
+    let path = soul_path_for(Some(scope));
+    if !path.exists() {
+        println!("shard '{scope}' has no on-disk data — nothing to delete");
+        return Ok(());
+    }
+    let shard_dir = path
+        .parent()
+        .ok_or_else(|| anyhow::anyhow!("shard path '{}' has no parent directory", path.display()))?;
+    std::fs::remove_dir_all(shard_dir)
+        .with_context(|| format!("delete shard directory {}", shard_dir.display()))?;
+    println!("shard '{scope}' deleted ({})", shard_dir.display());
+    Ok(())
+}
+
+#[cfg(test)]
+mod shard_tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    // `with_registry_scoped`/`load_soul_doc_scoped` resolve paths off the
+    // process-global `std::env::current_dir()`, so tests that touch a scoped
+    // shard must not run concurrently with each other or with anything else
+    // that changes cwd.
+    static CWD_LOCK: Mutex<()> = Mutex::new(());
+
+    struct TempCwd {
+        _guard: std::sync::MutexGuard<'static, ()>,
+        old_cwd: std::path::PathBuf,
+        _temp_dir: tempfile::TempDir,
+    }
+
+    impl TempCwd {
+        fn new() -> Self {
+            let guard = CWD_LOCK.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+            let old_cwd = std::env::current_dir().unwrap();
+            let temp_dir = tempfile::tempdir().unwrap();
+            std::fs::create_dir_all(temp_dir.path().join("._b00t_")).unwrap();
+            std::env::set_current_dir(temp_dir.path()).unwrap();
+            Self { _guard: guard, old_cwd, _temp_dir: temp_dir }
+        }
+    }
+
+    impl Drop for TempCwd {
+        fn drop(&mut self) {
+            let _ = std::env::set_current_dir(&self.old_cwd);
+        }
+    }
+
+    #[test]
+    fn scoped_write_is_isolated_from_legacy_and_other_shards() {
+        let _cwd = TempCwd::new();
+        let agent_foo = SoulScope::new(ShardKind::Agent, "foo");
+        let agent_bar = SoulScope::new(ShardKind::Agent, "bar");
+
+        df_table_create("t", &["x:int".to_string()], Some(agent_foo.clone())).unwrap();
+        df_frame_insert("t", &["x=1".to_string()], Some(agent_foo.clone())).unwrap();
+
+        // Same table name in a sibling shard must not see foo's row.
+        let bar_doc = load_soul_doc_scoped(Some(&agent_bar)).unwrap();
+        let bar_reg = load_registry(&bar_doc).unwrap();
+        assert!(!bar_reg.tables.contains_key("t"));
+
+        // Legacy/default shard must not see it either.
+        let legacy_doc = load_soul_doc_scoped(None).unwrap();
+        let legacy_reg = load_registry(&legacy_doc).unwrap();
+        assert!(!legacy_reg.tables.contains_key("t"));
+
+        // The actual shard sees exactly one row.
+        let foo_doc = load_soul_doc_scoped(Some(&agent_foo)).unwrap();
+        let foo_reg = load_registry(&foo_doc).unwrap();
+        assert_eq!(foo_reg.tables.get("t").unwrap().rows.len(), 1);
+    }
+
+    #[test]
+    fn shard_list_export_delete_round_trip() {
+        let _cwd = TempCwd::new();
+        let scope = SoulScope::new(ShardKind::Tool, "grok");
+        df_table_create("lessons", &["note:text".to_string()], Some(scope.clone())).unwrap();
+
+        df_shard_list().unwrap(); // smoke test: must not error with data present
+
+        let path = soul_path_for(Some(&scope));
+        assert!(path.exists());
+
+        df_shard_delete(&scope).unwrap();
+        assert!(!path.exists());
+
+        // Deleting again is a no-op, not an error.
+        df_shard_delete(&scope).unwrap();
+    }
 }

--- a/b00t-cli/src/lib.rs
+++ b/b00t-cli/src/lib.rs
@@ -102,6 +102,7 @@ pub mod scheduler;
 pub mod session_memory;
 pub mod skill_resolver;
 pub mod semantic_patch;
+pub mod soul_scope;
 pub mod soul_writer;
 pub mod step;
 pub mod traits;

--- a/b00t-cli/src/memory_provider.rs
+++ b/b00t-cli/src/memory_provider.rs
@@ -239,6 +239,41 @@ pub fn active_soul_path() -> PathBuf {
         .unwrap_or_else(soul_path)
 }
 
+/// #1102: scope-aware SOUL.tomllm path. `scope = None` resolves to exactly
+/// today's behavior (`active_soul_path()`) — the legacy/default shard, so
+/// existing unscoped data and callers are completely unaffected. `scope =
+/// Some(s)` resolves under `<root>/shards/<kind>/<id>/SOUL.tomllm`, using the
+/// same local-workspace-if-present-else-global root selection as the legacy
+/// path.
+pub fn soul_path_for(scope: Option<&crate::soul_scope::SoulScope>) -> PathBuf {
+    match scope {
+        None => active_soul_path(),
+        Some(s) => s.shard_dir(&shard_root()).join("SOUL.tomllm"),
+    }
+}
+
+/// #1102: scope-aware soul.db path, mirroring `soul_path_for`.
+pub fn soul_db_path_for(scope: Option<&crate::soul_scope::SoulScope>) -> PathBuf {
+    match scope {
+        None => active_soul_db_path(),
+        Some(s) => s.shard_dir(&shard_root()).join("soul.db"),
+    }
+}
+
+/// Root directory shards nest under: local workspace's `._b00t_/` if present,
+/// else the global `~/._b00t_/`.
+fn shard_root() -> PathBuf {
+    std::env::current_dir()
+        .ok()
+        .map(|d| d.join("._b00t_"))
+        .filter(|p| p.is_dir())
+        .unwrap_or_else(|| {
+            dirs::home_dir()
+                .unwrap_or_else(|| PathBuf::from("/tmp"))
+                .join("._b00t_")
+        })
+}
+
 /// Fallback file provider — used when SQLite unavailable or for SOUL.tomllm compat
 pub fn file_provider() -> FileMemory {
     FileMemory::new(soul_path())

--- a/b00t-cli/src/soul_scope.rs
+++ b/b00t-cli/src/soul_scope.rs
@@ -1,0 +1,226 @@
+//! #1102: explicit scoped shards for the soul memory system.
+//!
+//! Replaces the old binary local-vs-global split (a directory-presence
+//! check, see `memory_provider::active_soul_path`) with a 6-way categorical
+//! taxonomy — project/system/agent/skill/tool/datum — each independently
+//! addressable by kind + identifier. Deliberately additive: calls that don't
+//! pass a scope keep resolving to exactly the same path as before
+//! (`memory_provider::soul_path_for(None)` == `active_soul_path()`), so
+//! existing unscoped data is the de facto "legacy" shard with no migration
+//! required.
+
+use sha2::{Digest, Sha256};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ShardKind {
+    Project,
+    System,
+    Agent,
+    Skill,
+    Tool,
+    Datum,
+}
+
+impl ShardKind {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            ShardKind::Project => "project",
+            ShardKind::System => "system",
+            ShardKind::Agent => "agent",
+            ShardKind::Skill => "skill",
+            ShardKind::Tool => "tool",
+            ShardKind::Datum => "datum",
+        }
+    }
+
+    pub fn parse(s: &str) -> Option<Self> {
+        match s.to_ascii_lowercase().as_str() {
+            "project" => Some(ShardKind::Project),
+            "system" => Some(ShardKind::System),
+            "agent" => Some(ShardKind::Agent),
+            "skill" => Some(ShardKind::Skill),
+            "tool" => Some(ShardKind::Tool),
+            "datum" => Some(ShardKind::Datum),
+            _ => None,
+        }
+    }
+
+    pub fn all() -> [ShardKind; 6] {
+        [
+            ShardKind::Project,
+            ShardKind::System,
+            ShardKind::Agent,
+            ShardKind::Skill,
+            ShardKind::Tool,
+            ShardKind::Datum,
+        ]
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct SoulScope {
+    pub kind: ShardKind,
+    pub id: String,
+}
+
+impl SoulScope {
+    pub fn new(kind: ShardKind, id: impl Into<String>) -> Self {
+        Self { kind, id: id.into() }
+    }
+
+    /// Parse a `<kind>:<id>` CLI/MCP flag value, e.g. `"agent:pi"`.
+    pub fn parse_flag(s: &str) -> anyhow::Result<Self> {
+        let (kind_str, id) = s
+            .split_once(':')
+            .ok_or_else(|| anyhow::anyhow!("scope must be '<kind>:<id>', e.g. 'agent:pi' — got '{s}'"))?;
+        let kind = ShardKind::parse(kind_str).ok_or_else(|| {
+            anyhow::anyhow!(
+                "unknown shard kind '{kind_str}' — expected one of: project system agent skill tool datum"
+            )
+        })?;
+        if id.is_empty() {
+            anyhow::bail!("scope identifier must not be empty (got '{s}')");
+        }
+        Ok(Self::new(kind, id))
+    }
+
+    /// Default project scope inferred from the current directory: sha256 of
+    /// `git remote get-url origin` (stable across clones/worktrees of the
+    /// same repo), falling back to the git toplevel path when there's no
+    /// remote (e.g. a fresh local-only repo). `None` if cwd isn't inside a
+    /// git repo at all — callers fall back to the legacy shard in that case.
+    pub fn infer_project() -> Option<Self> {
+        repo_identity().map(|id| Self::new(ShardKind::Project, id))
+    }
+
+    /// Filesystem-safe directory for this shard, rooted under `<root>/shards/`.
+    pub fn shard_dir(&self, root: &Path) -> PathBuf {
+        root.join("shards")
+            .join(self.kind.as_str())
+            .join(sanitize_path_segment(&self.id))
+    }
+}
+
+impl std::fmt::Display for SoulScope {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}:{}", self.kind.as_str(), self.id)
+    }
+}
+
+fn git_toplevel() -> Option<String> {
+    let out = Command::new("git")
+        .args(["rev-parse", "--show-toplevel"])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let s = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    if s.is_empty() { None } else { Some(s) }
+}
+
+fn git_remote_url() -> Option<String> {
+    let out = Command::new("git")
+        .args(["remote", "get-url", "origin"])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let s = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    if s.is_empty() { None } else { Some(s) }
+}
+
+/// Stable repo identity for the "project" shard kind's default inference:
+/// sha256 hex prefix of the origin remote URL, or the toplevel path when
+/// there's no remote configured.
+pub fn repo_identity() -> Option<String> {
+    if let Some(url) = git_remote_url() {
+        let mut hasher = Sha256::new();
+        hasher.update(url.as_bytes());
+        let digest = hasher.finalize();
+        return Some(hex_prefix(&digest, 16));
+    }
+    git_toplevel()
+}
+
+fn hex_prefix(bytes: &[u8], n: usize) -> String {
+    bytes.iter().take(n).map(|b| format!("{b:02x}")).collect()
+}
+
+/// Renders an arbitrary scope identifier safe for use as one path segment.
+fn sanitize_path_segment(id: &str) -> String {
+    id.chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn shard_kind_round_trips_through_as_str_and_parse() {
+        for kind in ShardKind::all() {
+            assert_eq!(ShardKind::parse(kind.as_str()), Some(kind));
+        }
+    }
+
+    #[test]
+    fn shard_kind_parse_is_case_insensitive_and_rejects_unknown() {
+        assert_eq!(ShardKind::parse("Agent"), Some(ShardKind::Agent));
+        assert_eq!(ShardKind::parse("AGENT"), Some(ShardKind::Agent));
+        assert_eq!(ShardKind::parse("nonsense"), None);
+    }
+
+    #[test]
+    fn parse_flag_accepts_kind_colon_id() {
+        let scope = SoulScope::parse_flag("agent:pi").unwrap();
+        assert_eq!(scope.kind, ShardKind::Agent);
+        assert_eq!(scope.id, "pi");
+    }
+
+    #[test]
+    fn parse_flag_rejects_missing_colon_unknown_kind_or_empty_id() {
+        assert!(SoulScope::parse_flag("agent-pi").is_err());
+        assert!(SoulScope::parse_flag("nonsense:pi").is_err());
+        assert!(SoulScope::parse_flag("agent:").is_err());
+    }
+
+    #[test]
+    fn display_round_trips_through_parse_flag() {
+        let scope = SoulScope::new(ShardKind::Skill, "b00t-learn");
+        let rendered = scope.to_string();
+        let reparsed = SoulScope::parse_flag(&rendered).unwrap();
+        assert_eq!(scope, reparsed);
+    }
+
+    #[test]
+    fn sanitize_path_segment_neutralizes_path_traversal_and_separators() {
+        assert_eq!(sanitize_path_segment("../../etc/passwd"), ".._.._etc_passwd");
+        assert_eq!(sanitize_path_segment("weird id/with spaces"), "weird_id_with_spaces");
+        assert_eq!(sanitize_path_segment("safe-id_1.2"), "safe-id_1.2");
+    }
+
+    #[test]
+    fn shard_dir_nests_under_shards_kind_id() {
+        let scope = SoulScope::new(ShardKind::Tool, "grok");
+        let dir = scope.shard_dir(Path::new("/home/x/._b00t_"));
+        assert_eq!(dir, PathBuf::from("/home/x/._b00t_/shards/tool/grok"));
+    }
+
+    #[test]
+    fn repo_identity_is_stable_across_repeated_calls() {
+        // Whatever this returns (Some or None, depending on the test
+        // sandbox's git state), it must be deterministic within one process.
+        assert_eq!(repo_identity(), repo_identity());
+    }
+}

--- a/b00t-mcp/src/soul_dataframerr_tools.rs
+++ b/b00t-mcp/src/soul_dataframerr_tools.rs
@@ -52,6 +52,8 @@ pub struct SoulTableCreateCommand {
     pub name: String,
     #[arg(help = "Column defs: 'name:type' or 'name:type?' (nullable)")]
     pub columns: Vec<String>,
+    #[arg(long, help = "#1102 shard scope 'kind:id', e.g. 'agent:pi'. Omit for the legacy/default shard.")]
+    pub scope: Option<String>,
 }
 
 impl McpReflection for SoulTableCreateCommand {
@@ -78,6 +80,12 @@ impl McpExecutor for SoulTableCreateCommand {
         let mut args: Vec<&str> = vec!["table-create", name];
         let col_refs: Vec<&str> = columns.iter().map(|s| s.as_str()).collect();
         args.extend(col_refs.iter());
+        let scope_owned;
+        let scope: Option<&str> = params.get("scope").and_then(|v| v.as_str());
+        if let Some(s) = scope {
+            scope_owned = s.to_string();
+            args.extend(["--scope", &scope_owned]);
+        }
         run_soul(&args)
     }
 }
@@ -85,7 +93,10 @@ impl McpExecutor for SoulTableCreateCommand {
 // ── soul_table_list ───────────────────────────────────────────────────────────
 
 #[derive(Parser, Clone)]
-pub struct SoulTableListCommand;
+pub struct SoulTableListCommand {
+    #[arg(long, help = "#1102 shard scope 'kind:id', e.g. 'agent:pi'. Omit for the legacy/default shard.")]
+    pub scope: Option<String>,
+}
 
 impl McpReflection for SoulTableListCommand {
     fn mcp_tool_name() -> String {
@@ -97,8 +108,15 @@ impl McpReflection for SoulTableListCommand {
 }
 
 impl McpExecutor for SoulTableListCommand {
-    fn execute_mcp_call(_params: &HashMap<String, Value>) -> Result<String> {
-        run_soul(&["table-list"])
+    fn execute_mcp_call(params: &HashMap<String, Value>) -> Result<String> {
+        let mut args: Vec<&str> = vec!["table-list"];
+        let scope_owned;
+        let scope: Option<&str> = params.get("scope").and_then(|v| v.as_str());
+        if let Some(s) = scope {
+            scope_owned = s.to_string();
+            args.extend(["--scope", &scope_owned]);
+        }
+        run_soul(&args)
     }
 }
 
@@ -112,6 +130,8 @@ pub struct SoulRowInsertCommand {
     pub table: String,
     #[arg(help = "Field key=value pairs")]
     pub fields: Vec<String>,
+    #[arg(long, help = "#1102 shard scope 'kind:id', e.g. 'agent:pi'. Omit for the legacy/default shard.")]
+    pub scope: Option<String>,
 }
 
 impl McpReflection for SoulRowInsertCommand {
@@ -146,6 +166,12 @@ impl McpExecutor for SoulRowInsertCommand {
         let mut args: Vec<&str> = vec!["frame-insert", table];
         let pair_refs: Vec<&str> = pairs.iter().map(|s| s.as_str()).collect();
         args.extend(pair_refs.iter());
+        let scope_owned;
+        let scope: Option<&str> = params.get("scope").and_then(|v| v.as_str());
+        if let Some(s) = scope {
+            scope_owned = s.to_string();
+            args.extend(["--scope", &scope_owned]);
+        }
         run_soul(&args)
     }
 }
@@ -159,6 +185,8 @@ pub struct SoulRowQueryCommand {
     pub table: String,
     #[arg(long, help = "Return only last N rows")]
     pub last: Option<usize>,
+    #[arg(long, help = "#1102 shard scope 'kind:id', e.g. 'agent:pi'. Omit for the legacy/default shard.")]
+    pub scope: Option<String>,
 }
 
 impl McpReflection for SoulRowQueryCommand {
@@ -179,6 +207,12 @@ impl McpExecutor for SoulRowQueryCommand {
             last_str = n.to_string();
             args.extend(["--last", &last_str]);
         }
+        let scope_owned;
+        let scope: Option<&str> = params.get("scope").and_then(|v| v.as_str());
+        if let Some(s) = scope {
+            scope_owned = s.to_string();
+            args.extend(["--scope", &scope_owned]);
+        }
         run_soul(&args)
     }
 }
@@ -189,6 +223,8 @@ impl McpExecutor for SoulRowQueryCommand {
 pub struct SoulCursorCreateCommand {
     pub name: String,
     pub table: String,
+    #[arg(long, help = "#1102 shard scope 'kind:id', e.g. 'agent:pi'. Omit for the legacy/default shard.")]
+    pub scope: Option<String>,
 }
 
 impl McpReflection for SoulCursorCreateCommand {
@@ -204,7 +240,14 @@ impl McpExecutor for SoulCursorCreateCommand {
     fn execute_mcp_call(params: &HashMap<String, Value>) -> Result<String> {
         let name = str_param(params, "name")?;
         let table = str_param(params, "table")?;
-        run_soul(&["cursor-create", name, table])
+        let mut args: Vec<&str> = vec!["cursor-create", name, table];
+        let scope_owned;
+        let scope: Option<&str> = params.get("scope").and_then(|v| v.as_str());
+        if let Some(s) = scope {
+            scope_owned = s.to_string();
+            args.extend(["--scope", &scope_owned]);
+        }
+        run_soul(&args)
     }
 }
 
@@ -215,6 +258,8 @@ impl McpExecutor for SoulCursorCreateCommand {
 #[derive(Parser, Clone)]
 pub struct SoulCursorNextCommand {
     pub name: String,
+    #[arg(long, help = "#1102 shard scope 'kind:id', e.g. 'agent:pi'. Omit for the legacy/default shard.")]
+    pub scope: Option<String>,
 }
 
 impl McpReflection for SoulCursorNextCommand {
@@ -229,9 +274,13 @@ impl McpReflection for SoulCursorNextCommand {
 impl McpExecutor for SoulCursorNextCommand {
     fn execute_mcp_call(params: &HashMap<String, Value>) -> Result<String> {
         let name = str_param(params, "name")?;
+        let scope: Option<&str> = params.get("scope").and_then(|v| v.as_str());
         // cursor-next exits 1 at EOF — treat as non-error (return sentinel)
         let mut cmd = std::process::Command::new("b00t-cli");
         cmd.args(["soul", "cursor-next", name]);
+        if let Some(s) = scope {
+            cmd.args(["--scope", s]);
+        }
         let out = cmd.output().map_err(|e| anyhow::anyhow!("b00t-cli: {e}"))?;
         let stdout = String::from_utf8_lossy(&out.stdout).to_string();
         if out.status.code() == Some(1) {
@@ -249,6 +298,8 @@ impl McpExecutor for SoulCursorNextCommand {
 #[derive(Parser, Clone)]
 pub struct SoulCursorResetCommand {
     pub name: String,
+    #[arg(long, help = "#1102 shard scope 'kind:id', e.g. 'agent:pi'. Omit for the legacy/default shard.")]
+    pub scope: Option<String>,
 }
 
 impl McpReflection for SoulCursorResetCommand {
@@ -262,7 +313,15 @@ impl McpReflection for SoulCursorResetCommand {
 
 impl McpExecutor for SoulCursorResetCommand {
     fn execute_mcp_call(params: &HashMap<String, Value>) -> Result<String> {
-        run_soul(&["cursor-reset", str_param(params, "name")?])
+        let name = str_param(params, "name")?;
+        let mut args: Vec<&str> = vec!["cursor-reset", name];
+        let scope_owned;
+        let scope: Option<&str> = params.get("scope").and_then(|v| v.as_str());
+        if let Some(s) = scope {
+            scope_owned = s.to_string();
+            args.extend(["--scope", &scope_owned]);
+        }
+        run_soul(&args)
     }
 }
 
@@ -278,6 +337,8 @@ pub struct SoulAlarmSetCommand {
     pub aggregate: String,
     #[arg(long)]
     pub emit: String,
+    #[arg(long, help = "#1102 shard scope 'kind:id', e.g. 'agent:pi'. Omit for the legacy/default shard.")]
+    pub scope: Option<String>,
 }
 
 impl McpReflection for SoulAlarmSetCommand {
@@ -300,7 +361,7 @@ impl McpExecutor for SoulAlarmSetCommand {
             .and_then(|v| v.as_str())
             .unwrap_or("sum");
         let emit = str_param(params, "emit")?;
-        run_soul(&[
+        let mut args: Vec<&str> = vec![
             "alarm-set",
             name,
             table,
@@ -310,7 +371,14 @@ impl McpExecutor for SoulAlarmSetCommand {
             aggregate,
             "--emit",
             emit,
-        ])
+        ];
+        let scope_owned;
+        let scope: Option<&str> = params.get("scope").and_then(|v| v.as_str());
+        if let Some(s) = scope {
+            scope_owned = s.to_string();
+            args.extend(["--scope", &scope_owned]);
+        }
+        run_soul(&args)
     }
 }
 
@@ -319,6 +387,8 @@ impl McpExecutor for SoulAlarmSetCommand {
 #[derive(Parser, Clone)]
 pub struct SoulAlarmCheckCommand {
     pub table: String,
+    #[arg(long, help = "#1102 shard scope 'kind:id', e.g. 'agent:pi'. Omit for the legacy/default shard.")]
+    pub scope: Option<String>,
 }
 
 impl McpReflection for SoulAlarmCheckCommand {
@@ -332,7 +402,15 @@ impl McpReflection for SoulAlarmCheckCommand {
 
 impl McpExecutor for SoulAlarmCheckCommand {
     fn execute_mcp_call(params: &HashMap<String, Value>) -> Result<String> {
-        run_soul(&["alarm-check", str_param(params, "table")?])
+        let table = str_param(params, "table")?;
+        let mut args: Vec<&str> = vec!["alarm-check", table];
+        let scope_owned;
+        let scope: Option<&str> = params.get("scope").and_then(|v| v.as_str());
+        if let Some(s) = scope {
+            scope_owned = s.to_string();
+            args.extend(["--scope", &scope_owned]);
+        }
+        run_soul(&args)
     }
 }
 


### PR DESCRIPTION
## Summary
- Replaces soul's binary local-vs-global path split with an explicit 6-way categorical taxonomy (project/system/agent/skill/tool/datum), per #1102.
- Purely additive: any call that omits `--scope` resolves to exactly the same path as before — existing unscoped soul data is the de facto legacy/default shard, no migration needed.
- New `b00t-cli/src/soul_scope.rs`: `ShardKind`/`SoulScope`, `parse_flag("kind:id")`, and `repo_identity()` (sha256 of `git remote get-url origin`, falling back to the git toplevel path) as the default project-scope inference heuristic.
- Threaded scope through the 4 soul.rs I/O choke points and the 9 DataFramerr subcommands backing real `soul_*` MCP tools, plus matching `scope` params on the corresponding MCP tool structs.
- New `soul shard-list`/`shard-export`/`shard-delete` subcommands for independent shard listability/export/delete.

Part of the b00t backlog triage's phased plan: #1102 → #1104 (agent-scoped tokens, builds on `ShardKind`) → #1106+#1101 (reviewer-gate pattern).

## Test plan
- [x] `cargo build -p b00t-cli` and `cargo build -p b00t-mcp` — clean.
- [x] New `soul_scope.rs` unit tests: shard-kind round-trip, flag parse/reject, path-traversal sanitization, repo-identity stability.
- [x] New `soul.rs::shard_tests`: cross-shard isolation (a write to `agent:foo` is invisible from `agent:bar` and the legacy shard) and shard-list/export/delete round trip.
- [x] Confirmed `memory_provider.rs::test_file_memory_write_preserves_dataframerr_registry` is unaffected — it exercises `FileMemory` at an explicit temp path, never through `active_soul_path()`/`soul_path_for()`.