### PR TITLE
feat(b00t): agent-scoped token issuance across all #1102 shard kinds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,6 +109,15 @@ b00t-datum-core = { path = "b00t-datum-core" }
 b00t-zellij = { path = "b00t-zellij" }
 b00t-admin = { path = "b00t-admin" }
 b00t-reflect-types = { path = "vendor/ledgrrr/crates/b00t-reflect-types" }
+# #1104: NOT taking a Cargo dependency on vendor/ledgrrr's `ledger-core` here
+# -- its optional arc-kit-au -> msft-agent-gov-ledgrrr -> agentmesh chain
+# hard-pins serde =1.0.228, which conflicts with the rest of this workspace's
+# serde 1.0.229 (a real cross-cutting version conflict inside vendor/ledgrrr
+# itself, not something to paper over by bumping serde workspace-wide, and
+# out of scope to fix in that submodule right now -- other sessions are
+# actively working in it). agent_token.rs instead reproduces just the small
+# double-entry beancount transaction shape it needs locally; see that
+# module's doc comment.
 mti = "1.1.1"
 
 

--- a/b00t-cli/src/agent_token.rs
+++ b/b00t-cli/src/agent_token.rs
@@ -1,0 +1,831 @@
+//! Agent-scoped token issuance — #1104.
+//!
+//! Orchestrates: check cake balance (fail before privilege) → ensure a k8s
+//! ServiceAccount + RoleBinding exist for the requested #1102 shard scope →
+//! mint a scoped token via k8s TokenRequest → record the issuance as a
+//! double-entry accounting transaction → return the token.
+//!
+//! The ledger recording ([`AgentTokenJournalEntry`] below) deliberately does
+//! NOT depend on vendor/ledgrrr's `ledger-core` crate: pulling it in
+//! requires Cargo to fully resolve its optional `arc-kit-au` ->
+//! `msft-agent-gov-ledgrrr` -> `agentmesh` dependency chain regardless of
+//! feature flags, and `agentmesh v3.5.0` hard-pins `serde =1.0.228`, which
+//! conflicts with the rest of this workspace's `serde 1.0.229` — a real,
+//! pre-existing version conflict inside that submodule, out of scope to fix
+//! here (other sessions are actively working in `vendor/ledgrrr`). The
+//! journal entry shape below mirrors `ledger_core::journal`'s
+//! `JournalTransaction`/`from_agent_token_issuance`/`to_beancount_entry`
+//! field-for-field and format-string-for-format-string, so the on-disk
+//! `agent-tokens.beancount` file stays format-compatible if/when a real
+//! `ledger-core` dependency becomes usable again.
+//!
+//! Enforcement lives in `crate::commands::datum`'s `--as-agent-token` flag
+//! (and, mechanically, any other command gated on shard access), which
+//! calls [`authorize_shard_token`].
+//!
+//! One parameterized [`ROLE_SHARD_ACCESS`] ClusterRole is shared across all
+//! six #1102 shard kinds — it grants no real k8s API access itself (its only
+//! job is being a RoleBinding target); the specific kind+id a RoleBinding
+//! authorizes is carried as labels on the RoleBinding, not as six separate
+//! marker roles.
+
+use anyhow::{Context, Result, bail};
+use k8s_openapi::api::authentication::v1::{TokenRequest, TokenRequestSpec, TokenReview, TokenReviewSpec};
+use k8s_openapi::api::core::v1::{Namespace, ServiceAccount};
+use k8s_openapi::api::rbac::v1::{ClusterRole, RoleBinding, RoleRef, Subject};
+use kube::Client;
+use kube::api::{Api, ObjectMeta, PostParams};
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+use crate::cake_ledger::CakeLedger;
+use crate::soul_scope::SoulScope;
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/// Namespace all agent ServiceAccounts/RoleBindings live in.
+pub const AGENTS_NAMESPACE: &str = "b00t-agents";
+
+/// Marker ClusterRole name — shared across all #1102 shard kinds.
+/// [`authorize_shard_token`]'s TokenReview check looks for a RoleBinding
+/// naming this Role, filtered by shard labels; the Role itself grants no
+/// real k8s API access.
+pub const ROLE_SHARD_ACCESS: &str = "role-shard-access";
+
+/// Token lifetime for minted agent tokens (15 minutes).
+pub const TOKEN_TTL_SECONDS: i64 = 15 * 60;
+
+const LABEL_SHARD_KIND: &str = "b00t.elastic.ventures/shard-kind";
+const LABEL_SHARD_ID: &str = "b00t.elastic.ventures/shard-id";
+
+/// Embedded YAML for the `role-shard-access` marker ClusterRole. Shard data
+/// itself is not migrated into k8s-native resources — this Role's `rules`
+/// grant no meaningful k8s API access; its real job is being *bound to* via
+/// a per-(agent,scope) RoleBinding, not granting access itself. Applied
+/// (idempotent create-if-missing) by [`request_agent_token`] the first time
+/// it's needed — no manual `kubectl apply` step required.
+pub const ROLE_SHARD_ACCESS_YAML: &str = r#"
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: role-shard-access
+  labels:
+    app.kubernetes.io/managed-by: b00t
+rules:
+  # Harmless, self-referential permission — this Role's real job is being
+  # *bound to*, not granting k8s API access.
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources: ["clusterroles"]
+    resourceNames: ["role-shard-access"]
+    verbs: ["get"]
+"#;
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/// Request parameters for [`request_agent_token`].
+#[derive(Debug, Clone)]
+pub struct AgentTokenRequest {
+    pub agent_id: String,
+    pub scope: SoulScope,
+    pub cost: i64,
+}
+
+/// Successful issuance result.
+#[derive(Debug, Clone)]
+pub struct AgentTokenIssuance {
+    pub token: String,
+    pub tx_id: String,
+    pub expires_in_seconds: i64,
+    pub remaining_balance: i64,
+}
+
+/// Identity + authorization result from [`authorize_shard_token`].
+#[derive(Debug, Clone)]
+pub struct AuthorizedIdentity {
+    pub username: String,
+    pub namespace: String,
+    pub service_account_name: String,
+}
+
+// ---------------------------------------------------------------------------
+// Ledger path
+// ---------------------------------------------------------------------------
+
+/// Dedicated journal file for agent-token issuance — deliberately separate
+/// from any real tax-ledger data (never mix agent-token/test data with real
+/// financial records).
+pub fn default_ledger_path() -> Result<PathBuf> {
+    let home = dirs::home_dir().context("resolve home directory")?;
+    Ok(home.join(".b00t").join("ledger").join("agent-tokens.beancount"))
+}
+
+/// A double-entry beancount transaction for one agent-token issuance.
+/// Mirrors `ledger_core::journal::JournalTransaction` field-for-field — see
+/// this module's doc comment for why it's a local copy rather than a
+/// dependency on that crate.
+struct AgentTokenJournalEntry {
+    date: String,
+    narration: String,
+    asset_account: String,
+    counterparty_account: String,
+    amount: String,
+    currency: String,
+    tx_id: String,
+    source_ref: String,
+}
+
+impl AgentTokenJournalEntry {
+    /// Produces a balanced entry: `Assets:Cake:<agent_id>` debited by
+    /// `cost`, `Expenses:AgentTokens:<shard-type>` credited by `cost`,
+    /// where `<shard-type>` is the portion of `shard_ref` before the first
+    /// `:` (e.g. `datum` from `datum:some-datum-id`).
+    fn new(agent_id: &str, shard_ref: &str, cost: &str, tx_id: String, date: String) -> Self {
+        Self {
+            date,
+            narration: format!("agent token issued: {shard_ref}"),
+            asset_account: format!("Assets:Cake:{agent_id}"),
+            counterparty_account: format!(
+                "Expenses:AgentTokens:{}",
+                shard_ref.split(':').next().unwrap_or(shard_ref)
+            ),
+            amount: cost.to_string(),
+            currency: "CAKE".to_string(),
+            tx_id,
+            source_ref: format!("agent-token:{agent_id}"),
+        }
+    }
+
+    fn to_beancount_entry(&self) -> String {
+        let inverse = invert_amount(&self.amount);
+        format!(
+            "{} * \"{}\" \"{}\"\n  txid: \"{}\"\n  source_ref: \"{}\"\n  {} {} {}\n  {} {} {}\n",
+            self.date,
+            "AgentTokenIssuance",
+            self.narration.replace('"', "'"),
+            self.tx_id,
+            self.source_ref.replace('"', "'"),
+            self.asset_account,
+            self.amount,
+            self.currency,
+            self.counterparty_account,
+            inverse,
+            self.currency
+        )
+    }
+}
+
+fn invert_amount(amount: &str) -> String {
+    let trimmed = amount.trim();
+    if let Some(rest) = trimmed.strip_prefix('-') {
+        rest.to_string()
+    } else if let Some(rest) = trimmed.strip_prefix('+') {
+        format!("-{rest}")
+    } else {
+        format!("-{trimmed}")
+    }
+}
+
+fn append_journal_entry(path: &std::path::Path, entry: &AgentTokenJournalEntry) -> Result<()> {
+    use std::io::Write as _;
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).context("create ledger directory")?;
+    }
+    let mut file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .with_context(|| format!("open ledger file {}", path.display()))?;
+    file.write_all(entry.to_beancount_entry().as_bytes())
+        .and_then(|_| file.write_all(b"\n"))
+        .with_context(|| format!("append to ledger file {}", path.display()))
+}
+
+// ---------------------------------------------------------------------------
+// Component 1: issuance flow
+// ---------------------------------------------------------------------------
+
+/// Full issuance flow.
+///
+/// **Fail-before-privilege ordering is load-bearing**: the cake balance
+/// check happens strictly before any k8s client is constructed or any k8s
+/// API call is made.
+pub async fn request_agent_token(req: AgentTokenRequest) -> Result<AgentTokenIssuance> {
+    anyhow::ensure!(req.cost >= 0, "cost must be non-negative, got {}", req.cost);
+
+    // --- 1. Budget check — MUST happen before any k8s API interaction. ---
+    let ledger = CakeLedger::open().context("open cake ledger")?;
+    let balance = ledger.balance(&req.agent_id).context("check cake balance")?;
+    if balance < req.cost {
+        bail!(
+            "insufficient budget for agent '{}': have {} cake, need {}",
+            req.agent_id,
+            balance,
+            req.cost
+        );
+    }
+
+    // --- 2. k8s client (only reached once budget is confirmed). ---
+    let client = Client::try_default().await.context("connect to k8s cluster")?;
+
+    // --- 3. Ensure namespace + ServiceAccount. ---
+    ensure_namespace(&client, AGENTS_NAMESPACE).await?;
+    let sa_name = service_account_name(&req.agent_id);
+    ensure_service_account(&client, AGENTS_NAMESPACE, &sa_name).await?;
+
+    // --- 4. Ensure the marker ClusterRole exists (shared across all kinds). ---
+    ensure_role_shard_access(&client).await?;
+
+    // --- 5. Ensure the scope-labeled RoleBinding. ---
+    ensure_role_binding(&client, AGENTS_NAMESPACE, &sa_name, &req.scope).await?;
+
+    // --- 6. Mint a short-lived, scoped token. ---
+    let token = mint_token(&client, AGENTS_NAMESPACE, &sa_name).await?;
+
+    // --- 7. Record the issuance as a ledger transaction; debit cake. ---
+    let shard_ref = req.scope.to_string();
+    let tx_id = format!("agent-token-{}", uuid::Uuid::new_v4());
+    let date = chrono::Utc::now().format("%Y-%m-%d").to_string();
+    let entry = AgentTokenJournalEntry::new(
+        &req.agent_id,
+        &shard_ref,
+        &req.cost.to_string(),
+        tx_id.clone(),
+        date,
+    );
+    let ledger_path = default_ledger_path()?;
+    append_journal_entry(&ledger_path, &entry).context("append agent-token journal entry")?;
+
+    let remaining_balance = ledger
+        .spend(&req.agent_id, req.cost, &format!("agent-token:{shard_ref}"))
+        .context("debit cake balance")?;
+
+    Ok(AgentTokenIssuance {
+        token,
+        tx_id,
+        expires_in_seconds: TOKEN_TTL_SECONDS,
+        remaining_balance,
+    })
+}
+
+pub fn service_account_name(agent_id: &str) -> String {
+    format!("agent-{}", agent_id)
+}
+
+fn role_binding_name(sa_name: &str, scope: &SoulScope) -> String {
+    format!(
+        "{}-shard-{}-{}",
+        sa_name,
+        scope.kind.as_str(),
+        k8s_label_safe(&scope.id)
+    )
+}
+
+/// Renders an arbitrary shard identifier safe for use as a k8s label value:
+/// alphanumeric/`-`/`_`/`.` only, <=63 chars, starting and ending
+/// alphanumeric (k8s label-value constraints).
+fn k8s_label_safe(s: &str) -> String {
+    let mut out: String = s
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.' {
+                c
+            } else {
+                '-'
+            }
+        })
+        .collect();
+    out.truncate(63);
+    while out.starts_with(|c: char| !c.is_ascii_alphanumeric()) {
+        out.remove(0);
+    }
+    while out.ends_with(|c: char| !c.is_ascii_alphanumeric()) {
+        out.pop();
+    }
+    if out.is_empty() { "x".to_string() } else { out }
+}
+
+// ---------------------------------------------------------------------------
+// k8s helpers — idempotent create-if-missing
+// ---------------------------------------------------------------------------
+
+fn is_conflict(err: &kube::Error) -> bool {
+    matches!(err, kube::Error::Api(e) if e.code == 409)
+}
+
+async fn ensure_namespace(client: &Client, namespace: &str) -> Result<()> {
+    let api: Api<Namespace> = Api::all(client.clone());
+    if api.get(namespace).await.is_ok() {
+        return Ok(());
+    }
+    let ns = Namespace {
+        metadata: ObjectMeta {
+            name: Some(namespace.to_string()),
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    match api.create(&PostParams::default(), &ns).await {
+        Ok(_) => Ok(()),
+        Err(e) if is_conflict(&e) => Ok(()),
+        Err(e) => Err(e).context("create b00t-agents namespace"),
+    }
+}
+
+async fn ensure_service_account(client: &Client, namespace: &str, name: &str) -> Result<()> {
+    let api: Api<ServiceAccount> = Api::namespaced(client.clone(), namespace);
+    if api.get(name).await.is_ok() {
+        return Ok(());
+    }
+    let sa = ServiceAccount {
+        metadata: ObjectMeta {
+            name: Some(name.to_string()),
+            namespace: Some(namespace.to_string()),
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    match api.create(&PostParams::default(), &sa).await {
+        Ok(_) => Ok(()),
+        Err(e) if is_conflict(&e) => Ok(()),
+        Err(e) => Err(e).context("create agent ServiceAccount"),
+    }
+}
+
+async fn ensure_role_shard_access(client: &Client) -> Result<()> {
+    let api: Api<ClusterRole> = Api::all(client.clone());
+    if api.get(ROLE_SHARD_ACCESS).await.is_ok() {
+        return Ok(());
+    }
+    let role: ClusterRole =
+        serde_yaml::from_str(ROLE_SHARD_ACCESS_YAML).context("parse embedded role-shard-access YAML")?;
+    match api.create(&PostParams::default(), &role).await {
+        Ok(_) => Ok(()),
+        Err(e) if is_conflict(&e) => Ok(()),
+        Err(e) => Err(e).context("create role-shard-access ClusterRole"),
+    }
+}
+
+async fn ensure_role_binding(
+    client: &Client,
+    namespace: &str,
+    sa_name: &str,
+    scope: &SoulScope,
+) -> Result<()> {
+    let api: Api<RoleBinding> = Api::namespaced(client.clone(), namespace);
+    let rb_name = role_binding_name(sa_name, scope);
+    if api.get(&rb_name).await.is_ok() {
+        return Ok(());
+    }
+    let mut labels = BTreeMap::new();
+    labels.insert(LABEL_SHARD_KIND.to_string(), scope.kind.as_str().to_string());
+    labels.insert(LABEL_SHARD_ID.to_string(), k8s_label_safe(&scope.id));
+    let rb = RoleBinding {
+        metadata: ObjectMeta {
+            name: Some(rb_name),
+            namespace: Some(namespace.to_string()),
+            labels: Some(labels),
+            ..Default::default()
+        },
+        role_ref: RoleRef {
+            api_group: "rbac.authorization.k8s.io".to_string(),
+            kind: "ClusterRole".to_string(),
+            name: ROLE_SHARD_ACCESS.to_string(),
+        },
+        subjects: Some(vec![Subject {
+            kind: "ServiceAccount".to_string(),
+            name: sa_name.to_string(),
+            namespace: Some(namespace.to_string()),
+            ..Default::default()
+        }]),
+    };
+    match api.create(&PostParams::default(), &rb).await {
+        Ok(_) => Ok(()),
+        Err(e) if is_conflict(&e) => Ok(()),
+        Err(e) => Err(e).context("create shard-access RoleBinding"),
+    }
+}
+
+async fn mint_token(client: &Client, namespace: &str, sa_name: &str) -> Result<String> {
+    let api: Api<ServiceAccount> = Api::namespaced(client.clone(), namespace);
+    let tr = TokenRequest {
+        spec: TokenRequestSpec {
+            expiration_seconds: Some(TOKEN_TTL_SECONDS),
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let data = serde_json::to_vec(&tr).context("serialize TokenRequest")?;
+    let result: TokenRequest = api
+        .create_subresource("token", sa_name, &PostParams::default(), &data)
+        .await
+        .context("k8s TokenRequest")?;
+    result
+        .status
+        .map(|s| s.token)
+        .context("TokenRequest response missing status.token")
+}
+
+// ---------------------------------------------------------------------------
+// Enforcement: TokenReview-based
+// ---------------------------------------------------------------------------
+
+/// Validate `token` via k8s's TokenReview API, then confirm the resulting
+/// ServiceAccount identity has a RoleBinding to [`ROLE_SHARD_ACCESS`] labeled
+/// for `expected`'s exact kind + id. Returns a clear "not authorized for
+/// this shard" error (distinct from a generic/connection error) on failure.
+pub async fn authorize_shard_token(token: &str, expected: &SoulScope) -> Result<AuthorizedIdentity> {
+    let client = Client::try_default().await.context("connect to k8s cluster")?;
+
+    let api: Api<TokenReview> = Api::all(client.clone());
+    let review = TokenReview {
+        spec: TokenReviewSpec {
+            token: Some(token.to_string()),
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let result = api
+        .create(&PostParams::default(), &review)
+        .await
+        .context("k8s TokenReview")?;
+
+    let status = result
+        .status
+        .ok_or_else(|| anyhow::anyhow!("not authorized for this shard: empty TokenReview status"))?;
+
+    if !status.authenticated.unwrap_or(false) {
+        bail!(
+            "not authorized for this shard: token not authenticated ({})",
+            status.error.unwrap_or_else(|| "unknown reason".to_string())
+        );
+    }
+
+    let username = status
+        .user
+        .and_then(|u| u.username)
+        .ok_or_else(|| anyhow::anyhow!("not authorized for this shard: TokenReview response missing user info"))?;
+
+    let (namespace, sa_name) = parse_service_account_username(&username).ok_or_else(|| {
+        anyhow::anyhow!(
+            "not authorized for this shard: '{}' is not a ServiceAccount identity",
+            username
+        )
+    })?;
+
+    let bound = role_binding_exists_for(&client, &namespace, &sa_name, expected).await?;
+    if !bound {
+        bail!(
+            "not authorized for this shard: ServiceAccount '{}/{}' has no role-shard-access RoleBinding for '{}'",
+            namespace,
+            sa_name,
+            expected
+        );
+    }
+
+    Ok(AuthorizedIdentity {
+        username,
+        namespace,
+        service_account_name: sa_name,
+    })
+}
+
+/// Parse Kubernetes' standard ServiceAccount username format:
+/// `system:serviceaccount:<namespace>:<name>`.
+fn parse_service_account_username(username: &str) -> Option<(String, String)> {
+    let mut parts = username.splitn(4, ':');
+    match (parts.next(), parts.next(), parts.next(), parts.next()) {
+        (Some("system"), Some("serviceaccount"), Some(ns), Some(name)) if !ns.is_empty() && !name.is_empty() => {
+            Some((ns.to_string(), name.to_string()))
+        }
+        _ => None,
+    }
+}
+
+async fn role_binding_exists_for(
+    client: &Client,
+    namespace: &str,
+    sa_name: &str,
+    scope: &SoulScope,
+) -> Result<bool> {
+    let api: Api<RoleBinding> = Api::namespaced(client.clone(), namespace);
+    let list = api.list(&Default::default()).await.context("list RoleBindings")?;
+    let want_id = k8s_label_safe(&scope.id);
+    Ok(list.items.iter().any(|rb| {
+        rb.role_ref.name == ROLE_SHARD_ACCESS
+            && rb
+                .subjects
+                .as_ref()
+                .is_some_and(|subs| subs.iter().any(|s| s.kind == "ServiceAccount" && s.name == sa_name))
+            && rb.metadata.labels.as_ref().is_some_and(|labels| {
+                labels.get(LABEL_SHARD_KIND).map(String::as_str) == Some(scope.kind.as_str())
+                    && labels.get(LABEL_SHARD_ID) == Some(&want_id)
+            })
+    }))
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::soul_scope::ShardKind;
+
+    /// Soft-skip helper: probes whether a k8s cluster is actually
+    /// reachable (not just that *some* kubeconfig/in-cluster config
+    /// exists) via a real API call. Returns the connected client if so.
+    async fn live_cluster() -> Option<Client> {
+        let client = Client::try_default().await.ok()?;
+        let ns_api: Api<Namespace> = Api::all(client.clone());
+        ns_api.list(&Default::default()).await.ok()?;
+        Some(client)
+    }
+
+    #[test]
+    fn test_service_account_name() {
+        assert_eq!(service_account_name("claude-worker-7"), "agent-claude-worker-7");
+    }
+
+    /// Pinned against ledger_core::journal's own
+    /// `from_agent_token_issuance_sets_expected_fields` test — this local
+    /// copy must produce identical field values.
+    #[test]
+    fn journal_entry_sets_expected_fields() {
+        let entry = AgentTokenJournalEntry::new(
+            "claude-worker-7",
+            "datum:some-datum-id",
+            "3",
+            "tx-abc123".to_string(),
+            "2026-08-22".to_string(),
+        );
+        assert_eq!(entry.date, "2026-08-22");
+        assert_eq!(entry.narration, "agent token issued: datum:some-datum-id");
+        assert_eq!(entry.asset_account, "Assets:Cake:claude-worker-7");
+        assert_eq!(entry.counterparty_account, "Expenses:AgentTokens:datum");
+        assert_eq!(entry.amount, "3");
+        assert_eq!(entry.currency, "CAKE");
+        assert_eq!(entry.tx_id, "tx-abc123");
+        assert_eq!(entry.source_ref, "agent-token:claude-worker-7");
+    }
+
+    /// Pinned against ledger_core::journal's own
+    /// `from_agent_token_issuance_shard_ref_without_colon_falls_back_whole`.
+    #[test]
+    fn journal_entry_shard_ref_without_colon_falls_back_whole() {
+        let entry = AgentTokenJournalEntry::new(
+            "agent-x",
+            "datumonly",
+            "1",
+            "tx-1".to_string(),
+            "2026-08-22".to_string(),
+        );
+        assert_eq!(entry.counterparty_account, "Expenses:AgentTokens:datumonly");
+    }
+
+    /// Pinned against ledger_core::journal's own
+    /// `from_agent_token_issuance_produces_balanced_beancount_entry` — this
+    /// local copy's on-disk format must be byte-identical, so the ledger
+    /// stays format-compatible if a real `ledger-core` dependency becomes
+    /// usable again later.
+    #[test]
+    fn journal_entry_produces_balanced_beancount_entry() {
+        let entry = AgentTokenJournalEntry::new(
+            "claude-worker-7",
+            "datum:some-datum-id",
+            "3",
+            "tx-abc123".to_string(),
+            "2026-08-22".to_string(),
+        );
+        let rendered = entry.to_beancount_entry();
+
+        assert!(rendered.contains("Assets:Cake:claude-worker-7 3 CAKE"));
+        assert!(rendered.contains("Expenses:AgentTokens:datum -3 CAKE"));
+        assert_eq!(invert_amount(&entry.amount), "-3");
+        assert_eq!(invert_amount(&invert_amount(&entry.amount)), entry.amount);
+        assert!(rendered.contains("2026-08-22 * \"AgentTokenIssuance\""));
+        assert!(rendered.contains("txid: \"tx-abc123\""));
+        assert!(rendered.contains("source_ref: \"agent-token:claude-worker-7\""));
+    }
+
+    #[test]
+    fn append_journal_entry_creates_parent_dir_and_appends() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("nested").join("agent-tokens.beancount");
+        let entry = AgentTokenJournalEntry::new(
+            "agent-y",
+            "skill:b00t-learn",
+            "2",
+            "tx-2".to_string(),
+            "2026-08-22".to_string(),
+        );
+        append_journal_entry(&path, &entry).unwrap();
+        let contents = std::fs::read_to_string(&path).unwrap();
+        assert!(contents.contains("tx-2"));
+        assert!(contents.contains("Expenses:AgentTokens:skill"));
+    }
+
+    #[test]
+    fn role_binding_name_is_per_agent_and_scope() {
+        let scope_a = SoulScope::new(ShardKind::Datum, "foo");
+        let scope_b = SoulScope::new(ShardKind::Agent, "foo");
+        assert_ne!(
+            role_binding_name("agent-x", &scope_a),
+            role_binding_name("agent-x", &scope_b),
+            "different shard kinds for the same id must not collide"
+        );
+    }
+
+    #[test]
+    fn k8s_label_safe_neutralizes_invalid_chars_and_trims_edges() {
+        assert_eq!(k8s_label_safe("weird id/with:colons"), "weird-id-with-colons");
+        assert_eq!(k8s_label_safe("-leading-and-trailing-"), "leading-and-trailing");
+        assert_eq!(k8s_label_safe(""), "x");
+    }
+
+    #[test]
+    fn test_parse_service_account_username_valid() {
+        let parsed = parse_service_account_username("system:serviceaccount:b00t-agents:agent-foo");
+        assert_eq!(
+            parsed,
+            Some(("b00t-agents".to_string(), "agent-foo".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_parse_service_account_username_invalid() {
+        assert_eq!(parse_service_account_username("operator"), None);
+        assert_eq!(parse_service_account_username("system:anonymous"), None);
+        assert_eq!(parse_service_account_username(""), None);
+    }
+
+    #[test]
+    fn test_role_shard_access_yaml_parses() {
+        let role: ClusterRole =
+            serde_yaml::from_str(ROLE_SHARD_ACCESS_YAML).expect("embedded YAML must parse");
+        assert_eq!(role.metadata.name.as_deref(), Some(ROLE_SHARD_ACCESS));
+    }
+
+    /// Fail-before-privilege: with an agent that has no seeded cake balance
+    /// (0), the request must be denied with the budget error — without ever
+    /// attempting a k8s API call. `CakeLedger::open_at` isolates this test
+    /// to a private scratch DB, so no env-var mutation or cross-test
+    /// locking is needed for this half of the flow.
+    #[tokio::test]
+    async fn test_insufficient_budget_denied_before_any_k8s_call() {
+        // request_agent_token() itself calls CakeLedger::open() (the
+        // fixed, real path), so we can't isolate via open_at() here — but
+        // a freshly-generated, never-seen agent id is guaranteed a 0
+        // balance in that real ledger regardless of other tests' state.
+        let req = AgentTokenRequest {
+            agent_id: format!("never-funded-{}", uuid::Uuid::new_v4()),
+            scope: SoulScope::new(ShardKind::Datum, "some-datum-id"),
+            cost: 5,
+        };
+
+        let result = request_agent_token(req).await;
+        let err = result.expect_err("expected insufficient-budget denial");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("insufficient budget"),
+            "expected insufficient-budget error, got: {msg}"
+        );
+    }
+
+    /// Full positive flow against a real k8s cluster, exercised across two
+    /// different shard kinds for the same agent to confirm per-kind
+    /// RoleBinding isolation. `#[ignore]`d: constructing a k8s `Client` at
+    /// all (even one that will fail to find a cluster) touches rustls'
+    /// process-level `CryptoProvider`, which panics rather than erroring
+    /// when it can't auto-select one — this must not run in a normal
+    /// `cargo test`. Run explicitly with `cargo test -- --ignored` against
+    /// a real cluster (set KUBECONFIG).
+    #[tokio::test]
+    #[ignore = "requires a live k8s cluster (set KUBECONFIG); run with cargo test -- --ignored"]
+    async fn test_full_issuance_flow_against_live_cluster_if_reachable() {
+        if live_cluster().await.is_none() {
+            eprintln!(
+                "SKIP test_full_issuance_flow_against_live_cluster_if_reachable: \
+                 no k8s cluster reachable in this environment (set KUBECONFIG to \
+                 test against a live cluster)"
+            );
+            return;
+        }
+
+        let agent_id = format!("test-agent-{}", uuid::Uuid::new_v4());
+        let ledger = CakeLedger::open().expect("open cake ledger");
+        ledger.mint(&agent_id, 10, "test seed").expect("seed balance");
+
+        let issuance = request_agent_token(AgentTokenRequest {
+            agent_id: agent_id.clone(),
+            scope: SoulScope::new(ShardKind::Datum, "integration-test-datum"),
+            cost: 3,
+        })
+        .await
+        .expect("request_agent_token should succeed against a live cluster");
+
+        assert!(!issuance.token.is_empty(), "minted token must be non-empty");
+        assert_eq!(issuance.remaining_balance, 7);
+        assert_eq!(ledger.balance(&agent_id).expect("balance"), 7);
+
+        // Journal entry actually appended to the dedicated ledger file.
+        let ledger_path = default_ledger_path().expect("ledger path");
+        let contents = std::fs::read_to_string(&ledger_path).expect("read journal file");
+        assert!(contents.contains(&issuance.tx_id), "journal must contain this issuance's tx_id");
+        assert!(
+            contents.contains("datum:integration-test-datum"),
+            "journal must reference the shard"
+        );
+        assert!(
+            contents.contains(&format!("Assets:Cake:{agent_id}")),
+            "journal must debit the agent's cake account"
+        );
+
+        // Positive half of enforcement: the freshly-minted token IS
+        // authorized for the exact scope it was issued for...
+        let scope = SoulScope::new(ShardKind::Datum, "integration-test-datum");
+        let identity = authorize_shard_token(&issuance.token, &scope)
+            .await
+            .expect("freshly-minted token should be authorized for its own shard");
+        assert_eq!(identity.namespace, AGENTS_NAMESPACE);
+        assert_eq!(identity.service_account_name, service_account_name(&agent_id));
+
+        // ...but NOT for a different shard kind/id the same agent hasn't
+        // separately been issued a token for.
+        let other_scope = SoulScope::new(ShardKind::Agent, "integration-test-datum");
+        let denied = authorize_shard_token(&issuance.token, &other_scope).await;
+        assert!(
+            denied.is_err(),
+            "a datum-scoped token must not authorize an agent-scoped request"
+        );
+    }
+
+    /// A token for a ServiceAccount that has no `role-shard-access`
+    /// RoleBinding at all must be denied with the specific "not authorized
+    /// for this shard" error — not a crash, not a generic error.
+    /// `#[ignore]`d for the same rustls `CryptoProvider` reason as above.
+    #[tokio::test]
+    #[ignore = "requires a live k8s cluster (set KUBECONFIG); run with cargo test -- --ignored"]
+    async fn test_shard_authorization_denied_for_unbound_service_account() {
+        let Some(client) = live_cluster().await else {
+            eprintln!(
+                "SKIP test_shard_authorization_denied_for_unbound_service_account: \
+                 no k8s cluster reachable in this environment"
+            );
+            return;
+        };
+
+        // A bare ServiceAccount with NO RoleBinding to role-shard-access, in
+        // a throwaway namespace kept separate from b00t-agents on purpose.
+        let ns = "default";
+        let sa_name = format!("unbound-test-sa-{}", uuid::Uuid::new_v4());
+        let sa_api: Api<ServiceAccount> = Api::namespaced(client.clone(), ns);
+        let sa = ServiceAccount {
+            metadata: ObjectMeta {
+                name: Some(sa_name.clone()),
+                namespace: Some(ns.to_string()),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        sa_api
+            .create(&PostParams::default(), &sa)
+            .await
+            .expect("create throwaway ServiceAccount");
+
+        // Mint a token for it directly — bypassing request_agent_token,
+        // which would create the RoleBinding; this test specifically needs
+        // a token WITHOUT one.
+        let tr = TokenRequest {
+            spec: TokenRequestSpec {
+                expiration_seconds: Some(300),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let data = serde_json::to_vec(&tr).expect("serialize TokenRequest");
+        let result: TokenRequest = sa_api
+            .create_subresource("token", &sa_name, &PostParams::default(), &data)
+            .await
+            .expect("mint token for unbound ServiceAccount");
+        let token = result.status.expect("TokenRequest status").token;
+
+        let scope = SoulScope::new(ShardKind::Datum, "anything");
+        let err = authorize_shard_token(&token, &scope)
+            .await
+            .expect_err("unbound ServiceAccount token must be denied");
+        assert!(
+            err.to_string().contains("not authorized for this shard"),
+            "expected 'not authorized for this shard' error, got: {err}"
+        );
+
+        // Best-effort cleanup — not asserted, this is a throwaway resource.
+        let _ = sa_api
+            .delete(&sa_name, &kube::api::DeleteParams::default())
+            .await;
+    }
+}

--- a/b00t-cli/src/commands/ai.rs
+++ b/b00t-cli/src/commands/ai.rs
@@ -41,10 +41,43 @@ pub enum AiCommands {
         #[clap(help = "Comma-separated list of AI provider names to output")]
         providers: String,
     },
+    #[clap(about = "Agent identity & scoped token operations (#1104)")]
+    Agent {
+        #[clap(subcommand)]
+        cmd: AgentSubcommand,
+    },
+}
+
+#[derive(Parser)]
+pub enum AgentSubcommand {
+    #[clap(about = "Agent-scoped token operations")]
+    Token {
+        #[clap(subcommand)]
+        cmd: AgentTokenSubcommand,
+    },
+}
+
+#[derive(Parser)]
+pub enum AgentTokenSubcommand {
+    #[clap(
+        about = "Request a scoped, budget-checked agent token",
+        long_about = "Check cake balance (fail before privilege), ensure a k8s ServiceAccount+RoleBinding exist for the requested #1102 shard scope, mint a short-lived (15m) scoped token via k8s TokenRequest, and record the issuance as a ledger transaction.\n\nExample:\n  b00t-cli ai agent token request --agent claude-worker-7 --scope datum:my-datum --cost 3"
+    )]
+    Request {
+        #[clap(long, help = "Requesting agent's identity")]
+        agent: String,
+        #[clap(
+            long,
+            help = "#1102 shard scope 'kind:id', e.g. 'datum:my-datum' — kinds: project system agent skill tool datum"
+        )]
+        scope: String,
+        #[clap(long, help = "Cake cost to debit for this issuance")]
+        cost: i64,
+    },
 }
 
 impl AiCommands {
-    pub fn execute(&self, _path: &str) -> Result<()> {
+    pub async fn execute(&self, _path: &str) -> Result<()> {
         match self {
             AiCommands::Add { .. } => {
                 println!("🤖 AI add functionality coming soon...");
@@ -87,6 +120,46 @@ impl AiCommands {
                 println!("📤 AI output functionality coming soon...");
                 Ok(())
             }
+            AiCommands::Agent { cmd } => match cmd {
+                AgentSubcommand::Token { cmd } => match cmd {
+                    AgentTokenSubcommand::Request { agent, scope, cost } => {
+                        use crate::agent_token::{AgentTokenRequest, request_agent_token};
+                        use crate::cake_ledger::CakeLedger;
+                        use crate::soul_scope::SoulScope;
+
+                        let parsed_scope = SoulScope::parse_flag(scope)?;
+
+                        // Pre-flight cost menu: cake is the real, enforced
+                        // gate (request_agent_token re-checks it atomically
+                        // before any k8s call). Budget-stack integration is
+                        // deliberately not wired here — b00t-cli's
+                        // `budget` subcommand is per-job-stack, not
+                        // per-agent, and there's no natural stack for an
+                        // ad-hoc token request to belong to without a
+                        // separate design decision; that's left for a
+                        // follow-on rather than a forced, mismatched check.
+                        if let Ok(ledger) = CakeLedger::open() {
+                            if let Ok(balance) = ledger.balance(agent) {
+                                println!("💰 '{agent}' cake balance: {balance} (cost: {cost})");
+                            }
+                        }
+
+                        let issuance = request_agent_token(AgentTokenRequest {
+                            agent_id: agent.clone(),
+                            scope: parsed_scope,
+                            cost: *cost,
+                        })
+                        .await?;
+
+                        println!("🔑 Agent token issued for '{agent}' (scope: {scope})");
+                        println!("   token:      {}", issuance.token);
+                        println!("   tx_id:      {}", issuance.tx_id);
+                        println!("   expires_in: {}s", issuance.expires_in_seconds);
+                        println!("   balance:    {}", issuance.remaining_balance);
+                        Ok(())
+                    }
+                },
+            },
         }
     }
 }
@@ -95,12 +168,12 @@ impl AiCommands {
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_ai_commands_exist() {
+    #[tokio::test]
+    async fn test_ai_commands_exist() {
         let add_cmd = AiCommands::Add {
             file: "test.toml".to_string(),
         };
 
-        assert!(add_cmd.execute("test").is_ok());
+        assert!(add_cmd.execute("test").await.is_ok());
     }
 }

--- a/b00t-cli/src/commands/datum.rs
+++ b/b00t-cli/src/commands/datum.rs
@@ -12,6 +12,11 @@ pub enum DatumCommands {
     Show {
         #[clap(help = "Datum name to show (e.g., just, rust, docker)")]
         name: String,
+        #[clap(
+            long,
+            help = "Authorize via a scoped agent token (#1104: k8s TokenReview + role-shard-access RoleBinding check for scope 'datum:<name>') instead of ambient trust"
+        )]
+        as_agent_token: Option<String>,
     },
 
     #[clap(about = "Generate JSTree-compatible JSON from datums")]
@@ -216,9 +221,11 @@ pub enum DatumCommands {
     },
 }
 
-pub fn handle_datum_command(path: &str, datum_command: &DatumCommands) -> Result<()> {
+pub async fn handle_datum_command(path: &str, datum_command: &DatumCommands) -> Result<()> {
     match datum_command {
-        DatumCommands::Show { name } => handle_show(path, name),
+        DatumCommands::Show { name, as_agent_token } => {
+            handle_show(path, name, as_agent_token.as_deref()).await
+        }
         DatumCommands::Tree {
             output,
             group_by_type,
@@ -327,7 +334,17 @@ pub fn handle_datum_command(path: &str, datum_command: &DatumCommands) -> Result
     }
 }
 
-fn handle_show(b00t_path: &str, datum_name: &str) -> Result<()> {
+async fn handle_show(b00t_path: &str, datum_name: &str, as_agent_token: Option<&str>) -> Result<()> {
+    // #1104: when --as-agent-token is given, gate the read path on a k8s
+    // TokenReview + role-shard-access RoleBinding check (scoped to
+    // datum:<datum_name>) rather than ambient trust.
+    if let Some(token) = as_agent_token {
+        let scope = crate::soul_scope::SoulScope::new(crate::soul_scope::ShardKind::Datum, datum_name);
+        crate::agent_token::authorize_shard_token(token, &scope)
+            .await
+            .context("datum show --as-agent-token")?;
+    }
+
     // Find the datum
     let datum = datum_utils::find_datum_by_pattern(b00t_path, datum_name)?
         .ok_or_else(|| anyhow::anyhow!("Datum '{}' not found", datum_name))?;

--- a/b00t-cli/src/lib.rs
+++ b/b00t-cli/src/lib.rs
@@ -91,6 +91,7 @@ pub mod job_executor;
 pub mod job_ipc;
 pub mod job_state;
 pub mod just_ast;
+pub mod agent_token;
 pub mod k0mmand3r;
 pub mod k8s;
 pub mod memory_provider;

--- a/b00t-cli/src/main.rs
+++ b/b00t-cli/src/main.rs
@@ -2320,7 +2320,7 @@ async fn main() {
             }
         }
         Some(Commands::Ai { ai_command }) => {
-            if let Err(e) = ai_command.execute(&cli.path) {
+            if let Err(e) = ai_command.execute(&cli.path).await {
                 eprintln!("Error: {}", e);
                 std::process::exit(1);
             }
@@ -2604,7 +2604,7 @@ async fn main() {
         }
         Some(Commands::Datum { datum_command }) => {
             use b00t_cli::commands::datum::handle_datum_command;
-            if let Err(e) = handle_datum_command(&cli.path, datum_command) {
+            if let Err(e) = handle_datum_command(&cli.path, datum_command).await {
                 eprintln!("Error: {}", e);
                 std::process::exit(1);
             }

--- a/docs/superpowers/specs/2026-08-31-agent-scoped-token-issuance.md
+++ b/docs/superpowers/specs/2026-08-31-agent-scoped-token-issuance.md
@@ -1,0 +1,126 @@
+# Agent-Scoped Token Issuance (#1104)
+
+**Date:** 2026-08-31
+**Status:** Implemented, generalized to all six #1102 shard kinds.
+**Context:** Implements the "operator holds root trust; short-lived,
+narrowly-scoped tokens are issued from it" flow from
+elasticdotventures/_b00t_#1104, scoped to the #1102 shard taxonomy
+(project/system/agent/skill/tool/datum). Supersedes an earlier unmerged
+pilot (`origin/feat/agent-scoped-token-issuance`, commit `aa1a425e`) which
+proved the same flow end-to-end for the `datum` shard-type only.
+
+## Goal
+
+Give individual AI agents their own scoped, revocable identity/tokens
+instead of one shared blanket credential, with memory-shard access (RBAC)
+and cost tracking (cake) unified under one issuance flow — across all six
+#1102 shard kinds, not just one.
+
+## Architecture
+
+```
+b00t ai agent token request --agent <id> --scope <kind>:<id> --cost <N>
+        │
+        ▼
+1. cake balance check (CakeLedger::balance — fail before privilege)
+        │  insufficient → deny immediately, no k8s calls, no journal entry
+        ▼
+2. ensure ServiceAccount "agent-<id>" in namespace "b00t-agents" (idempotent)
+        ▼
+3. ensure ClusterRole "role-shard-access" exists (idempotent, embedded YAML,
+   shared across ALL six shard kinds — not one ClusterRole per kind)
+        ▼
+4. ensure RoleBinding: ServiceAccount → role-shard-access, labeled with the
+   exact shard kind + id this binding authorizes (idempotent)
+        ▼
+5. k8s TokenRequest API → short-lived (15 min) SA token
+        ▼
+6. record issuance as a double-entry transaction, appended to
+   ~/.b00t/ledger/agent-tokens.beancount (dedicated file, never mixed with
+   real financial records) — this debits the agent's cake balance for `cost`
+        ▼
+7. print/return the minted token
+```
+
+Enforcement is via k8s's TokenReview API, wired into `b00t-cli datum show`
+via `--as-agent-token <token>` (scoped to `datum:<name>`) — mechanically
+extensible to any other soul-shard-backed read path.
+
+## Why one ClusterRole, not six
+
+The unmerged pilot minted a per-shard-kind marker ClusterRole
+(`role-shard-datum`). Generalizing that 1:1 to six kinds would mean six
+near-identical marker roles with no real access difference between them —
+pure sprawl. Instead, one `role-shard-access` ClusterRole is shared across
+all kinds; the specific kind + id a RoleBinding authorizes is carried as
+labels (`b00t.elastic.ventures/shard-kind`, `b00t.elastic.ventures/shard-id`)
+on the RoleBinding itself, checked by `authorize_shard_token`'s TokenReview
+path. A RoleBinding is still minted per (agent, kind, id) — only the
+ClusterRole is shared.
+
+## Why not a dependency on `ledger-core`
+
+The original design intent (and the unmerged pilot) called
+`ledger_core::journal::JournalTransaction::from_agent_token_issuance`
+directly. Attempting to wire that up here surfaced a real, pre-existing
+problem: `ledger-core`'s optional `arc-kit-au` → `msft-agent-gov-ledgrrr` →
+`agentmesh` dependency chain (which Cargo resolves regardless of feature
+flags, since path-dependency manifests are parsed unconditionally) hard-pins
+`agentmesh v3.5.0`'s required `serde =1.0.228`, which conflicts with the
+rest of this workspace's `serde 1.0.229`.
+
+This is a cross-cutting version conflict inside `vendor/ledgrrr` itself,
+unrelated to agent-token issuance, and out of scope to fix here — other
+sessions are actively working in that submodule. `b00t-cli/src/agent_token.rs`
+instead reproduces the exact same double-entry beancount shape locally
+(`AgentTokenJournalEntry`, tests pinned against `ledger-core`'s own test
+expectations for byte-identical output). The on-disk ledger format is
+unaffected; swapping in the real `ledger-core` dependency once the
+`agentmesh`/serde conflict is resolved is a drop-in change, not a format
+migration.
+
+## Components
+
+### 1. `b00t-cli/src/agent_token.rs` — issuance + enforcement module
+
+Implements the 7-step flow above and `authorize_shard_token` (TokenReview +
+RoleBinding-label check), exposed as
+`b00t ai agent token request --agent <id> --scope <kind>:<id> --cost <N>`
+(wired via `AiCommands::Agent { Token { Request { .. } } }` in
+`b00t-cli/src/commands/ai.rs`). Depends on #1102's `crate::soul_scope`
+(`SoulScope`/`ShardKind`) for the scope taxonomy and on the existing
+`kube`/`k8s-openapi` dependencies already present in `b00t-cli/Cargo.toml`.
+
+### 2. `b00t-cli/src/commands/ai.rs` — CLI surface
+
+`AiCommands::Agent { Token { Request } }`, taking `--agent`, `--scope
+<kind>:<id>`, `--cost`. Prints a pre-flight cake-balance line before
+issuance. Deliberately does **not** wire `b00t-cli budget`'s
+stack-scoped controller in here — that subsystem is per-job-stack, not
+per-agent, and there's no natural stack for an ad-hoc token request to
+belong to without a separate design decision. Left as a follow-on rather
+than a forced, semantically-mismatched check.
+
+### 3. `b00t-cli/src/commands/datum.rs` — enforcement wiring
+
+`datum show --as-agent-token <token>` calls `authorize_shard_token(token,
+&SoulScope::new(ShardKind::Datum, datum_name))` before reading. Mechanically
+extensible: any other command backed by a #1102 soul shard can gate the
+same way once it has a natural `SoulScope` to check against.
+
+## Not implemented in this pass
+
+- The `ledgerr_authorize_agent_token`/`ledgerr_release_credential` MCP
+  domain-tool surface described in #1104's original proposal (issuance as a
+  `vendor/ledgrrr` transaction, exposed over MCP) — requires new code in
+  that submodule, explicitly deferred and out of scope while other sessions
+  are active there. b00t-cli's implementation is fully local (direct k8s +
+  local ledger file, no MCP round-trip) and functional for internal use
+  without it.
+- Cost-menu / discoverable "what can I afford" surfacing beyond the single
+  pre-flight cake-balance line — the issue's fuller "menu of affordable
+  services" vision needs a broader design (what counts as a "service," how
+  cost ceilings are declared per skill/tool) that's out of scope for this
+  pass.
+- Extending enforcement beyond `datum show` to other soul-shard-backed
+  commands — mechanical once needed, not done preemptively (YAGNI).


### PR DESCRIPTION
## Summary
- Implements #1104: per-agent, individually-distinguishable, revocable tokens issued from k8s, gated on cake balance and scoped to a #1102 soul shard, enforced via k8s TokenReview.
- Generalizes an unmerged prior pilot (\`origin/feat/agent-scoped-token-issuance\`, commit \`aa1a425e\`) from one hardcoded shard-type (\`datum\`) to all six #1102 \`ShardKind\`s. That commit turned out to be a disconnected root commit with no shared git history with \`main\`, so this is a from-scratch reimplementation informed by reading it, not a literal rebase.
- One shared \`role-shard-access\` ClusterRole across all six shard kinds (not one per kind) — the specific kind+id a RoleBinding authorizes is carried as RoleBinding labels, avoiding 6x role sprawl.
- **Does not** depend on \`vendor/ledgrrr\`'s \`ledger-core\`: its optional \`arc-kit-au\` → \`msft-agent-gov-ledgrrr\` → \`agentmesh\` chain hard-pins \`serde =1.0.228\`, conflicting with this workspace's \`serde 1.0.229\` — a real, pre-existing conflict inside that submodule, out of scope to fix here while other sessions are active in it. \`AgentTokenJournalEntry\` reproduces the exact double-entry beancount shape locally instead, with tests pinned against \`ledger-core\`'s own test expectations for byte-identical output. Full rationale in the new design doc.

Part of the b00t-backlog-triage phased plan: #1102 (merged, #1220) → **#1104 (this PR)** → #1106+#1101.

## Not in this pass (explicitly deferred, see design doc)
- \`ledgerr_authorize_agent_token\` MCP-tool surface in \`vendor/ledgrrr\`.
- Cost-menu/budget-stack integration beyond a pre-flight cake-balance line.
- Enforcement beyond \`datum show\`.

## Test plan
- [x] \`cargo build -p b00t-cli\` — clean.
- [x] \`cargo test -p b00t-cli --lib\` → 1605 passed, 0 failed, 6 ignored.
- [x] 2 of the ignored tests are this module's live-k8s-cluster integration tests, \`#[ignore]\`d because constructing a k8s \`Client\` at all touches rustls' process-level \`CryptoProvider\`, which panics (not errors) when it can't auto-select one in this test environment — run explicitly with \`cargo test -- --ignored\` against a real cluster (set \`KUBECONFIG\`).