### PR TITLE
chore: remove dangling app4dog symlinks

### DIFF
--- a/_b00t_/app4dog--workspace--dev.stack.tomllm
+++ b/_b00t_/app4dog--workspace--dev.stack.tomllm
@@ -1,1 +1,0 @@
-/home/brianh/promptexecution/app4dog/._b00t_/dev.stack.tomllm

--- a/_b00t_/app4dog--workspace--ml.stack.tomllm
+++ b/_b00t_/app4dog--workspace--ml.stack.tomllm
@@ -1,1 +1,0 @@
-/home/brianh/promptexecution/app4dog/._b00t_/ml.stack.tomllm

--- a/_b00t_/app4dog--workspace--workspace.justfile.tomllm
+++ b/_b00t_/app4dog--workspace--workspace.justfile.tomllm
@@ -1,1 +1,0 @@
-/home/brianh/promptexecution/app4dog/._b00t_/workspace.justfile.tomllm

--- a/_b00t_/app4dog--workspace--workspace.project.tomllm
+++ b/_b00t_/app4dog--workspace--workspace.project.tomllm
@@ -1,1 +1,0 @@
-/home/brianh/promptexecution/app4dog/._b00t_/workspace.project.tomllm

--- a/_b00t_/app4dog--workspace.project._b00t_.tomllm
+++ b/_b00t_/app4dog--workspace.project._b00t_.tomllm
@@ -1,1 +1,0 @@
-/home/brianh/promptexecution/app4dog/app4dog--workspace.project._b00t_.tomllm


### PR DESCRIPTION
Refs: b00t task #36. These five _b00t_/app4dog--workspace*.tomllm symlinks point at /home/brianh/promptexecution/app4dog/._b00t_/*.tomllm, which never existed on any tracked machine (confirmed via git log --all in the app4dog repo). Deleting rather than 'fixing' since there is no real content to point at.