### PR TITLE
feat(b00t): reviewer-gate pattern for skill relevance + disclosure safety

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1524,6 +1524,7 @@ dependencies = [
  "anyhow",
  "ascent",
  "async-trait",
+ "b00t-bouncer",
  "b00t-ipc",
  "base64 0.22.1",
  "cfg-if 1.0.4",

--- a/b00t-c0re-lib/Cargo.toml
+++ b/b00t-c0re-lib/Cargo.toml
@@ -96,6 +96,8 @@ quote = "1.0.45"
 # used at runtime (not just tests) for shallow-cloning external MCP registry sources
 # (e.g. vinkius-mcp-database) into a scratch dir that's cleaned up on drop
 tempfile = "3.10"
+# #1101: cheap wordlist first-pass filter in front of the disclosure gate
+b00t-bouncer = { path = "../b00t-bouncer" }
 
 [dev-dependencies]
 tokio-test = "0.4"

--- a/b00t-c0re-lib/src/lfmf.rs
+++ b/b00t-c0re-lib/src/lfmf.rs
@@ -214,6 +214,28 @@ impl LfmfSystem {
 
     /// Record a lesson learned from failure
     pub async fn record_lesson(&mut self, tool: &str, lesson: &str) -> Result<()> {
+        self.record_lesson_scoped(tool, lesson, false, false).await
+    }
+
+    /// #1101: scope-aware variant. `global = true` routes the write through
+    /// a disclosure-safety gate before it lands on disk — a cheap wordlist
+    /// first-pass filter (`b00t-bouncer`), then the sm0l reviewer gate
+    /// (`b00t_c0re_lib::reviewer_gate`) if that first pass doesn't already
+    /// fail outright. A SENSITIVE/Fail verdict blocks the write unless
+    /// `force` is set; the attempt is logged to events.jsonl either way.
+    /// `global = false` (repo-scoped) skips the gate entirely — unchanged
+    /// from `record_lesson`'s prior behavior.
+    pub async fn record_lesson_scoped(
+        &mut self,
+        tool: &str,
+        lesson: &str,
+        global: bool,
+        force: bool,
+    ) -> Result<()> {
+        if global {
+            self.run_disclosure_gate(lesson, force)?;
+        }
+
         // Resolve category (might be a datum name)
         let category = self.resolve_category(tool);
         let lesson_obj = self.parse_lesson(&category, lesson)?;
@@ -285,6 +307,52 @@ impl LfmfSystem {
             .await
             .context("Failed to store lesson in vector database")?;
 
+        Ok(())
+    }
+
+    /// #1101: disclosure-safety gate for global-scope writes. Cheap
+    /// wordlist first-pass (`b00t-bouncer`) runs first; only if that
+    /// passes does the slower sm0l reviewer gate run. A `Fail`/`SENSITIVE`
+    /// verdict blocks the write (returns Err) unless `force` is set.
+    /// Logged to events.jsonl either way, per #1101's audit requirement.
+    fn run_disclosure_gate(&self, content: &str, force: bool) -> Result<()> {
+        let bouncer = b00t_bouncer::Bouncer::new();
+        if let b00t_bouncer::BouncerResult::Fail { gate, reason } = bouncer.validate_input(content) {
+            crate::events::write_event(
+                "lfmf_disclosure_gate",
+                &format!("blocked (bouncer/{gate}): {reason} — force={force}"),
+            );
+            if !force {
+                anyhow::bail!(
+                    "lfmf --global blocked by bouncer ({gate}): {reason}.                      Pass --force to override if this is a false positive."
+                );
+            }
+            return Ok(());
+        }
+
+        match crate::reviewer_gate::gate_verdict(content, &crate::reviewer_gate::GateMode::Disclosure) {
+            crate::reviewer_gate::GateVerdict::Block { reason } => {
+                crate::events::write_event(
+                    "lfmf_disclosure_gate",
+                    &format!("blocked (reviewer): {reason} — force={force}"),
+                );
+                if !force {
+                    anyhow::bail!(
+                        "lfmf --global blocked by disclosure gate: {reason}.                          Pass --force to override if this is a false positive."
+                    );
+                }
+            }
+            crate::reviewer_gate::GateVerdict::Pass => {
+                crate::events::write_event("lfmf_disclosure_gate", "safe");
+            }
+            crate::reviewer_gate::GateVerdict::Unavailable { warning } => {
+                eprintln!("⚠️  lfmf --global: {warning}");
+                crate::events::write_event(
+                    "lfmf_disclosure_gate",
+                    &format!("unavailable, failed open: {warning}"),
+                );
+            }
+        }
         Ok(())
     }
 

--- a/b00t-c0re-lib/src/lib.rs
+++ b/b00t-c0re-lib/src/lib.rs
@@ -71,6 +71,7 @@ pub mod rhai_engine;
 pub mod runtime_env;
 pub mod satisfies;
 pub mod secret_validation;
+pub mod reviewer_gate;
 pub mod sm0l_dispatch;
 pub mod state_introspection;
 pub mod sudo_operator;

--- a/b00t-c0re-lib/src/reviewer_gate.rs
+++ b/b00t-c0re-lib/src/reviewer_gate.rs
@@ -1,0 +1,184 @@
+//! #1106/#1101: shared "reviewer gate" primitive — the documented-but-
+//! unbuilt karpathy/deepwiki 3-gate autolearn pattern's Research gate,
+//! generalized to two verdict vocabularies over one dispatch path.
+//!
+//! A sm0l reviewer model sits between Orient and Act, judging either:
+//! - **Relevance** (#1106): is this skill/datum's content relevant to the
+//!   current goal, before its full body is consumed? `RELEVANT|SKIP:<reason>`.
+//! - **Disclosure** (#1101): is this content safe to write to a shared,
+//!   global, or public-facing scope? `SAFE|SENSITIVE:<reason>`.
+//!
+//! Both issues explicitly require failing OPEN (permissive, with a loud
+//! warning) when the reviewer backend is unreachable or returns something
+//! unparseable — alpha tooling should degrade visibly, not silently block
+//! normal work. Callers that need a stricter default (e.g. #1101's "SENSITIVE
+//! blocks by default") implement that policy themselves by matching on
+//! [`GateVerdict::Block`] vs the other variants; this module only reports
+//! what the reviewer actually said (or that it couldn't be asked).
+//!
+//! Dispatch substrate: `sm0l_dispatch::dispatch()`, NOT `grok ask`. Per
+//! `_b00t_/learn/grok.md`, `grok ask`'s default irontology backend fails
+//! silently (empty results, not an error) when no HelixDB server is
+//! running — a poor foundation for a gate whose whole job is to fail
+//! *loudly* when unavailable. `sm0l_dispatch::SmolEndpoint::discover()`
+//! already implements the fail-open priority chain both issues want
+//! (env override → local ch0nky/sm0l ports → HF Inference API → Err), is
+//! already live (used by `commands::learn`'s DWIW path), and is fully
+//! independent of HelixDB.
+
+use crate::sm0l_dispatch::{self, SmolBehavior, SmolConfig};
+
+/// Which judgment this gate call is making.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GateMode {
+    /// #1106: is the reviewed content relevant to `goal`?
+    Relevance { goal: String },
+    /// #1101: is the reviewed content safe to disclose publicly?
+    Disclosure,
+}
+
+/// Outcome of a gate call.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GateVerdict {
+    /// `RELEVANT` / `SAFE`.
+    Pass,
+    /// `SKIP:<reason>` / `SENSITIVE:<reason>` — a real, parsed verdict from
+    /// the reviewer, not an availability failure.
+    Block { reason: String },
+    /// The reviewer backend was unreachable, or returned something that
+    /// didn't parse as either verdict token. Callers should treat this as
+    /// permissive (proceed) per both issues' fail-open requirement, while
+    /// surfacing `warning` to the operator — this is NOT the same as a
+    /// reviewed-and-safe [`GateVerdict::Pass`], and callers that want to
+    /// distinguish "reviewed" from "review unavailable" can match on this
+    /// variant specifically.
+    Unavailable { warning: String },
+}
+
+impl GateVerdict {
+    /// True for `Pass` and `Unavailable` (fail-open) — false only for a
+    /// genuine, parsed `Block` verdict.
+    pub fn allows_proceeding(&self) -> bool {
+        !matches!(self, GateVerdict::Block { .. })
+    }
+}
+
+/// Ask the reviewer gate to judge `content` under `mode`. Fails open (with
+/// a loud `eprintln!`) on any dispatch or parse failure — never panics,
+/// never silently blocks.
+pub fn gate_verdict(content: &str, mode: &GateMode) -> GateVerdict {
+    let behavior = match mode {
+        GateMode::Relevance { goal } => SmolBehavior::RelevanceGate { goal: goal.clone() },
+        GateMode::Disclosure => SmolBehavior::DisclosureGate,
+    };
+    let config = SmolConfig::default();
+    match sm0l_dispatch::dispatch(&behavior, &config, content, None, 32_000) {
+        Ok(output) => parse_verdict(mode, output.result.as_deref().unwrap_or("")),
+        Err(e) => {
+            let warning = format!("reviewer gate unavailable ({e}) — failing open");
+            eprintln!("⚠️  {warning}");
+            GateVerdict::Unavailable { warning }
+        }
+    }
+}
+
+fn parse_verdict(mode: &GateMode, raw: &str) -> GateVerdict {
+    let trimmed = raw.trim();
+    let (pass_token, block_prefix) = match mode {
+        GateMode::Relevance { .. } => ("RELEVANT", "SKIP:"),
+        GateMode::Disclosure => ("SAFE", "SENSITIVE:"),
+    };
+
+    if trimmed.eq_ignore_ascii_case(pass_token) {
+        return GateVerdict::Pass;
+    }
+    if let Some(reason) = strip_prefix_ci(trimmed, block_prefix) {
+        return GateVerdict::Block { reason: reason.trim().to_string() };
+    }
+
+    let warning = format!("reviewer gate returned unparseable verdict '{trimmed}' — failing open");
+    eprintln!("⚠️  {warning}");
+    GateVerdict::Unavailable { warning }
+}
+
+/// Case-insensitive `str::strip_prefix`, since sm0l models don't always
+/// respect exact-case instructions.
+fn strip_prefix_ci<'a>(s: &'a str, prefix: &str) -> Option<&'a str> {
+    if s.len() >= prefix.len() && s[..prefix.len()].eq_ignore_ascii_case(prefix) {
+        Some(&s[prefix.len()..])
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_verdict_relevance_pass() {
+        assert_eq!(
+            parse_verdict(&GateMode::Relevance { goal: "x".into() }, "RELEVANT"),
+            GateVerdict::Pass
+        );
+        assert_eq!(
+            parse_verdict(&GateMode::Relevance { goal: "x".into() }, "relevant"),
+            GateVerdict::Pass,
+            "reviewer verdicts should be matched case-insensitively"
+        );
+    }
+
+    #[test]
+    fn parse_verdict_relevance_block() {
+        assert_eq!(
+            parse_verdict(&GateMode::Relevance { goal: "x".into() }, "SKIP:not on topic"),
+            GateVerdict::Block { reason: "not on topic".to_string() }
+        );
+    }
+
+    #[test]
+    fn parse_verdict_disclosure_pass_and_block() {
+        assert_eq!(
+            parse_verdict(&GateMode::Disclosure, "SAFE"),
+            GateVerdict::Pass
+        );
+        assert_eq!(
+            parse_verdict(&GateMode::Disclosure, "SENSITIVE:leaks internal hostname"),
+            GateVerdict::Block { reason: "leaks internal hostname".to_string() }
+        );
+    }
+
+    #[test]
+    fn parse_verdict_unparseable_fails_open() {
+        let v = parse_verdict(&GateMode::Relevance { goal: "x".into() }, "uh, maybe?");
+        assert!(matches!(v, GateVerdict::Unavailable { .. }));
+        assert!(v.allows_proceeding());
+    }
+
+    #[test]
+    fn parse_verdict_empty_fails_open() {
+        let v = parse_verdict(&GateMode::Disclosure, "");
+        assert!(matches!(v, GateVerdict::Unavailable { .. }));
+    }
+
+    #[test]
+    fn allows_proceeding_is_false_only_for_block() {
+        assert!(GateVerdict::Pass.allows_proceeding());
+        assert!(GateVerdict::Unavailable { warning: "x".into() }.allows_proceeding());
+        assert!(!GateVerdict::Block { reason: "x".into() }.allows_proceeding());
+    }
+
+    /// `gate_verdict()` itself, with no sm0l endpoint reachable in this
+    /// test environment, must fail open rather than error/panic — this is
+    /// the end-to-end path a real caller (skill activate, lfmf --global)
+    /// exercises when the reviewer backend genuinely isn't running.
+    #[test]
+    fn gate_verdict_fails_open_when_no_endpoint_reachable() {
+        // Best-effort: only meaningful when no B00T_AI_SM0L_BASE / local
+        // sm0l port / HF_TOKEN happens to be configured in the test
+        // environment. If one IS configured, this just exercises the real
+        // dispatch path instead, which is also fine to run.
+        let verdict = gate_verdict("some content", &GateMode::Disclosure);
+        assert!(verdict.allows_proceeding());
+    }
+}

