### PR TITLE
feat: reviewable bare-metal/systemd GPU CI runner manifest (refs #1226, #1233)

### DIFF
--- a/.github/workflows/ci-gpu-systemd.yml
+++ b/.github/workflows/ci-gpu-systemd.yml
@@ -1,0 +1,62 @@
+# CI: bare-metal / systemd GPU self-hosted runner proof of concept.
+#
+# ⚠️ Deliberately `workflow_dispatch` ONLY. Do NOT add `pull_request` or
+# `push` triggers here without reading the trigger-scope decision tracked in
+# issue #1233 first — this job runs directly on this host's OS (no
+# container/VM boundary) with real filesystem/GPU/network access, not a
+# disposable GH-hosted VM. This repo is public; widening the trigger scope
+# to fork PRs is a separate, explicit decision for a human to make (already
+# tracked in #1233, shared with the companion k8s/ARC runner in PR #1232),
+# not something to fall into by copy-pasting `ci.yml`'s triggers.
+#
+# This is the systemd/bare-metal alternative to PR #1232's k8s/ARC-based
+# runner (`.github/workflows/ci-gpu.yml`, `k8s/gh-runner-gpu/`). See
+# systemd/b00t-gpu-runner/README.md for when to prefer one over the other.
+#
+# Also note: this workflow cannot actually run anywhere yet. It targets
+# runner labels (`self-hosted, gpu, sm3lly`) that no registered runner
+# currently carries — see systemd/b00t-gpu-runner/README.md for the missing
+# prerequisite (a runner registration token) and the still-unrun
+# `setup-runner.sh` + `svc.sh install`/`start`.
+name: CI (GPU self-hosted systemd PoC)
+
+on:
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: "Why run this manually (shows up in the run log)"
+        required: false
+        default: "manual bare-metal GPU runner smoke test"
+
+concurrency:
+  group: ci-gpu-systemd-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  gpu-smoke-test:
+    name: GPU smoke test (nvidia-smi + scoped cargo test)
+    # Must match the labels a runner registers with via
+    # systemd/b00t-gpu-runner/environment.example's GH_RUNNER_LABELS.
+    # Unlike ARC's gha-runner-scale-set (matched by scale-set name in
+    # ci-gpu.yml), a plain systemd-installed actions-runner is matched by
+    # this ordinary `[self-hosted, ...]` label array.
+    runs-on: [self-hosted, gpu, sm3lly]
+    timeout-minutes: 20
+    steps:
+      - name: Prove the GPU is actually visible to this job
+        run: nvidia-smi
+
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      # Scoped to two small, fast-building workspace crates on purpose — NOT
+      # `--workspace` (that's issue #1226's whole problem, and a much
+      # bigger, separate proof-of-concept step once this one is confirmed
+      # working end-to-end).
+      - name: cargo test (scoped crates)
+        run: cargo test --locked -p b00t-datum-core -p k0mmand3r --all-targets

--- a/systemd/b00t-gpu-runner/README.md
+++ b/systemd/b00t-gpu-runner/README.md
@@ -1,0 +1,131 @@
+# b00t-gpu-runner (bare-metal / systemd GitHub Actions runner)
+
+Reviewable manifest (not applied/installed/registered) for offering this host's
+NVIDIA RTX 3090 to GitHub Actions CI as a **bare-metal, systemd-managed**
+self-hosted runner — using GitHub's own officially-supported `actions-runner`
+release + `config.sh` / `svc.sh` flow, the same way GitHub's docs describe
+installing a self-hosted runner "as a service."
+
+This is the **alternative** to PR #1232's k8s/ARC-based approach
+(`k8s/gh-runner-gpu/`), not a replacement for it. Both target #1226 (CI
+slowness — 30-45+ min `cargo test --workspace` on cold `ubuntu-latest`); pick
+whichever fits how this box is meant to be used.
+
+## systemd (this PR) vs. k8s/ARC (#1232) — which to use
+
+| | **systemd bare-metal (here)** | **k8s/ARC (#1232)** |
+|---|---|---|
+| GPU access | Direct — host driver/CUDA, no device plugin, no time-slicing config | Shared across pods via NVIDIA device plugin + time-slicing (`nvidia.com/gpu: 3` allocatable on one physical 3090) |
+| Concurrency | One job at a time (whole GPU, whole box, for the job's duration) | Multiple concurrent runner pods can share the GPU |
+| Scaling | Fixed: exactly the runners you `svc.sh install` | Autoscaling `AutoscalingRunnerSet` — runner pods come and go with queued jobs |
+| Moving parts | GitHub's own `actions-runner` tarball + systemd unit it generates | ARC controller, Helm chart, RuntimeClass, device plugin, k0s |
+| Isolation between jobs | None beyond whatever the job itself cleans up — same host, same systemd user, run to run | Each job gets a fresh ephemeral pod |
+| Best for | Simple, single-job-at-a-time GPU CI (e.g. one `cargo test` run at a time) where the whole box is fine to dedicate for a few minutes | Multiple concurrent workflows/PRs wanting GPU access, or wanting the runner pool to scale to zero when idle |
+| Prerequisite blocking both | No GitHub token exists yet for either — see below | Same — see `k8s/gh-runner-gpu/README.md` |
+
+Use **this** (systemd) if you want the simplest possible path to "a GPU job
+runs on this box" and don't need more than one GPU CI job running at once.
+Use **#1232's k8s/ARC** approach if you want the runner pool to scale, or to
+share the GPU across concurrent jobs.
+
+Nothing prevents running both — they're independent registrations (different
+runner names/labels) against the same repo.
+
+## Prerequisites
+
+**Nothing in this directory has been applied.** No runner is installed, no
+systemd unit exists yet, and no registration token/secret has been created.
+This is the same missing-prerequisite state as #1232.
+
+You need one of:
+
+- A **runner registration token** (short-lived, ~1 hour TTL, generated
+  specifically for registering a new self-hosted runner) — obtained via
+  either:
+  - `gh api repos/OWNER/REPO/actions/runners/registration-token -X POST --jq .token`, or
+  - the repo's **Settings → Actions → Runners → New self-hosted runner** page
+    (GitHub generates and displays the `config.sh` command with the token
+    pre-filled).
+
+This is **not** a personal access token (PAT). A registration token is a
+narrow-purpose, short-lived credential minted only for the runner-registration
+handshake (`config.sh` exchanges it once during setup for the runner's own
+longer-lived credentials, which it then stores locally and refreshes itself —
+you don't manage those). A PAT is a general, longer-lived credential scoped to
+a user's API access and is the wrong kind of token for this flow; GitHub's own
+runner registration UI issues (and expects) the short-lived token, not a PAT.
+
+## Setup flow (official `actions-runner` pattern)
+
+This mirrors exactly what GitHub's own "Add self-hosted runner" instructions
+generate — `setup-runner.sh` in this directory automates these same steps:
+
+1. Download the pinned `actions-runner-linux-x64-<version>.tar.gz` release
+   asset from `actions/runner` and verify its sha256.
+2. Extract it to an install directory (e.g. `/opt/gh-runner-gpu`).
+3. Run the runner's own `./config.sh --url <repo-url> --token <reg-token> \
+   --name <runner-name> --labels <labels> --unattended`.
+4. Run the runner's own `sudo ./svc.sh install` — **this is what actually
+   creates the systemd unit** (typically
+   `/etc/systemd/system/actions.runner.<org>-<repo>.<name>.service`), running
+   as a dedicated non-root service user. We deliberately do not hand-write a
+   unit file here: `svc.sh` is the officially-supported installer, and a
+   hand-written unit risks drifting from what a future runner self-update
+   expects (working directory layout, env file location, service user, etc).
+5. Run `sudo ./svc.sh start` to start the service.
+
+See `setup-runner.sh` for the scripted version of steps 1-3 (config only) and
+`environment.example` for the env vars it reads. Steps 4-5 (`svc.sh
+install`/`start`) require root and are intentionally left as explicit manual
+commands — see the script's final printed instructions.
+
+## GPU access
+
+No device plugin, no `RuntimeClass`, no time-slicing config is needed here —
+none of that machinery exists to share one physical GPU across many
+scheduled pods. This runner is a normal OS process under systemd; it inherits
+this host's NVIDIA driver and CUDA install directly, and the GPU is entirely
+available to whatever job that runner process executes, for the duration of
+that job. Confirm the driver is visible before registering anything real:
+
+```
+nvidia-smi --query-gpu=name,driver_version --format=csv,noheader
+```
+
+(Verified present on this host during this session: `NVIDIA GeForce RTX 3090`,
+driver `580.167.08`.)
+
+## Security posture (same as #1232)
+
+`elasticdotventures/_b00t_` is a **public** repo. A self-hosted runner that
+fires on `pull_request` (including from forks) is a known attack vector — the
+workflow gets arbitrary code execution directly on this host, not a
+disposable GH-hosted VM. This is exactly the same risk #1232 already
+identified and the same tradeoff — do not re-litigate it in a second issue.
+
+Accordingly, the companion workflow in this PR
+(`.github/workflows/ci-gpu-systemd.yml`) is **`workflow_dispatch`-only**: it
+is not added to `ci.yml`'s `pull_request`/`push` triggers, and cannot fire
+from a PR (fork or same-repo).
+
+The decision on if/when to widen trigger scope for *either* the systemd or
+the k8s/ARC GPU runner is already tracked centrally in **#1233** — see that
+issue for the options under consideration. This PR does not open a second,
+duplicate follow-on issue.
+
+## What this PR does NOT do
+
+- Does not download, extract, or run anything from `setup-runner.sh`.
+- Does not create a registration token or any secret.
+- Does not run `config.sh` or `svc.sh install`/`start`.
+- Does not create or touch any systemd unit file.
+- Does not change `.github/workflows/ci.yml`'s existing triggers.
+- Does not replace or conflict with #1232's k8s/ARC manifest.
+
+## References
+
+- Relates to #1226 (CI slowness).
+- Trigger-scope decision tracked in #1233 (shared with #1232).
+- Companion PR: #1232 (k8s/ARC alternative — read that PR's README for the
+  scaling/shared-GPU approach).
+- Upstream: https://github.com/actions/runner (official release + `config.sh`/`svc.sh`).

--- a/systemd/b00t-gpu-runner/environment.example
+++ b/systemd/b00t-gpu-runner/environment.example
@@ -1,0 +1,43 @@
+# b00t-gpu-runner environment file (example)
+#
+# Copy to `environment` (untracked, gitignored by whoever deploys this) and
+# fill in real values before sourcing it into setup-runner.sh:
+#
+#   cp environment.example environment
+#   $EDITOR environment
+#   set -a; source environment; set +a
+#   ./setup-runner.sh
+#
+# Do NOT commit a filled-in copy of this file — GH_RUNNER_TOKEN is a
+# credential (even though it's short-lived).
+
+# Repo (or org) URL this runner registers against.
+GH_RUNNER_URL="https://github.com/elasticdotventures/_b00t_"
+
+# Short-lived runner REGISTRATION token — NOT a personal access token (PAT).
+#
+# Registration tokens expire in about an hour and are single-purpose: they
+# only authorize the one-time config.sh handshake that registers a new
+# runner, after which the runner stores its own longer-lived credentials
+# locally and refreshes them itself. Generate one right before running
+# setup-runner.sh (it will be stale by the time you get around to using it
+# later):
+#
+#   gh api repos/elasticdotventures/_b00t_/actions/runners/registration-token \
+#     -X POST --jq .token
+#
+# ...or via the GitHub UI: Settings -> Actions -> Runners -> New self-hosted
+# runner (the config.sh command it shows you has the token pre-filled).
+GH_RUNNER_TOKEN="__REPLACE_WITH_SHORT_LIVED_REGISTRATION_TOKEN__"
+
+# Comma-separated labels used to target this runner from workflow `runs-on:`.
+# `gpu` and `sm3lly` (this host's name) let workflows select it specifically;
+# `self-hosted` is added implicitly by GitHub but listed here for clarity.
+GH_RUNNER_LABELS="self-hosted,gpu,sm3lly"
+
+# Name this runner registers as (shown in Settings -> Actions -> Runners).
+GH_RUNNER_NAME="sm3lly-gpu-systemd"
+
+# Optional: install/work directory (defaults to /opt/gh-runner-gpu in
+# setup-runner.sh if unset).
+# GH_RUNNER_HOME="/opt/gh-runner-gpu"

--- a/systemd/b00t-gpu-runner/setup-runner.sh
+++ b/systemd/b00t-gpu-runner/setup-runner.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# setup-runner.sh — reviewable installer for a bare-metal GitHub Actions
+# self-hosted runner, using the official `actions/runner` release tarball's
+# own config.sh/svc.sh flow.
+#
+# THIS IS A REVIEWABLE ARTIFACT. It is not executed as part of this PR.
+# It has not been run against this host. No runner has been installed,
+# configured, or registered by producing this file.
+#
+# What this script does when run by a human, in order:
+#   1. Downloads a pinned actions-runner-linux-x64 release tarball and
+#      verifies its sha256 checksum.
+#   2. Extracts it to $GH_RUNNER_HOME (default /opt/gh-runner-gpu), unless
+#      already extracted there.
+#   3. Runs the runner's own ./config.sh to register it with GitHub, unless
+#      it looks already configured (.runner file present).
+#   4. Prints (but does NOT run) the sudo ./svc.sh install/start commands
+#      needed to actually create and start the systemd unit — those require
+#      root and are left as an explicit final step for a human.
+#
+# It deliberately does NOT hand-write a systemd unit file: actions/runner's
+# own ./svc.sh generates and installs the unit (typically at
+# /etc/systemd/system/actions.runner.<org>-<repo>.<name>.service), and that
+# is the officially-supported way to do this. Hand-rolling a unit risks
+# drifting from what a future runner self-update expects.
+#
+# Required environment variables (see environment.example):
+#   GH_RUNNER_URL      Repo or org URL to register against.
+#   GH_RUNNER_TOKEN     Short-lived runner REGISTRATION token (not a PAT).
+#   GH_RUNNER_LABELS    Comma-separated labels, e.g. self-hosted,gpu,sm3lly
+#   GH_RUNNER_NAME      Name this runner registers as.
+# Optional:
+#   GH_RUNNER_HOME      Install directory (default /opt/gh-runner-gpu).
+#   GH_RUNNER_VERSION   actions/runner release version (default pinned below).
+
+set -euo pipefail
+
+# --- Pinned release (bump deliberately; verify the sha256 changes with it) ---
+RUNNER_VERSION="${GH_RUNNER_VERSION:-2.337.0}"
+RUNNER_ARCH="linux-x64"
+RUNNER_TARBALL="actions-runner-${RUNNER_ARCH}-${RUNNER_VERSION}.tar.gz"
+RUNNER_URL="https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/${RUNNER_TARBALL}"
+# sha256 of actions-runner-linux-x64-2.337.0.tar.gz, from the GitHub Releases
+# API asset digest at the time this script was written. Re-verify (and
+# update GH_RUNNER_VERSION + this hash together) before using a newer
+# release: `gh api repos/actions/runner/releases/latest --jq '.assets[] |
+# select(.name | contains("linux-x64")) | .digest'`
+RUNNER_SHA256="70920811a4f8ad4328818682bca5c6469c1c942fab52448868071d0063816613"
+
+GH_RUNNER_HOME="${GH_RUNNER_HOME:-/opt/gh-runner-gpu}"
+
+log() { printf '[setup-runner] %s\n' "$*" >&2; }
+die() { log "ERROR: $*"; exit 1; }
+
+require_env() {
+  local var="$1"
+  if [[ -z "${!var:-}" ]]; then
+    die "required environment variable ${var} is not set (see environment.example)"
+  fi
+}
+
+require_env GH_RUNNER_URL
+require_env GH_RUNNER_TOKEN
+require_env GH_RUNNER_LABELS
+require_env GH_RUNNER_NAME
+
+if [[ "${GH_RUNNER_TOKEN}" == "__REPLACE_WITH_SHORT_LIVED_REGISTRATION_TOKEN__" ]]; then
+  die "GH_RUNNER_TOKEN still has the placeholder value from environment.example"
+fi
+
+# --- 0. sanity: confirm this host actually has the GPU we're registering for ---
+if command -v nvidia-smi >/dev/null 2>&1; then
+  log "GPU check:"
+  nvidia-smi --query-gpu=name,driver_version --format=csv,noheader || true
+else
+  log "WARNING: nvidia-smi not found on PATH — is this the right host for a GPU runner?"
+fi
+
+# --- 1. download + verify pinned tarball ---
+mkdir -p "${GH_RUNNER_HOME}"
+cd "${GH_RUNNER_HOME}"
+
+if [[ -f "${RUNNER_TARBALL}" ]]; then
+  log "tarball ${RUNNER_TARBALL} already present in ${GH_RUNNER_HOME}, skipping download"
+else
+  log "downloading ${RUNNER_URL}"
+  curl -fsSL -o "${RUNNER_TARBALL}" "${RUNNER_URL}"
+fi
+
+log "verifying sha256 checksum"
+echo "${RUNNER_SHA256}  ${RUNNER_TARBALL}" | sha256sum -c -
+
+# --- 2. extract (idempotent: skip if config.sh already present) ---
+if [[ -x "${GH_RUNNER_HOME}/config.sh" ]]; then
+  log "runner already extracted in ${GH_RUNNER_HOME}, skipping tar extract"
+else
+  log "extracting ${RUNNER_TARBALL} to ${GH_RUNNER_HOME}"
+  tar xzf "${RUNNER_TARBALL}" -C "${GH_RUNNER_HOME}"
+fi
+
+# --- 3. configure (idempotent: skip if already registered) ---
+if [[ -f "${GH_RUNNER_HOME}/.runner" ]]; then
+  log "${GH_RUNNER_HOME}/.runner already exists — runner appears already configured, skipping config.sh"
+  log "(to re-register, first run ./config.sh remove --token <token> as the runner user)"
+else
+  log "running ./config.sh to register runner '${GH_RUNNER_NAME}' with labels '${GH_RUNNER_LABELS}'"
+  "${GH_RUNNER_HOME}/config.sh" \
+    --url "${GH_RUNNER_URL}" \
+    --token "${GH_RUNNER_TOKEN}" \
+    --name "${GH_RUNNER_NAME}" \
+    --labels "${GH_RUNNER_LABELS}" \
+    --unattended \
+    --replace
+fi
+
+# --- 4. svc.sh install/start requires root; print, don't run ---
+log ""
+log "config.sh step complete. Remaining steps require root and are NOT run by"
+log "this script — run them explicitly once you've reviewed them:"
+log ""
+log "  cd ${GH_RUNNER_HOME}"
+log "  sudo ./svc.sh install     # creates the systemd unit, e.g.:"
+log "                            #   /etc/systemd/system/actions.runner.<org>-<repo>.${GH_RUNNER_NAME}.service"
+log "  sudo ./svc.sh start"
+log ""
+log "To check status later:  sudo ./svc.sh status"
+log "To uninstall later:     sudo ./svc.sh uninstall && ./config.sh remove --token <new-token>"


### PR DESCRIPTION
## Summary

Reviewable manifest (not applied/installed/registered) for offering sm3lly's NVIDIA RTX 3090 to GitHub Actions CI as a **bare-metal, systemd-managed** self-hosted runner, using GitHub's own officially-supported `actions-runner` release tarball + `config.sh`/`svc.sh` install flow (the same pattern GitHub's own "add a self-hosted runner" instructions generate).

**This is a companion to #1232, not a replacement for it.** #1232 already shipped the k8s/ARC-based way to offer this box's GPU to CI. The literal ask ("the local systemd should allow the local node to offer its gpu for jobs") wants a bare-metal, systemd-managed runner with direct GPU access — no device plugin, no time-slicing, no k0s in the loop, since nothing is being shared across pods here. This PR is that second, simpler option, so a human reviewer can pick systemd, k8s/ARC, or both.

**Nothing in this PR is applied or installed.** No token has been created, `setup-runner.sh` has not been run, no tarball has been downloaded, and no systemd unit exists on this host.

## systemd (here) vs. k8s/ARC (#1232)

| | systemd bare-metal (here) | k8s/ARC (#1232) |
|---|---|---|
| GPU access | Direct via host driver/CUDA, no device plugin/time-slicing | Shared across pods via NVIDIA device plugin + time-slicing |
| Concurrency | One job at a time, whole GPU/whole box | Multiple concurrent runner pods can share the GPU |
| Scaling | Fixed — exactly what you `svc.sh install` | Autoscaling `AutoscalingRunnerSet` |
| Moving parts | GitHub's own `actions-runner` tarball + generated systemd unit | ARC controller + Helm chart + RuntimeClass + device plugin + k0s |

Full comparison and setup instructions in `systemd/b00t-gpu-runner/README.md`.

## What's here

- `systemd/b00t-gpu-runner/README.md` — comparison to #1232, prerequisites (a short-lived runner **registration token**, not a PAT — verified this distinction against how `config.sh` actually consumes it), and the official `actions-runner` setup flow.
- `systemd/b00t-gpu-runner/setup-runner.sh` — reviewable (not executed) `set -euo pipefail` script: downloads a pinned `actions-runner-linux-x64-2.337.0.tar.gz` (sha256-verified against the GitHub Releases API asset digest), extracts to `/opt/gh-runner-gpu`, runs the runner's own `./config.sh` (parameterized via env vars, no hardcoded secrets), then prints (does not run) the root-requiring `sudo ./svc.sh install`/`start` commands. Each step checks for prior completion before re-running (idempotent-ish). Deliberately does **not** hand-write a systemd unit file — `svc.sh` is the officially-supported generator, and hand-rolling one risks drifting from what a runner self-update expects.
- `systemd/b00t-gpu-runner/environment.example` — `GH_RUNNER_URL`, `GH_RUNNER_TOKEN` (placeholder), `GH_RUNNER_LABELS=self-hosted,gpu,sm3lly`, `GH_RUNNER_NAME`, documenting the registration-token vs. PAT distinction and how to mint one (`gh api .../actions/runners/registration-token -X POST` or the repo Settings UI).
- `.github/workflows/ci-gpu-systemd.yml` — new, separate workflow, `workflow_dispatch`-only, `runs-on: [self-hosted, gpu, sm3lly]`, scoped to `nvidia-smi` + `cargo test -p b00t-datum-core -p k0mmand3r` (same scoped-crate approach as #1232's `ci-gpu.yml`, not the full workspace).

## Verified before writing this

- `nvidia-smi --query-gpu=name,driver_version --format=csv,noheader` → `NVIDIA GeForce RTX 3090, 580.167.08` — GPU still present and visible on this host.
- `actions/runner` latest release is `v2.337.0`; pinned that version and its sha256 digest (`gh api repos/actions/runner/releases/latest --jq '.assets[]...digest'`) into `setup-runner.sh`.
- Registration-token vs. PAT distinction confirmed: GitHub self-hosted runner registration tokens are short-lived (~1hr), single-purpose credentials for the `config.sh` handshake — not a general-purpose PAT.
- YAML syntax: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci-gpu-systemd.yml'))"` → OK.
- Shell syntax: `shellcheck` is not installed on this box; ran `bash -n systemd/b00t-gpu-runner/setup-runner.sh` → OK instead.

## Security tradeoff — same posture as #1232, please read before merging

`elasticdotventures/_b00t_` is a **public** repo. A self-hosted runner (bare-metal or k8s) that fires on `pull_request` is a known attack vector: a malicious fork PR's workflow gets arbitrary code execution on this host — here, direct OS-level access, not even a container boundary. This is the exact same risk #1232 already raised, so `ci-gpu-systemd.yml` is **`workflow_dispatch`-only** and is not wired into `ci.yml`'s `pull_request`/`push` triggers.

The decision on if/when to widen trigger scope (for either the systemd or the k8s/ARC GPU runner) is already tracked centrally in **#1233** — this PR does not open a second, duplicate follow-on issue.

## Explicitly NOT done in this PR

- No registration token created, no secret created.
- No download/extraction of the actions-runner tarball.
- No `config.sh` or `svc.sh install`/`start` run.
- No systemd unit file created on this or any host.
- No change to `.github/workflows/ci.yml`'s existing triggers.
- No change to #1232's `k8s/gh-runner-gpu/` manifest or `ci-gpu.yml` — both left exactly as that PR shipped them; see #1232 for the k8s/ARC alternative.

## References

- Relates to #1226 (CI slowness).
- Trigger-scope decision tracked in #1233 (shared with #1232).
- Companion PR: #1232 (k8s/ARC alternative for the same GPU).

🤖 Generated with [Claude Code](https://claude.com/claude-code)