### PR TITLE
ci: wire sccache into the workspace check+test job (#1226)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,8 +105,24 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
+      # 🤓 sccache: proven 7-10x locally (merged PR #662, `_b00t_/sccache.cli.toml`
+      # datum) but never wired into CI until now — #1226 documents this job still
+      # taking 30-45+ min even with Swatinem/rust-cache below warm, because that
+      # action only caches the whole `target/`+registry as one artifact keyed on
+      # Cargo.lock; any changed crate (or its dependents) still recompiles from
+      # scratch. sccache caches per-compilation-unit instead, so it helps on
+      # exactly the runs rust-cache's coarser cache can't — a partial-change PR.
+      # The two are complementary, not redundant; keep both.
+      - name: Set up sccache
+        uses: mozilla-actions/sccache-action@v0.0.11
+
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
+
+      - name: Enable sccache as the rustc wrapper
+        run: |
+          echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
+          echo "SCCACHE_GHA_ENABLED=true" >> "$GITHUB_ENV"
 
       # 🤓 Native/CLI deps some tests shell out to. Not present on a bare
       #    ubuntu-latest runner — without these the tests fail with "command
@@ -163,3 +179,9 @@ jobs:
       #    tested code. All non-doctest tests still run for real. See #919.
       - name: cargo test --workspace --locked --all-targets
         run: cargo test --workspace --locked --all-targets
+
+      # 🤓 Hit-rate evidence for #1226: printed even on failure (this run's own
+      # cache behavior is worth seeing whether or not the tests above passed).
+      - name: sccache stats
+        if: always()
+        run: sccache --show-stats


### PR DESCRIPTION
## Summary

Contributes to #1226 (CI's `cargo check + test (workspace)` job taking 30-45+ min). sccache is already proven in this repo — merged PR #662 measured `cargo build -p b00t-admin`: 10min+ → 1m20s (~7-10x) — but it was only ever wired via each developer's own `~/.cargo/config.toml`, never into CI.

- Adds `mozilla-actions/sccache-action@v0.0.11` (the official action) right after the Rust toolchain install — handles installing the `sccache` binary and wiring GitHub Actions' own cache backend (`SCCACHE_GHA_ENABLED=true`), so this needs **no new cloud infra or credentials**.
- Sets `RUSTC_WRAPPER=sccache` for the rest of the job.
- Kept alongside `Swatinem/rust-cache@v2`, not instead of it — they're complementary. rust-cache caches the whole `target/`+registry as one artifact keyed on `Cargo.lock`; any changed crate (or its dependents) still fully recompiles even with that cache warm. sccache caches per-compilation-unit, so it helps on exactly the runs rust-cache's coarser cache can't (a partial-change PR touching one or two crates in this ~30-crate workspace).
- Adds a final `sccache --show-stats` step (`if: always()`, so it prints even if tests fail) as hit-rate evidence for #1226's own tracking — the ask there was partly to root-cause *why* it's slow, and real cache-hit numbers from a live run are direct evidence rather than more speculation.

## Test plan

- [x] YAML validated (`python3 -c "import yaml; yaml.safe_load(...)"`) — no syntax errors
- [ ] First run on this PR will be cold (sccache's GHA-backed cache starts empty) — the real signal is the **second** run after this merges (or a second push to this PR), where `sccache --show-stats` should show real hits. Flagging this explicitly rather than claiming this PR alone proves the speedup — that requires a second data point this PR's own first CI run can't provide.

Relates to #1226 (does not close it — that issue's other asks, e.g. per-crate CI scoping, are separate follow-up work, not addressed here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)