--- a/b00t-c0re-lib/src/sm0l_dispatch.rs
+++ b/b00t-c0re-lib/src/sm0l_dispatch.rs
@@ -39,6 +39,15 @@ pub enum SmolBehavior {
     Summarize,
     /// Binary pass/fail: did this command succeed? Returns "ok" or first failure line.
     CheckOutputOk,
+    /// #1106: the karpathy/deepwiki 3-gate autolearn pattern's Research
+    /// gate — a sm0l reviewer sitting between Orient and Act, judging
+    /// whether a candidate skill/datum is relevant to `goal` BEFORE its
+    /// full body is consumed. Verdict shape: `RELEVANT` | `SKIP:<reason>`.
+    RelevanceGate { goal: String },
+    /// #1101: same gate shape, judging disclosure safety instead of
+    /// relevance — used before a write to a shared/global/public scope.
+    /// Verdict shape: `SAFE` | `SENSITIVE:<reason>`.
+    DisclosureGate,
 }
 
 /// Configuration for sm0l behavior variants that need parameters.
@@ -130,6 +139,32 @@ impl SmolBehavior {
                 "If the input shows a successful outcome with no errors: respond with exactly: ok\n",
                 "Otherwise: respond with the first failure line verbatim. No other output."
             ).to_string(),
