### PR TITLE
k8s: reviewable b00t-historian deployment artifact for vultr1 (#1229)

### DIFF
--- a/Dockerfile.historian
+++ b/Dockerfile.historian
@@ -1,0 +1,199 @@
+# syntax=docker/dockerfile:latest
+#
+# Minimal image for `b00t-historian` (b00t-cli/src/bin/b00t-historian.rs) —
+# the durable NATS-subject scribe / souls+vultr+hive-mesh coordinator this
+# builds for issue #1229 (deploy on vultr1's k0s as the hive-wide channel
+# coordinator). Mirrors Dockerfile.b00t-cli's cargo-chef structure (same
+# workspace COPY set — b00t-historian lives inside the b00t-cli crate, which
+# path-depends on most of the workspace, same as the b00t-cli/b00t-mcp
+# binaries that Dockerfile builds) but only installs the one binary this
+# workload needs and skips the _b00t_ datum/config resources layer — this
+# binary reads no datum files at runtime, unlike b00t-cli's own subcommands.
+
+# ================================
+# Stage 0: Just binary from fork
+# ================================
+FROM ghcr.io/elasticdotventures/just:latest AS just-binary
+
+# ================================
+# Stage 1: cargo-chef base (dependency cache layer)
+# ================================
+# See Dockerfile.b00t-cli for why each of these apt packages is required
+# (openssl-sys building from source, b00t-embed's native transitive deps).
+FROM rust:1.96-slim AS chef
+RUN apt-get update && apt-get install -y \
+    pkg-config \
+    libssl-dev \
+    ca-certificates \
+    python3 \
+    python3-dev \
+    perl \
+    build-essential \
+    && rm -rf /var/lib/apt/lists/*
+RUN cargo install cargo-chef --locked
+WORKDIR /build
+
+# ================================
+# Stage 2: planner — compute the dependency recipe
+# ================================
+FROM chef AS planner
+
+# Same workspace COPY set as Dockerfile.b00t-cli: this is a virtual
+# workspace, cargo-chef needs every listed member's Cargo.toml present, and
+# b00t-cli (which owns the b00t-historian binary) transitively depends on
+# most of these. Keep this list in sync with Dockerfile.b00t-cli's if the
+# workspace membership changes.
+COPY Cargo.toml Cargo.lock ./
+COPY _b00t_/ ./_b00t_/
+COPY b00t-admin/ ./b00t-admin/
+COPY b00t-ast/ ./b00t-ast/
+COPY b00t-azure-cp/ ./b00t-azure-cp/
+COPY b00t-bouncer/ ./b00t-bouncer/
+COPY b00t-cad/ ./b00t-cad/
+COPY b00t-candle-serve/ ./b00t-candle-serve/
+COPY b00t-cli/ ./b00t-cli/
+COPY b00t-council/ ./b00t-council/
+COPY b00t-crate/ ./b00t-crate/
+COPY b00t-c0re-a2a/ ./b00t-c0re-a2a/
+COPY b00t-c0re-gov/ ./b00t-c0re-gov/
+COPY b00t-c0re-hierarchy/ ./b00t-c0re-hierarchy/
+COPY b00t-c0re-lib/ ./b00t-c0re-lib/
+COPY b00t-c0re-npm/ ./b00t-c0re-npm/
+COPY b00t-c0re-role/ ./b00t-c0re-role/
+COPY b00t-datum-core/ ./b00t-datum-core/
+COPY b00t-embed/ ./b00t-embed/
+COPY b00t-embed-serve/ ./b00t-embed-serve/
+COPY b00t-forge-kv/ ./b00t-forge-kv/
+COPY b00t-grok/ ./b00t-grok/
+COPY b00t-ipc/ ./b00t-ipc/
+COPY b00t-isometric-wasm/ ./b00t-isometric-wasm/
+COPY b00t-l3dg3rr-viz/ ./b00t-l3dg3rr-viz/
+COPY b00t-lib-chat/ ./b00t-lib-chat/
+COPY b00t-lsp/ ./b00t-lsp/
+COPY b00t-mcp/ ./b00t-mcp/
+COPY b00t-mcp-npm/ ./b00t-mcp-npm/
+COPY b00t-mermaid-wasm/ ./b00t-mermaid-wasm/
+COPY b00t-pyverse/ ./b00t-pyverse/
+COPY b00t-stt-serve/ ./b00t-stt-serve/
+COPY b00t-ui-wasm/ ./b00t-ui-wasm/
+COPY b00t-zellij/ ./b00t-zellij/
+COPY blessed/ ./blessed/
+COPY capability-forge/ ./capability-forge/
+COPY k0mmand3r/ ./k0mmand3r/
+COPY pm2-tasker/ ./pm2-tasker/
+COPY vendor/embed-anything-b00t/rust/ ./vendor/embed-anything-b00t/rust/
+COPY vendor/embed-anything-b00t/processors/ ./vendor/embed-anything-b00t/processors/
+COPY vendor/irontology-mcp/ ./vendor/irontology-mcp/
+COPY vendor/ledgrrr/crates/b00t-reflect-types/ ./vendor/ledgrrr/crates/b00t-reflect-types/
+COPY vendor/runpod-sdk/ ./vendor/runpod-sdk/
+COPY vendor/tomllm/ ./vendor/tomllm/
+
+RUN cargo chef prepare --recipe-path recipe.json
+
+# ================================
+# Stage 3: builder — cook deps (cacheable), then build the one binary
+# ================================
+FROM chef AS rust-builder
+
+COPY --from=just-binary /usr/local/bin/just /usr/local/bin/just
+
+COPY --from=planner /build/recipe.json recipe.json
+
+# See Dockerfile.b00t-cli for why these two vendored path-deps are copied in
+# before `cook` (excluded from [workspace] members, so chef drops them from
+# the reconstructed dummy tree otherwise).
+COPY vendor/embed-anything-b00t/rust/ ./vendor/embed-anything-b00t/rust/
+COPY vendor/embed-anything-b00t/processors/ ./vendor/embed-anything-b00t/processors/
+COPY vendor/runpod-sdk/ ./vendor/runpod-sdk/
+
+RUN cargo chef cook --release --recipe-path recipe.json
+
+# Real sources — same set as the planner stage.
+COPY Cargo.toml Cargo.lock ./
+COPY _b00t_/ ./_b00t_/
+COPY b00t-admin/ ./b00t-admin/
+COPY b00t-ast/ ./b00t-ast/
+COPY b00t-azure-cp/ ./b00t-azure-cp/
+COPY b00t-bouncer/ ./b00t-bouncer/
+COPY b00t-cad/ ./b00t-cad/
+COPY b00t-candle-serve/ ./b00t-candle-serve/
+COPY b00t-cli/ ./b00t-cli/
+COPY b00t-council/ ./b00t-council/
+COPY b00t-crate/ ./b00t-crate/
+COPY b00t-c0re-a2a/ ./b00t-c0re-a2a/
+COPY b00t-c0re-gov/ ./b00t-c0re-gov/
+COPY b00t-c0re-hierarchy/ ./b00t-c0re-hierarchy/
+COPY b00t-c0re-lib/ ./b00t-c0re-lib/
+COPY b00t-c0re-npm/ ./b00t-c0re-npm/
+COPY b00t-c0re-role/ ./b00t-c0re-role/
+COPY b00t-datum-core/ ./b00t-datum-core/
+COPY b00t-embed/ ./b00t-embed/
+COPY b00t-embed-serve/ ./b00t-embed-serve/
+COPY b00t-forge-kv/ ./b00t-forge-kv/
+COPY b00t-grok/ ./b00t-grok/
+COPY b00t-ipc/ ./b00t-ipc/
+COPY b00t-isometric-wasm/ ./b00t-isometric-wasm/
+COPY b00t-l3dg3rr-viz/ ./b00t-l3dg3rr-viz/
+COPY b00t-lib-chat/ ./b00t-lib-chat/
+COPY b00t-lsp/ ./b00t-lsp/
+COPY b00t-mcp/ ./b00t-mcp/
+COPY b00t-mcp-npm/ ./b00t-mcp-npm/
+COPY b00t-mermaid-wasm/ ./b00t-mermaid-wasm/
+COPY b00t-pyverse/ ./b00t-pyverse/
+COPY b00t-stt-serve/ ./b00t-stt-serve/
+COPY b00t-ui-wasm/ ./b00t-ui-wasm/
+COPY b00t-zellij/ ./b00t-zellij/
+COPY blessed/ ./blessed/
+COPY capability-forge/ ./capability-forge/
+COPY k0mmand3r/ ./k0mmand3r/
+COPY pm2-tasker/ ./pm2-tasker/
+COPY vendor/embed-anything-b00t/rust/ ./vendor/embed-anything-b00t/rust/
+COPY vendor/embed-anything-b00t/processors/ ./vendor/embed-anything-b00t/processors/
+COPY vendor/irontology-mcp/ ./vendor/irontology-mcp/
+COPY vendor/ledgrrr/crates/b00t-reflect-types/ ./vendor/ledgrrr/crates/b00t-reflect-types/
+COPY vendor/runpod-sdk/ ./vendor/runpod-sdk/
+COPY vendor/tomllm/ ./vendor/tomllm/
+
+# Only the one binary this image ships — not b00t-cli's full `cargo install
+# --path b00t-cli` (that would also build the `b00t` / `b00t-cli` multi-call
+# entrypoint binary this image has no use for).
+RUN cargo install --path b00t-cli --bin b00t-historian --locked --root /usr/local
+
+RUN /usr/local/bin/b00t-historian --version
+
+# ================================
+# Stage 4: runtime — small Debian base, just the binary + certs
+# ================================
+FROM debian:12-slim AS runtime
+
+ARG BUILD_VERSION=0.0.1
+ARG BUILD_COMMIT=unknown
+ARG BUILD_DATE
+
+LABEL org.opencontainers.image.source=https://github.com/elasticdotventures/_b00t_
+LABEL org.opencontainers.image.description="b00t-historian: durable NATS-subject scribe / hive-wide souls+vultr+mesh coordinator (issue #1229)"
+LABEL org.opencontainers.image.licenses=MIT
+LABEL org.opencontainers.image.version=${BUILD_VERSION}
+LABEL org.opencontainers.image.revision=${BUILD_COMMIT}
+LABEL org.opencontainers.image.created=${BUILD_DATE}
+
+RUN apt-get update && apt-get install -y \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/* \
+    && useradd --system --create-home --home-dir /home/historian --shell /usr/sbin/nologin historian
+
+COPY --from=rust-builder /usr/local/bin/b00t-historian /usr/local/bin/b00t-historian
+
+# `run` is a foreground loop by design (see the binary's own doc comment —
+# "run this under nohup/pm2/systemd for real persistence"); under k0s that
+# job is the Deployment's restartPolicy, not an init system in the image.
+# --log-dir (durable NDJSON archive) is expected to be a mounted volume —
+# see k8s/historian/deployment.yaml, not baked into this image.
+RUN mkdir -p /data/historian && chown historian:historian /data/historian
+USER historian
+WORKDIR /home/historian
+
+ENV NATS_URL=nats://127.0.0.1:4222
+
+ENTRYPOINT ["/usr/local/bin/b00t-historian"]
+CMD ["run", "--subject", "b00t.hive.mesh.>", "--log-dir", "/data/historian/sessions"]

--- a/k8s/historian/README.md
+++ b/k8s/historian/README.md
@@ -1,0 +1,129 @@
+# b00t-historian on vultr1's k0s — issue #1229
+
+**Status: NOT APPLIED.** Everything in this directory (and
+`../../Dockerfile.historian`) is a reviewable artifact only. No image has
+been built or pushed, and nothing has been copied to vultr1 or applied to
+its k0s cluster. This session had no SSH/kubectl access to
+`vultr1.v.promptexecution.com` (confirmed: SSH times out from the box this
+was written on) — actual deployment is a manual follow-up step for whoever
+has access to that box.
+
+## What this is
+
+Deploys `b00t-historian` (`b00t-cli/src/bin/b00t-historian.rs`) as a real
+k0s workload on vultr1/b00t-node, per #1229: a hive-wide coordinator
+subscribed to `souls.>`, `vultr.>` (both always-on, hardcoded in the
+binary's `run` loop) and `b00t.hive.mesh.>` (this deployment's one
+`--subject` flag), instead of the current interim Python port on `sm3lly`
+scoped only to `hive.sm3ll-fung1.>`.
+
+Files:
+- `../../Dockerfile.historian` — multi-stage build (cargo-chef, mirrors
+  `Dockerfile.b00t-cli`'s structure) producing a small `debian:12-slim`
+  runtime image with just the `b00t-historian` binary.
+- `configmap.yaml` — `NATS_URL` + `HISTORIAN_SUBJECT`, no secrets.
+- `secret.example.yaml` — template for `NATS_USER`/`NATS_PASSWORD`. Copy to
+  `secret.yaml`, fill in, **do not commit `secret.yaml`**. Read the
+  comments in that file first — there's a known gap in the hub NATS
+  server's current auth config that this alone doesn't fix (see below).
+- `deployment.yaml` — single-replica Deployment, `hostNetwork: true`,
+  hostPath volume for the durable NDJSON archive.
+
+## Known gap: hub NATS auth (read before filling in secret.yaml)
+
+The k0s-managed NATS server on vultr1 (`pods/nats/nats-pod-configured.yaml`
+in the infrastructure repo, applied via `podman play kube`, client port
+hostPort 4222) runs in **operator/JWT multi-tenant auth mode**
+(`auth_required: true`), with only the `SYS` account preloaded in its
+resolver. `b00t-historian` only supports plain `--nats-user`/
+`--nats-password` auth (no NKey/creds-file path) — pointed at that server
+as configured today, it will hit `-ERR 'Authorization Violation'`, the
+exact same documented gap that already blocks the `dapr` `nats-pubsub`
+component on this box (see the `b00t-daprd.service` comment in
+`terraform/b00t/cloud-init/b00t-node.yaml.tpl`).
+
+This PR ships the env-var plumbing (`NATS_USER`/`NATS_PASSWORD` ->
+container, `optional: true` so the Deployment still starts and fails
+visibly in `kubectl logs` rather than crash-looping on a missing Secret)
+so that once a real plain-auth account/user is minted for this workload —
+e.g. the same way `capability-forge` mints accounts, or a plain-auth
+account added to `nats-pod-configured.yaml` — wiring it up is just filling
+in `secret.yaml`. Actually minting that credential and confirming the
+connection works is explicitly **not** done by this PR; it's part of the
+manual apply step below.
+
+## Build + push (not yet done)
+
+```sh
+# from the repo root
+docker build -f Dockerfile.historian \
+  --build-arg BUILD_VERSION=$(sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml | head -n1) \
+  --build-arg BUILD_COMMIT=$(git rev-parse --short HEAD) \
+  --build-arg BUILD_DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ) \
+  -t ghcr.io/elasticdotventures/b00t-historian:latest .
+
+docker push ghcr.io/elasticdotventures/b00t-historian:latest
+```
+
+(Mirrors `.github/workflows/b00t-cli-container.yml`'s existing
+`ghcr.io`/`elasticdotventures` convention. Wiring an equivalent CI workflow
+for this image — auto-build on `Dockerfile.historian`/`b00t-cli/**`
+changes — is a reasonable follow-on but out of scope here: a working,
+reviewable manifest is the priority for this PR, not a new CI pipeline.)
+
+This session did not attempt this build: no scoped need to spend the CI
+minutes/registry push from here, and `docker build`/`podman build` were not
+run in this session at all — see "Validation performed" below for what was
+actually verified instead.
+
+## Deploy to vultr1 (manual — requires access this session does not have)
+
+1. Build + push the image (above), from a machine/CI runner that has
+   registry credentials.
+2. `scp` or otherwise copy this directory's manifests to vultr1:
+   ```sh
+   scp k8s/historian/{configmap.yaml,deployment.yaml,secret.yaml} \
+     vultr1.v.promptexecution.com:/tmp/historian/
+   ```
+   (`secret.yaml` here is the filled-in copy of `secret.example.yaml` —
+   never the example itself with placeholder values, and never committed.)
+3. On vultr1, place them under k0s's static-manifest directory so the
+   stack controller applies **and keeps re-applying** them (the same
+   reason the OIDC discovery RBAC binding lives under
+   `/var/lib/k0s/manifests/oidc-discovery-rbac/` instead of being
+   `kubectl apply`'d once — confirmed by live testing that a one-off apply
+   does not survive a k0s restart on this box):
+   ```sh
+   sudo mkdir -p /var/lib/k0s/manifests/historian
+   sudo cp /tmp/historian/*.yaml /var/lib/k0s/manifests/historian/
+   ```
+4. Confirm the Secret's NATS account actually works before expecting
+   traffic — see "Known gap" above. Watch `kubectl -n default logs deploy/
+   b00t-historian` for `Authorization Violation` vs. a clean subscribe.
+5. Verify against #1229's acceptance criteria (discovery query from a
+   different LAN leaf gets a reply from a peer connected via a different
+   leaf, etc.) — this is real end-to-end verification that requires the
+   live mesh and is explicitly not something this PR alone can confirm.
+
+## Validation performed in this PR (no cluster/build access)
+
+- `python3 -c "import yaml; list(yaml.safe_load_all(open(f)))"` for every
+  `.yaml` file in this directory — see the PR description for the exact
+  output.
+- `podman build -f Dockerfile.historian --target planner .` (`podman`
+  available in this session, `docker` on this box is itself a podman
+  shim) — ran successfully: every `COPY` path resolves and
+  `cargo chef prepare --recipe-path recipe.json` completed without error,
+  confirming the workspace-member COPY list is correct and the workspace
+  resolves cleanly through cargo-chef's dependency planner.
+- The remaining stages (`cargo chef cook --release` compiling ~40 workspace
+  crates including native deps like `embed_anything`/`esaxx-rs`, then
+  `cargo install --path b00t-cli --bin b00t-historian`) were **not** run —
+  a full release compile of this workspace is minutes-to-tens-of-minutes
+  even with warm caches, and this session had no registry to push a
+  resulting image to anyway. Those stages were checked by eye against the
+  already-working `Dockerfile.b00t-cli` instead (same base images, same
+  COPY set, same `cargo install --path b00t-cli` entry point — only the
+  `--bin` target and final runtime stage differ). Run the full
+  `docker build`/`podman build` (no `--target`) as part of the manual
+  deploy step above before trusting the image boots.

--- a/k8s/historian/configmap.yaml
+++ b/k8s/historian/configmap.yaml
@@ -1,0 +1,29 @@
+# Non-secret configuration for b00t-historian on vultr1's k0s cluster.
+#
+# NOT YET APPLIED — see README.md in this directory. This is a REVIEWABLE
+# artifact for issue #1229; deploying it to vultr1 is a manual follow-up
+# for whoever has kubectl/SSH access to that box.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: historian-config
+  namespace: default
+  labels:
+    app: b00t-historian
+data:
+  # The k0s-managed nats-server pod (pods/nats/nats-pod-configured.yaml in
+  # the infrastructure repo) publishes its client port as hostPort 4222 —
+  # every other same-host service on vultr1 (capability-forge, the dapr
+  # nats-pubsub component) reaches it via nats://127.0.0.1:4222, and this
+  # Deployment does the same via hostNetwork: true (see deployment.yaml) so
+  # it needs no Service/DNS/node-IP lookup to reach it.
+  NATS_URL: "nats://127.0.0.1:4222"
+
+  # b00t-historian's `run` subcommand always additionally subscribes to
+  # souls.> (cross-host agent activity) and vultr.> (provisioning delegate
+  # request/reply) regardless of this flag — see b00t-cli/src/bin/
+  # b00t-historian.rs. This is the ONE extra wildcard --subject issue #1229
+  # asks for: the hive-mesh gossip channel (feat/1229-historian-mailbox
+  # lands the actual b00t.hive.mesh.* publishers/consumers this scribes;
+  # this deployment doesn't block on that landing first).
+  HISTORIAN_SUBJECT: "b00t.hive.mesh.>"

--- a/k8s/historian/deployment.yaml
+++ b/k8s/historian/deployment.yaml
@@ -1,0 +1,121 @@
+# b00t-historian — hive-wide channel coordinator (issue #1229).
+#
+# NOT YET APPLIED. This directory is meant to be copied to vultr1's
+# /var/lib/k0s/manifests/historian/ so k0s's own stack controller applies
+# AND continuously re-applies it — the same pattern already used for OIDC
+# discovery RBAC (terraform/b00t/cloud-init/b00t-node.yaml.tpl in the
+# infrastructure repo: a one-off `kubectl apply` does NOT survive a k0s
+# restart on that box, static manifests under /var/lib/k0s/manifests/<name>/
+# do). See README.md in this directory for the full copy/apply procedure —
+# it is a manual step for whoever has access to vultr1, not done by this PR.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: b00t-historian
+  namespace: default
+  labels:
+    app: b00t-historian
+spec:
+  # Single replica by design — this is a coordinator process with its own
+  # local NDJSON archive and in-memory souls table, not a horizontally
+  # scaled service. Two replicas would double-subscribe the same wildcard
+  # subjects and split the souls_activity table across two untied
+  # processes.
+  replicas: 1
+  strategy:
+    # Never run two at once even mid-rollout: on a single-node cluster a
+    # RollingUpdate briefly wants both the old and new pod scheduled, and
+    # both would bind the same hostNetwork port set / hostPath log dir.
+    type: Recreate
+  selector:
+    matchLabels:
+      app: b00t-historian
+  template:
+    metadata:
+      labels:
+        app: b00t-historian
+    spec:
+      # Reaches the k0s-managed NATS pod's client port via
+      # nats://127.0.0.1:4222 exactly like every other same-host b00t
+      # service does (capability-forge, the dapr nats-pubsub component —
+      # see terraform/b00t/cloud-init/b00t-node.yaml.tpl in the
+      # infrastructure repo) rather than via a k8s Service: the NATS server
+      # itself runs as a plain podman pod (`podman play kube`), not inside
+      # this k0s cluster, so there is no in-cluster Service/DNS name for it
+      # to resolve — only the host's own loopback + hostPort binding.
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      containers:
+        - name: historian
+          # Placeholder tag — build and push per README.md before this is
+          # ever actually applied; nothing here has been built or pushed by
+          # this PR.
+          image: ghcr.io/elasticdotventures/b00t-historian:latest
+          imagePullPolicy: IfNotPresent
+          args:
+            - "run"
+            - "--id"
+            - "historian-vultr1"
+            - "--subject"
+            - "$(HISTORIAN_SUBJECT)"
+            - "--log-dir"
+            - "/data/historian/sessions"
+            - "--basename"
+            - "hive-mesh-hub"
+          env:
+            - name: HISTORIAN_SUBJECT
+              valueFrom:
+                configMapKeyRef:
+                  name: historian-config
+                  key: HISTORIAN_SUBJECT
+            - name: NATS_URL
+              valueFrom:
+                configMapKeyRef:
+                  name: historian-config
+                  key: NATS_URL
+            # NATS_USER / NATS_PASSWORD come from historian-nats-credentials
+            # (see secret.example.yaml — NOT committed with real values).
+            # optional: true so this Deployment still starts (and the
+            # container's own retry/backoff makes the actual NATS
+            # connection failure visible in `kubectl logs`) even before
+            # that Secret exists or before the server-side auth gap
+            # documented in secret.example.yaml is closed.
+            - name: NATS_USER
+              valueFrom:
+                secretKeyRef:
+                  name: historian-nats-credentials
+                  key: NATS_USER
+                  optional: true
+            - name: NATS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: historian-nats-credentials
+                  key: NATS_PASSWORD
+                  optional: true
+          volumeMounts:
+            - name: historian-data
+              mountPath: /data/historian
+          resources:
+            requests:
+              cpu: 25m
+              memory: 32Mi
+            limits:
+              cpu: 250m
+              memory: 128Mi
+          securityContext:
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+      volumes:
+        # hostPath, not emptyDir: the whole point of this binary is a
+        # *durable* NDJSON archive (see its own doc comment) that survives
+        # pod restarts/rescheduling — matches the single-node cluster's
+        # existing pattern of local host-backed storage for the NATS pod's
+        # own data (pods/nats/nats-pod-configured.yaml's emptyDir mounts,
+        # which live under the podman-managed side of the same host).
+        # There is no dynamic PV provisioner on this single-node k0s
+        # cluster today, so hostPath is the pragmatic choice, not a
+        # long-term one.
+        - name: historian-data
+          hostPath:
+            path: /var/lib/b00t/historian
+            type: DirectoryOrCreate

--- a/k8s/historian/secret.example.yaml
+++ b/k8s/historian/secret.example.yaml
@@ -1,0 +1,36 @@
+# TEMPLATE — copy to secret.yaml, fill in real values, and do NOT commit
+# secret.yaml (it is covered by .gitignore's existing *.local/*secret*
+# patterns; double-check before `git add` regardless).
+#
+# 🤓 KNOWN GAP, confirmed by reading the infra repo's own cloud-init
+# template (terraform/b00t/cloud-init/b00t-node.yaml.tpl, the
+# b00t-daprd.service comment): the k0s-managed NATS server at 4222 runs in
+# operator/JWT multi-tenant auth mode (`auth_required: true`) with only the
+# SYS account preloaded in its resolver — a client presenting plain
+# user/password (which is all b00t-historian's --nats-user/--nats-password
+# flags support; it has no NKey/creds-file auth path) gets
+# `-ERR 'Authorization Violation'`, the exact same documented gap that
+# already blocks daprd's nats-pubsub component on this box today.
+#
+# This Secret's plumbing (NATS_USER/NATS_PASSWORD env -> the container) is
+# still worth shipping now: b00t-historian reads these two env vars
+# natively (see connect_options() in b00t-cli/src/bin/b00t-historian.rs),
+# so once a real account+user exists on that NATS server for this
+# workload — minted the same way capability-forge mints accounts today, or
+# via a plain-auth account added to nats-pod-configured.yaml — populating
+# this Secret is the only change needed. Until then, leave both values
+# empty (or omit the Secret+envFrom in deployment.yaml entirely): the
+# server-side gap means historian will hit the same Authorization Violation
+# daprd does, and this is called out as a manual follow-up, not something
+# this PR resolves.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: historian-nats-credentials
+  namespace: default
+  labels:
+    app: b00t-historian
+type: Opaque
+stringData:
+  NATS_USER: "CHANGEME"
+  NATS_PASSWORD: "CHANGEME"


### PR DESCRIPTION
## Summary

Produces a **reviewable artifact** for #1229 (deploy `b00t-historian` on vultr1's k0s as the hive-wide channel coordinator) — a Dockerfile + k0s static-manifest directory. Does **not** close #1229 alone: acceptance criteria there require live end-to-end verification against the real mesh (cross-LAN discovery replies, mailbox delivery, etc.) that only actual deployment can prove.

**⚠️ Nothing in this PR has been applied anywhere.** This session had no SSH/kubectl access to `vultr1.v.promptexecution.com` (confirmed: SSH times out from the box this was written on). Actual deployment — building the image, pushing it, copying manifests to vultr1, placing them under k0s's static-manifest dir, and verifying the connection — is a manual follow-up for whoever has access to that box. See `k8s/historian/README.md` for the exact procedure.

## What's here

- **`Dockerfile.historian`** — multi-stage cargo-chef build (mirrors the existing `Dockerfile.b00t-cli`'s structure/base images/COPY set) producing a small `debian:12-slim` runtime image containing only the `b00t-historian` binary.
- **`k8s/historian/deployment.yaml`** — single-replica Deployment, `hostNetwork: true` (the hub's NATS server is a plain podman pod outside this k0s cluster, reached the same way every other same-host b00t service reaches it: `nats://127.0.0.1:4222`), `--subject 'b00t.hive.mesh.>'` (the binary's `run` loop already always subscribes `souls.>` and `vultr.>` on top of this), hostPath volume for the durable NDJSON archive.
- **`k8s/historian/configmap.yaml`** — non-secret `NATS_URL`/`HISTORIAN_SUBJECT`.
- **`k8s/historian/secret.example.yaml`** — template for `NATS_USER`/`NATS_PASSWORD` (not committed with real values) — **documents a known gap**: the hub NATS server runs in operator/JWT auth mode with only the `SYS` account preloaded, so plain user/password auth (all `b00t-historian` supports) will hit `Authorization Violation` until a real account/user is minted — the exact same documented gap already blocking `dapr`'s `nats-pubsub` component on that box today (see `b00t-daprd.service` in the infrastructure repo's cloud-init template). This PR ships the plumbing; closing that gap is a follow-up.
- **`k8s/historian/README.md`** — build+push, copy-to-vultr1, and apply procedure, plus the not-yet-applied status and the auth gap above.

Follows the same static-manifest-under-`/var/lib/k0s/manifests/<name>/` pattern already established for OIDC discovery RBAC on vultr1 (a one-off `kubectl apply` does not survive a k0s restart on that box; k0s's own stack controller re-applying from that directory does).

## Validation performed (no cluster/build access)

- Every `.yaml` in `k8s/historian/` parses cleanly: `python3 -c "import yaml; list(yaml.safe_load_all(open(f)))"`.
- `podman build -f Dockerfile.historian --target planner .` completed successfully — confirms every `COPY` path resolves and `cargo chef prepare` succeeds against the full workspace-member list.
- The remaining build stages (full release compile, ~40 workspace crates including native deps) were **not** run — too heavy for this session and there's no registry to push a resulting image to from here anyway. Checked by eye against the already-working `Dockerfile.b00t-cli` instead (same base images/COPY set/`cargo install --path b00t-cli` entry point, only the `--bin` target and runtime stage differ).

## Explicitly not done here

- Not applied to vultr1 (no access this session — see above).
- Not minting the NATS account/user needed to actually close the auth gap in `secret.example.yaml`.
- Not plumbing the #1104 agent-scoped-token identity substrate through this Deployment — noted in the issue itself as a reasonable follow-on, not required for a first working Deployment.
- Not adding a CI workflow to auto-build/push this image — a manual `docker build`/`push` per the README is enough for a first pass; wiring `.github/workflows/` is a follow-on.

Refs #1229.