### PR TITLE
fix: add opt-in nvm install recipe to node.cli.toml

### DIFF
--- a/_b00t_/node.cli.toml
+++ b/_b00t_/node.cli.toml
@@ -1,9 +1,11 @@
 # node.cli.toml — minimal reference datum for the Node.js runtime.
 # @tribal: created to close dangling `depends_on = ["node.cli"]`/["node"]
 #   references (geminicli.cli, zellij-mcp-server.mcp, qwen-code.cli) found
-#   during a datum-graph audit. No install script is fabricated here — Node
-#   version management (nvm/fnm/pkgx/system package manager) is an
-#   environment choice, not something b00t should silently pick for you.
+#   during a datum-graph audit. Node version management (nvm/fnm/pkgx/system
+#   package manager) is an environment choice, not something b00t should
+#   silently pick for you — so the [install] recipe below (nvm) is strictly
+#   opt-in via `b00t install node`. No [roles].required_for is set here;
+#   bootstrap/`b00t up` MUST NOT auto-install a node runtime.
 
 [b00t]
 name = "node"
@@ -12,6 +14,12 @@ hint = "Node.js JavaScript runtime — required by several npx/npm-based MCP ser
 version = "node --version"
 version_regex = 'v(\d+\.\d+\.\d+)'
 docs = "https://nodejs.org/en/download"
+install = """
+command -v nvm >/dev/null 2>&1 || curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash
+export NVM_DIR="$HOME/.nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && \\. "$NVM_DIR/nvm.sh"
+nvm install --lts
+"""
 
 [validate]
 command = "node --version"
@@ -26,8 +34,8 @@ description = "Check npm version"
 command = "npm --version"
 
 # b00t:map v1
-# summary: node — minimal detect-only datum, no fabricated install script
-# tags: node, nodejs, npm, npx, runtime, cli
+# summary: node — detect-only by default; opt-in nvm install via `b00t install node`
+# tags: node, nodejs, npm, npx, runtime, cli, nvm
 # tier: sm0l
-# cmds: node --version
+# cmds: node --version, b00t install node
 # complexity: 1

--- a/b00t-cli/src/lib.rs
+++ b/b00t-cli/src/lib.rs
@@ -722,6 +722,30 @@ hint = "containers"
     }
 
     #[test]
+    fn node_cli_install_resolves_nvm_command() {
+        #[derive(Deserialize)]
+        struct TestDatum {
+            install: InstallSpec,
+        }
+        #[derive(Deserialize)]
+        struct TestFile {
+            b00t: TestDatum,
+        }
+
+        let toml_text =
+            std::fs::read_to_string(concat!(env!("CARGO_MANIFEST_DIR"), "/../_b00t_/node.cli.toml"))
+                .expect("node.cli.toml should exist");
+        let file: TestFile = toml::from_str(&toml_text).unwrap();
+        let command = file
+            .b00t
+            .install
+            .command_string()
+            .expect("node.cli.toml install must resolve to a runnable command, not InstallSpec::Metadata");
+
+        assert!(command.contains("nvm install --lts"));
+    }
+
+    #[test]
     fn resolve_prefers_runtime_over_cli() {
         let dir = tempfile::tempdir().unwrap();
         write_runtime_datum(dir.path(), "dual", "/bin/true");


### PR DESCRIPTION
node.cli.toml was detect-only by design, leaving "b00t install node" with nothing to run for datums that depend_on node (geminicli.cli, zellij-mcp-server.mcp, qwen-code.cli). Adds a bare `install = """..."""` string under [b00t] (the proven-working convention used by corepack.cli.toml/pnpm.cli.toml) that installs nvm and runs `nvm install --lts`, invoked only via explicit `b00t install node` — no [roles].required_for is added, so bootstrap/`b00t up` still never auto-installs a node runtime, preserving the datum's original philosophy.

Verified empirically that the sccache.cli.toml-style `[install]\ncommand = "..."` table shape (what the task literally suggested copying) silently matches serde's untagged InstallSpec::Metadata variant instead of Command, so command_string() returns None and the install would do nothing — hence the different shape used here. Added a regression test (node_cli_install_resolves_nvm_command) that loads node.cli.toml directly and asserts install.command_string() actually resolves, to catch that class of bug for this datum going forward.

Refs: b00t task #38