+            Self::RelevanceGate { goal } => format!(
+                "You are a relevance reviewer sitting between Orient and Act in an agent's \
+                 OODA loop. You will be shown a goal and a candidate skill/datum's content. \
+                 Decide whether the content is relevant to accomplishing the goal — never \
+                 skip this judgment just because the content was retrieved; retrieval success \
+                 does not imply relevance.\n\
+                 Goal: {goal}\n\n\
+                 Respond with exactly one of:\n\
+                 RELEVANT\n\
+                 SKIP:<short reason>\n\
+                 No other output, no commentary."
+            ),
+            Self::DisclosureGate => concat!(
+                "You are a disclosure-safety reviewer sitting between Orient and Act, judging \
+                 content about to be written to a shared, global, or public-facing scope. \
+                 Decide whether the content reveals specific project- or system-specific \
+                 operational context (credentials, internal hostnames, private infrastructure \
+                 details, account-specific configuration, or similar) that should not be \
+                 disclosed publicly. A generic lesson usable by any agent on any project is \
+                 SAFE; something that only makes sense given this specific operator's private \
+                 setup is SENSITIVE.\n\n\
+                 Respond with exactly one of:\n\
+                 SAFE\n\
+                 SENSITIVE:<short reason>\n\
+                 No other output, no commentary."
+            ).to_string(),
         }
     }
 
