### PR TITLE
feat: reviewable ARC GPU CI runner manifest (workflow_dispatch PoC, refs #1226)

### DIFF
--- a/.github/workflows/ci-gpu.yml
+++ b/.github/workflows/ci-gpu.yml
@@ -1,0 +1,61 @@
+# CI: GPU self-hosted runner proof of concept.
+#
+# ⚠️ Deliberately `workflow_dispatch` ONLY. Do NOT add `pull_request` or
+# `push` triggers here without reading k8s/gh-runner-gpu/README.md's
+# "Security tradeoff" section first — this job runs on a self-hosted runner
+# with real filesystem/GPU/network access to this box's k0s cluster, not a
+# disposable GH-hosted VM. This repo is public; widening the trigger scope
+# to fork PRs is a separate, explicit decision for a human to make (see the
+# follow-on issue linked from the PR that introduced this file), not
+# something to fall into by copy-pasting `ci.yml`'s triggers.
+#
+# Also note: this workflow cannot actually run anywhere yet. It targets a
+# runner scale set (`gpu-sm3lly`, matched via `runs-on:` below) that has not
+# been installed — see k8s/gh-runner-gpu/README.md for the missing
+# prerequisite (a GitHub token secret) and the still-unrun `helm install`.
+name: CI (GPU self-hosted PoC)
+
+on:
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: "Why run this manually (shows up in the run log)"
+        required: false
+        default: "manual GPU runner smoke test"
+
+concurrency:
+  group: ci-gpu-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  gpu-smoke-test:
+    name: GPU smoke test (nvidia-smi + scoped cargo test)
+    # Must exactly match `runnerScaleSetName` in k8s/gh-runner-gpu/values.yaml.
+    # ARC's gha-runner-scale-set matches jobs to a scale set by this string,
+    # not by a `[self-hosted, ...]` label array (that's the older
+    # actions-runner-controller RunnerDeployment model).
+    runs-on: gpu-sm3lly
+    timeout-minutes: 20
+    steps:
+      - name: Prove the GPU is actually visible to this job
+        run: nvidia-smi
+
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Show warm cache state (proves NVMe cache persistence across runs)
+        run: |
+          echo "CARGO_HOME=$CARGO_HOME"
+          du -sh "$CARGO_HOME" 2>/dev/null || echo "(cache empty — first run on this node)"
+
+      # Scoped to two small, fast-building workspace crates on purpose — NOT
+      # `--workspace` (that's issue #1226's whole problem, and a much
+      # bigger, separate proof-of-concept step once this one is confirmed
+      # working end-to-end).
+      - name: cargo test (scoped crates)
+        run: cargo test --locked -p b00t-datum-core -p k0mmand3r --all-targets

--- a/k8s/gh-runner-gpu/README.md
+++ b/k8s/gh-runner-gpu/README.md
@@ -1,0 +1,112 @@
+# gh-runner-gpu — GPU self-hosted CI runner (reviewable artifact, NOT applied)
+
+Offers sm3llsl1k3s0ld3r's GPU (and warm local NVMe caches) to GitHub Actions
+CI for `elasticdotventures/_b00t_`, via the actions-runner-controller (ARC)
+install already running on this box's k0s cluster. Directly targets the
+CI-slowness pain in [#1226](https://github.com/elasticdotventures/_b00t_/issues/1226)
+(30–45 min `cargo test --workspace`) as a complement to the sccache work in
+PR #1227 — this gives CI a warm `$CARGO_HOME` and a GPU instead of a cold
+`ubuntu-latest` runner every time.
+
+**Nothing here has been applied or registered.** No secret has been
+created, no `helm install` has been run, no workflow has been wired into
+the normal PR trigger path. This directory + `.github/workflows/ci-gpu.yml`
+are for review first.
+
+## What already exists on the cluster (verified, not assumed)
+
+- ARC controller is installed and healthy: `arc-gha-rs-controller` deployment
+  in namespace `arc-systems`, chart `gha-runner-scale-set-controller-0.14.2`
+  (`helm list -n arc-systems`). It runs with `--auto-scaling-runner-set-only`
+  and a `ClusterRoleBinding`, so it can manage an `AutoscalingRunnerSet` in
+  any namespace — it does not need to live in `arc-systems`.
+- **Zero** `AutoscalingRunnerSet` resources exist anywhere yet
+  (`k0s kubectl get autoscalingrunnersets -A` → no resources found). The
+  controller is ready; nothing is registered against it.
+- GPU is fully wired: node label `nvidia.com/gpu.present=true`,
+  `nvidia.com/gpu: 3` allocatable (time-sliced RTX 3090),
+  `nvidia-device-plugin-daemonset` running in `kube-system`, and a
+  pre-existing `RuntimeClass nvidia` (handler: `nvidia`) that
+  `values.yaml` in this directory uses.
+- The node has no taints, so no `tolerations` block is required (unlike the
+  stale manifest below, which tolerates `node-role.kubernetes.io/control-plane`
+  for the same reason — same single-node cluster).
+
+## What does NOT exist yet (the actual blocker)
+
+**A GitHub token secret.** `k0s kubectl get secrets -n arc-systems` shows
+only the Helm release secret itself — nothing containing a PAT or GitHub
+App installation token. `values.yaml` references a secret named
+`gh-runner-gpu-creds` in a new `arc-runners` namespace
+(`githubConfigSecret: gh-runner-gpu-creds`) that does not exist. Create it
+before installing anything:
+
+```bash
+k0s kubectl create namespace arc-runners
+k0s kubectl create secret generic gh-runner-gpu-creds \
+  --namespace arc-runners \
+  --from-literal=github_token=<PAT-or-GitHub-App-installation-token>
+```
+
+See `secret.example.yaml` for the exact shape and token-scope notes. This
+step is intentionally NOT automated by this PR — minting a token is a human
+decision (which credential, whose account, PAT vs. GitHub App).
+
+Once the secret exists, the install itself would be:
+
+```bash
+helm install gh-runner-gpu \
+  oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set \
+  --version 0.14.2 \
+  --namespace arc-runners \
+  -f k8s/gh-runner-gpu/values.yaml
+```
+
+That command is documented, not run, by this PR.
+
+## Security tradeoff: why the companion workflow is `workflow_dispatch`-only
+
+`elasticdotventures/_b00t_` is a **public** repo (`gh repo view` →
+`"visibility":"PUBLIC"`). Self-hosted runners on a public repo that accepts
+`pull_request`-triggered CI are a well-known attack vector: a malicious
+fork PR's workflow run gets arbitrary code execution on the runner's actual
+host — here, that host is this physical box with a GPU and root-adjacent
+k0s access, not a disposable GH-hosted VM.
+
+Checked PR history (`gh pr list --repo elasticdotventures/_b00t_ --state all
+--limit 20 --json author`): every one of the last 20 PRs was authored by
+`elasticdotventures` — there is no external-contributor traffic today, so
+practical risk is currently low. **That can change at any time on a public
+repo without any config change on our side**, so this PR does not rely on
+"no one else sends PRs" as a control.
+
+Mitigation implemented: `.github/workflows/ci-gpu.yml` is gated on
+`workflow_dispatch` only — it is **not** added to the existing
+`on: pull_request` / `on: push` triggers in `.github/workflows/ci.yml`.
+A workflow_dispatch-only job cannot be triggered by a PR (fork or
+same-repo) at all; it requires a repo collaborator to manually run it from
+the Actions tab or `gh workflow run`. This is the conservative default —
+a human should explicitly decide before this ever fires automatically on
+PR traffic, and before its trigger scope is widened. See the follow-on
+issue referenced from the PR description for that decision.
+
+## What NOT to copy: the stale prior art
+
+`k8s.🚢/gh-runner/deployment.yaml` is an existing, unrelated, non-ARC
+manifest — a raw `Deployment` running `myoung34/github-runner:latest`
+against a *different* repo (`PromptExecution/rust-docs-mcp-b00t`), requiring
+a human to manually refresh its registration token every hour
+(`gh api -X POST .../actions/runners/registration-token`). It is left
+untouched by this PR. It is exactly the manual-token-refresh problem ARC
+exists to solve — do not extend or resurrect that pattern for this repo.
+
+## Files here
+
+| File | Purpose |
+|---|---|
+| `values.yaml` | Helm values for the `gha-runner-scale-set` chart (v0.14.2, matching the installed controller). GPU request/limit, NVMe-backed `CARGO_HOME`/work-dir hostPath cache, `runtimeClassName: nvidia`, `maxRunners: 1`. |
+| `secret.example.yaml` | Documents the `gh-runner-gpu-creds` secret shape and the imperative `kubectl create secret` command. Not meant to be applied literally — see the CHANGEME placeholder. |
+| `README.md` | This file. |
+
+Companion workflow: `.github/workflows/ci-gpu.yml` (repo root, not in this
+directory — GitHub only reads workflows from `.github/workflows/`).

--- a/k8s/gh-runner-gpu/secret.example.yaml
+++ b/k8s/gh-runner-gpu/secret.example.yaml
@@ -1,0 +1,41 @@
+# TEMPLATE — do NOT `kubectl apply` this file as-is, and do NOT commit a
+# copy with a real token filled in (double-check `git status`/`git diff`
+# before staging if you ever do fill this in locally).
+#
+# This is the MISSING PREREQUISITE referenced in ../../k8s/gh-runner-gpu/README.md:
+# nothing in this directory can be installed until this secret exists in the
+# `arc-runners` namespace, because values.yaml's `githubConfigSecret:
+# gh-runner-gpu-creds` references it by name (chart's "Variation C: pre-defined
+# secret" — see `helm show values oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set --version 0.14.2`).
+#
+# PREFERRED: don't write this file's contents at all — create the secret
+# imperatively so the token never touches disk as YAML:
+#
+#   k0s kubectl create namespace arc-runners
+#   k0s kubectl create secret generic gh-runner-gpu-creds \
+#     --namespace arc-runners \
+#     --from-literal=github_token=<PAT-or-GitHub-App-installation-token>
+#
+# Token requirements (classic PAT, repo-scoped):
+#   - scope: repo  (ARC needs to manage self-hosted runner registration for
+#     elasticdotventures/_b00t_)
+#   - a fine-grained PAT or GitHub App installation token works too — see
+#     the chart's own values.yaml comments for the github_app_id /
+#     github_app_installation_id / github_app_private_key alternative,
+#     which is the better long-term answer (no human-owned PAT to rotate)
+#     but is a separate, bigger setup step than this PoC needs.
+#
+# The declarative form below is equivalent and is what `kubectl create
+# secret --dry-run=client -o yaml` would emit — kept here only as
+# documentation of the exact shape ARC expects, CHANGEME is never a valid
+# value:
+apiVersion: v1
+kind: Secret
+metadata:
+  name: gh-runner-gpu-creds
+  namespace: arc-runners
+  labels:
+    app.kubernetes.io/part-of: gh-runner-gpu
+type: Opaque
+stringData:
+  github_token: "CHANGEME"

--- a/k8s/gh-runner-gpu/values.yaml
+++ b/k8s/gh-runner-gpu/values.yaml
@@ -1,0 +1,108 @@
+# Helm values for the `gha-runner-scale-set` chart, targeting the
+# actions-runner-controller (ARC) install already running on sm3llsl1k3s0ld3r's
+# k0s cluster.
+#
+# ⚠️ NOT APPLIED. This is a reviewable artifact only — see ../../k8s/gh-runner-gpu/README.md
+# for the missing prerequisite (a GitHub token secret) and the exact install command.
+#
+# Chart:    oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set
+# Version:  0.14.2  (must match the already-installed arc-gha-rs-controller image tag —
+#                     confirmed via `helm list -n arc-systems`: chart gha-runner-scale-set-controller-0.14.2)
+# Release namespace: arc-runners  (deliberately NOT arc-systems, which is reserved for the
+#                     controller itself — each runner scale set gets its own namespace per
+#                     upstream convention: https://docs.github.com/en/actions/tutorials/use-actions-runner-controller/deploy-runner-scale-sets)
+# Install command (DO NOT RUN without the secret from README.md in place first):
+#   helm install gh-runner-gpu \
+#     oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set \
+#     --version 0.14.2 \
+#     --namespace arc-runners --create-namespace \
+#     -f k8s/gh-runner-gpu/values.yaml
+
+# Repo-scoped (not org-wide) on purpose: this is a single-repo proof of concept,
+# smallest possible blast radius for a first GPU runner.
+githubConfigUrl: "https://github.com/elasticdotventures/_b00t_"
+
+# References a PRE-EXISTING k8s secret (Variation C in the chart's own values.yaml
+# comments) — never inline a token here. See README.md for how to create it.
+githubConfigSecret: gh-runner-gpu-creds
+
+# The exact string a workflow's `runs-on:` must match. ARC's new
+# gha-runner-scale-set architecture matches jobs to scale sets by this name,
+# not by a `[self-hosted, ...]` label array (that's the older/classic
+# actions-runner-controller RunnerDeployment model, and also how the stale
+# k8s.🚢/gh-runner/deployment.yaml manifest — a raw Deployment running
+# myoung34/github-runner, requiring manual hourly token refresh — does it;
+# do not copy that pattern, ARC exists specifically to avoid it).
+runnerScaleSetName: gpu-sm3lly
+
+# Single physical GPU box, time-sliced to 3 (see nvidia-device-plugin-config
+# in this cluster) — cap at 1 concurrent runner pod for this PoC so we don't
+# have multiple CI jobs fighting over the same warm build cache directories
+# below at once. Raise once real concurrency behavior has been observed.
+minRunners: 0
+maxRunners: 1
+
+# containerMode intentionally left unset (chart default): job steps run
+# directly inside the single `runner` container below, the same way a
+# GitHub-hosted runner works. Both alternate modes (`dind`, `kubernetes`)
+# run each job step in its own freshly-scheduled sub-pod/sub-container,
+# which would need separate `nvidia.com/gpu` resource requests and
+# `runtimeClassName` plumbed onto THOSE pod specs too — solvable, but
+# unnecessary complexity for a first proof of concept. Revisit only if a
+# workflow needs per-step container isolation.
+# containerMode:
+#   type: "kubernetes"
+
+template:
+  spec:
+    # Only one node in this cluster has a GPU (and only one node exists,
+    # period) — explicit nodeSelector documents the requirement rather than
+    # relying on that being incidentally true.
+    nodeSelector:
+      nvidia.com/gpu.present: "true"
+
+    # Matches the pre-existing `nvidia` RuntimeClass on this cluster
+    # (`k0s kubectl get runtimeclass nvidia` — handler: nvidia), the same
+    # mechanism nvidia-device-plugin-daemonset relies on elsewhere in this
+    # cluster to inject driver libraries/devices into a requesting pod.
+    runtimeClassName: nvidia
+
+    containers:
+      - name: runner
+        image: ghcr.io/actions/actions-runner:latest
+        command: ["/home/runner/run.sh"]
+        env:
+          # Warm build cache on local NVMe instead of a cold ubuntu-latest
+          # runner's empty $HOME every run — this is the other half of
+          # #1226's fix alongside sccache (see PR #1227): CI stops paying
+          # full dependency-download + full-recompile cost on every job.
+          - name: CARGO_HOME
+            value: /cache/cargo-home
+        resources:
+          requests:
+            cpu: "2"
+            memory: 4Gi
+            nvidia.com/gpu: 1
+          limits:
+            cpu: "4"
+            memory: 8Gi
+            nvidia.com/gpu: 1
+        volumeMounts:
+          - name: cargo-cache
+            mountPath: /cache/cargo-home
+          - name: runner-work
+            mountPath: /home/runner/_work
+
+    volumes:
+      # hostPath, not emptyDir: the whole point is a cache that survives
+      # across ephemeral runner pods. Path lives on this box's NVMe-backed
+      # root volume (`df -h /` → /dev/mapper/ubuntu--vg-ubuntu--lv, 7.2T).
+      # DirectoryOrCreate so first apply doesn't fail on a missing dir.
+      - name: cargo-cache
+        hostPath:
+          path: /var/lib/gh-runner-gpu/cargo-home
+          type: DirectoryOrCreate
+      - name: runner-work
+        hostPath:
+          path: /var/lib/gh-runner-gpu/work
+          type: DirectoryOrCreate


### PR DESCRIPTION
## Summary

Reviewable manifest (not applied) for offering sm3llsl1k3s0ld3r's GPU and warm local NVMe caches to GitHub Actions CI, via the actions-runner-controller (ARC) already installed on this box's k0s cluster. Directly targets #1226's CI-slowness pain (30-45+ min `cargo test --workspace` on cold `ubuntu-latest`) — a higher-leverage fix for that issue than the nextest swap (#1228) was, and complements the sccache work already landed in #1227 by also giving CI a warm dependency cache and a GPU instead of a cold, disposable VM.

**Nothing in this PR is applied or registered.** No k8s secret has been created, no `helm install` has been run, and the AutoscalingRunnerSet does not exist on the cluster yet.

## Verified state before writing this (see commands in each file's comments)

- ARC controller is already installed and healthy (`arc-gha-rs-controller`, chart `gha-runner-scale-set-controller-0.14.2`, namespace `arc-systems`) but **zero** `AutoscalingRunnerSet` resources exist anywhere — the controller is ready, nothing is registered.
- GPU is fully wired on the cluster: `nvidia.com/gpu.present=true` node label, `nvidia.com/gpu: 3` allocatable (time-sliced RTX 3090), `nvidia-device-plugin-daemonset` running, and a pre-existing `RuntimeClass nvidia` this manifest uses.
- **No GitHub token secret exists** in `arc-systems` (or anywhere) for runner registration — this is the actual blocker to making this real, documented explicitly rather than fabricated/guessed at. See `k8s/gh-runner-gpu/README.md`.
- `k8s.🚢/gh-runner/deployment.yaml` is pre-existing, unrelated, non-ARC prior art (raw Deployment, different repo, manual hourly token refresh) — left untouched; it's the exact manual-token-refresh problem ARC exists to avoid, not something to extend.

## What's here

- `k8s/gh-runner-gpu/values.yaml` — Helm values for the `gha-runner-scale-set` chart (pinned to `0.14.2`, matching the installed controller), with `nvidia.com/gpu: 1` request/limit, `runtimeClassName: nvidia`, and an NVMe-backed hostPath `$CARGO_HOME` + work-dir cache that survives across ephemeral runner pods.
- `k8s/gh-runner-gpu/secret.example.yaml` — documents the missing `gh-runner-gpu-creds` secret's exact shape and the imperative `kubectl create secret` command (no real token committed).
- `k8s/gh-runner-gpu/README.md` — the missing-prerequisite writeup, plus the security tradeoff below, written out for a human to make the actual call.
- `.github/workflows/ci-gpu.yml` — a new, separate workflow: `nvidia-smi` + `cargo test` scoped to two small crates (`b00t-datum-core`, `k0mmand3r`), **not** the full workspace (that's a bigger follow-on once this is proven).

## Security tradeoff — please read before merging

`elasticdotventures/_b00t_` is a **public** repo. Self-hosted runners on a public repo's PR-triggered CI are a known attack vector: a malicious fork PR's workflow run gets arbitrary code execution on the runner's actual host — here, a real box with GPU + k0s access, not a disposable GH-hosted VM.

Checked the last 20 PRs (`gh pr list --state all --limit 20 --json author`): all authored by `elasticdotventures`, so no external-PR traffic exists today. That can change at any time on a public repo without any config change here, so **`ci-gpu.yml` is gated on `workflow_dispatch` only** — it is not added to `ci.yml`'s `pull_request`/`push` triggers, and cannot fire from a PR (fork or same-repo) at all. Widening this is a separate, deliberate decision — tracked in the follow-on issue below rather than baked into this PR.

## Follow-on

- Closes/relates to #1226 (does not close it alone — the GPU runner isn't registered yet, so it can't move the needle on real CI times until someone completes the prerequisite steps in `k8s/gh-runner-gpu/README.md`).
- Follow-on issue for "wire this into the main CI workflow for real" (the bigger, separate trigger-scope decision): #1233.

## Explicitly NOT done in this PR

- No secret created, no `helm install` run, no `AutoscalingRunnerSet` applied.
- No change to `.github/workflows/ci.yml`'s existing triggers.
- No touching of the stale `k8s.🚢/gh-runner/deployment.yaml`.