@@ -138,6 +173,8 @@ impl SmolBehavior {
             Self::FilterErrors(t) => format!("filter-{}", t.as_str()),
             Self::Summarize => "summarize".to_string(),
             Self::CheckOutputOk => "check-ok".to_string(),
+            Self::RelevanceGate { .. } => "relevance-gate".to_string(),
+            Self::DisclosureGate => "disclosure-gate".to_string(),
         }
     }
 }

--- a/b00t-cli/src/commands/learn.rs
+++ b/b00t-cli/src/commands/learn.rs
@@ -48,6 +48,12 @@ pub struct LearnArgs {
     #[arg(long, help = "Record globally (default: repo)")]
     pub global: bool,
 
+    #[arg(
+        long,
+        help = "#1101: override a global-scope disclosure-gate block (only affects --global)"
+    )]
+    pub force: bool,
+
     // Search lessons (replaces advice)
     #[arg(long, help = "Search lessons: '<query>' or 'list'")]
     pub search: Option<String>,
@@ -93,7 +99,7 @@ pub async fn handle_learn(path: &str, args: LearnArgs) -> Result<()> {
 
     // Record lesson
     if let Some(ref lesson) = args.record {
-        return handle_record(path, topic_val.as_deref(), &lesson, args.global).await;
+        return handle_record(path, topic_val.as_deref(), &lesson, args.global, args.force).await;
     }
 
     // Search lessons
@@ -485,7 +491,7 @@ async fn handle_dwiw(path: &str, topic: &str, mcp_ctx: bool, limit: usize) -> Re
     Ok(())
 }
 
-async fn handle_record(path: &str, topic: Option<&str>, lesson: &str, global: bool) -> Result<()> {
+async fn handle_record(path: &str, topic: Option<&str>, lesson: &str, global: bool, force: bool) -> Result<()> {
     let topic = topic.ok_or_else(|| anyhow::anyhow!("Topic required for recording lesson"))?;
 
     // Parse "<topic>: <body>" format
@@ -545,7 +551,7 @@ async fn handle_record(path: &str, topic: Option<&str>, lesson: &str, global: bo
     println!("Scope: {}", scope);
 
     lfmf_system
-        .record_lesson(topic, lesson)
+        .record_lesson_scoped(topic, lesson, global, force)
         .await
         .context("Failed to record lesson")?;
 

--- a/b00t-cli/src/commands/lfmf.rs
+++ b/b00t-cli/src/commands/lfmf.rs
@@ -185,7 +185,7 @@ pub async fn handle_lfmf_advice(path: &str, tool: &str, query: Option<&str>) -> 
 
 /// Handle LFMF (Lessons From My Failures) recording
 /// Uses shared LFMF system from b00t-c0re-lib for consistency
-pub async fn handle_lfmf(path: &str, tool: &str, lesson: &str, scope: &str) -> Result<()> {
+pub async fn handle_lfmf(path: &str, tool: &str, lesson: &str, scope: &str, force: bool) -> Result<()> {
     // Ensure lessons write into the provided path unless explicitly overridden
     ensure_learn_dir(path)?;
 
@@ -226,8 +226,8 @@ pub async fn handle_lfmf(path: &str, tool: &str, lesson: &str, scope: &str) -> R
         );
     }
 
-    // Scope handling: currently only memoized, extend LfmfSystem for future
     println!("Scope: {}", scope);
+    let is_global = scope == "global";
 
     // Storage format is "topic: body" — topic must stay colon-free or the core
     // parse_lesson re-split corrupts it (URL-derived topics contain ':').
@@ -238,7 +238,7 @@ pub async fn handle_lfmf(path: &str, tool: &str, lesson: &str, scope: &str) -> R
         None => format!("{}: {}", safe_topic, parsed.body),
     };
 
-    if let Err(e) = lfmf_system.record_lesson(tool, &stored).await {
+    if let Err(e) = lfmf_system.record_lesson_scoped(tool, &stored, is_global, force).await {
         log_event(&LfmfTelemetryEvent::now(
             LfmfAction::Record,
             tool,

--- a/b00t-cli/src/commands/skill.rs
+++ b/b00t-cli/src/commands/skill.rs
@@ -60,6 +60,11 @@ pub enum SkillCommands {
         name: String,
         #[clap(long, help = "Prefix with role context from named role datum")]
         role: Option<String>,
+        #[clap(
+            long,
+            help = "#1106: run the sm0l relevance-gate reviewer before emitting the skill body, judged against this goal. Opt-in; fails open (emits the skill anyway) with a warning if the reviewer backend is unreachable."
+        )]
+        gate: Option<String>,
     },
 
     #[clap(about = "Serve skills via HTTP for remote loading by opencode")]
@@ -213,8 +218,34 @@ pub fn handle_skill_command(cmd: &SkillCommands, path: &str) -> Result<()> {
             Ok(())
         }
 
-        SkillCommands::Activate { name, role } => {
+        SkillCommands::Activate { name, role, gate } => {
             let content = resolver.load(name)?;
+
+            // #1106: opt-in relevance gate — the karpathy/deepwiki 3-gate
+            // autolearn pattern's Research gate, applied here for the
+            // first time. Fails open (still emits the skill, loudly
+            // warns) rather than silently no-op'ing or blocking, per the
+            // issue's explicit requirement.
+            if let Some(goal) = gate {
+                use b00t_c0re_lib::reviewer_gate::{GateMode, GateVerdict, gate_verdict};
+                let review_input = format!(
+                    "Skill: {}\nDescription: {}\n\n{}",
+                    content.meta.name, content.meta.description, content.instructions
+                );
+                match gate_verdict(&review_input, &GateMode::Relevance { goal: goal.clone() }) {
+                    GateVerdict::Block { reason } => {
+                        println!(
+                            "🚫 Skill '{}' skipped by relevance gate for goal '{}': {}",
+                            name, goal, reason
+                        );
+                        return Ok(());
+                    }
+                    GateVerdict::Unavailable { warning } => {
+                        eprintln!("⚠️  skill activate --gate: {warning}");
+                    }
+                    GateVerdict::Pass => {}
+                }
+            }
 
             // Optional role context prefix
             if let Some(role_name) = role {

--- a/b00t-cli/src/commands/soul.rs
+++ b/b00t-cli/src/commands/soul.rs
@@ -1644,38 +1644,53 @@ mod shard_tests {
     use super::*;
     use std::sync::Mutex;
 
-    // `with_registry_scoped`/`load_soul_doc_scoped` resolve paths off the
-    // process-global `std::env::current_dir()`, so tests that touch a scoped
-    // shard must not run concurrently with each other or with anything else
-    // that changes cwd.
-    static CWD_LOCK: Mutex<()> = Mutex::new(());
+    // #1102 shard resolution prefers a LOCAL `._b00t_/` (cwd-based) over the
+    // global (HOME-based) root, and falls back to the latter only when cwd
+    // has no `._b00t_/`. Isolating via `std::env::set_current_dir` would
+    // collide with several OTHER, pre-existing test modules in this same
+    // binary that independently mutate cwd with only a module-local mutex
+    // each (see e.g. main.rs's `datum_dir_resolution_tests`, commands::init,
+    // commands::skill — none coordinate with each other, since cwd is
+    // process-global across the whole `cargo test` binary). Isolating via
+    // HOME instead has a much smaller collision surface (only one other
+    // module, b00t-cli's own top-level `tests::TempHome`, touches HOME), so
+    // that's what these tests do, matching that existing precedent.
+    static HOME_LOCK: Mutex<()> = Mutex::new(());
 
-    struct TempCwd {
+    struct TempHome {
         _guard: std::sync::MutexGuard<'static, ()>,
-        old_cwd: std::path::PathBuf,
+        old_home: Option<String>,
         _temp_dir: tempfile::TempDir,
     }
 
-    impl TempCwd {
+    impl TempHome {
         fn new() -> Self {
-            let guard = CWD_LOCK.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
-            let old_cwd = std::env::current_dir().unwrap();
+            let guard = HOME_LOCK.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+            let old_home = std::env::var("HOME").ok();
             let temp_dir = tempfile::tempdir().unwrap();
-            std::fs::create_dir_all(temp_dir.path().join("._b00t_")).unwrap();
-            std::env::set_current_dir(temp_dir.path()).unwrap();
-            Self { _guard: guard, old_cwd, _temp_dir: temp_dir }
+            // SAFETY: guarded by HOME_LOCK above.
+            unsafe {
+                std::env::set_var("HOME", temp_dir.path());
+            }
+            Self { _guard: guard, old_home, _temp_dir: temp_dir }
         }
     }
 
-    impl Drop for TempCwd {
+    impl Drop for TempHome {
         fn drop(&mut self) {
-            let _ = std::env::set_current_dir(&self.old_cwd);
+            // SAFETY: guarded by HOME_LOCK, held until this guard drops.
+            unsafe {
+                match &self.old_home {
+                    Some(h) => std::env::set_var("HOME", h),
+                    None => std::env::remove_var("HOME"),
+                }
+            }
         }
     }
 
     #[test]
     fn scoped_write_is_isolated_from_legacy_and_other_shards() {
-        let _cwd = TempCwd::new();
+        let _home = TempHome::new();
         let agent_foo = SoulScope::new(ShardKind::Agent, "foo");
         let agent_bar = SoulScope::new(ShardKind::Agent, "bar");
 
@@ -1700,7 +1715,7 @@ mod shard_tests {
 
     #[test]
     fn shard_list_export_delete_round_trip() {
-        let _cwd = TempCwd::new();
+        let _home = TempHome::new();
         let scope = SoulScope::new(ShardKind::Tool, "grok");
         df_table_create("lessons", &["note:text".to_string()], Some(scope.clone())).unwrap();
 

--- a/b00t-cli/src/integration_tests.rs
+++ b/b00t-cli/src/integration_tests.rs
@@ -112,14 +112,14 @@ mod integration_tests {
         let lesson1 = "First: lesson learned.";
         let lesson2 = "Second: lesson learned.";
         // First call: should create file
-        let result1 = handle_lfmf(temp_path, tool, lesson1, "repo");
+        let result1 = handle_lfmf(temp_path, tool, lesson1, "repo", false);
         assert!(result1.await.is_ok());
         let file_path = temp_dir.path().join("learn").join(format!("{}.md", tool));
         assert!(file_path.exists());
         let content1 = std::fs::read_to_string(&file_path).unwrap();
         assert!(content1.contains(lesson1));
         // Second call: should append
-        let result2 = handle_lfmf(temp_path, tool, lesson2, "repo");
+        let result2 = handle_lfmf(temp_path, tool, lesson2, "repo", false);
         assert!(result2.await.is_ok());
         let content2 = std::fs::read_to_string(&file_path).unwrap();
         assert!(content2.contains(lesson1));

--- a/b00t-cli/src/main.rs
+++ b/b00t-cli/src/main.rs
@@ -245,6 +245,11 @@ Advice mode (consult prior lessons before fixing):
             help = "Record lesson globally (mutually exclusive with --repo)"
         )]
         global: bool,
+        #[clap(
+            long,
+            help = "#1101: override a global-scope disclosure-gate block (only affects --global)"
+        )]
+        force: bool,
     },
     #[clap(
         about = "Get advice for syntax errors and debugging",
@@ -2887,6 +2892,7 @@ async fn main() {
             lesson,
             repo: _,
             global,
+            force,
         }) => {
             // Validate required fields
             let tool = match tool.as_ref().or(positional_tool.as_ref()) {
@@ -2933,7 +2939,7 @@ async fn main() {
                     std::process::exit(1);
                 }
             } else if let Err(e) =
-                b00t_cli::commands::lfmf::handle_lfmf(&cli.path, &tool, &lesson, scope).await
+                b00t_cli::commands::lfmf::handle_lfmf(&cli.path, &tool, &lesson, scope, *force).await
             {
                 eprintln!("Error: {}", e);
                 std::process::exit(1);


### PR DESCRIPTION
## Summary
- Implements the karpathy/deepwiki 3-gate autolearn pattern's long-documented-but-unbuilt Research gate (#1106), and extends the same mechanism to a disclosure-safety judgment for global-scope writes (#1101) — one shared dispatch path, two verdict vocabularies.
- New \`b00t-c0re-lib/src/reviewer_gate.rs\`: \`gate_verdict(content, mode)\` where \`GateMode::Relevance{goal}\` → \`RELEVANT|SKIP:<reason>\`, \`GateMode::Disclosure\` → \`SAFE|SENSITIVE:<reason>\`. Fails **open** (loud warning, never silent, never a panic) on dispatch failure or an unparseable response, per both issues' explicit requirement.
- Dispatch substrate is \`sm0l_dispatch\` (two new \`SmolBehavior\` variants), **not** \`grok ask\` — \`_b00t_/learn/grok.md\` already documents that \`grok ask\`'s default irontology backend fails *silently* without a live HelixDB server, a poor foundation for a gate whose whole job is to fail *loudly*. \`sm0l_dispatch::SmolEndpoint::discover()\` already implements the fail-open priority chain both issues want and is fully independent of HelixDB.
- \`skill activate --gate "<goal>"\`: new opt-in flag, byte-identical behavior when absent (zero regression risk).
- \`lfmf --global\` / \`learn --record --global\`: the \`--global\` flag's scope was previously **cosmetic** (printed but never affected storage or triggered any check) — now threaded for real into a new \`LfmfSystem::record_lesson_scoped\`, which runs a cheap \`b00t-bouncer\` wordlist first-pass filter then the sm0l disclosure gate before writing. A blocked write requires a new \`--force\` flag to override; every attempt is logged via the existing \`events::write_event\` trail either way.

Part of the b00t-backlog-triage phased plan: #1102 (merged) → #1104 (merged) → **#1106+#1101 (this PR)**.

## Test plan
- [x] \`cargo build -p b00t-cli\` — clean.
- [x] \`cargo test -p b00t-cli --lib\` → 1605 passed, 0 failed, 6 ignored.
- [x] \`cargo test -p b00t-c0re-lib --lib\` → 530 passed, 0 failed, 6 ignored, including 7 new \`reviewer_gate\` tests (verdict parsing for both modes, case-insensitive matching, fail-open on unparseable/empty response, and an end-to-end \`gate_verdict()\` call confirming fail-open with no sm0l endpoint reachable).