### PR TITLE
test(lfmf): port salvage-duplication regression tests from #1183 onto #1163's fix

### DIFF
--- a/b00t-cli/tests/fixtures/lfmf_writer_cases.json
+++ b/b00t-cli/tests/fixtures/lfmf_writer_cases.json
@@ -1,0 +1,35 @@
+{
+  "comment": "Production-scale (real o200k_base tiktoken, topic_max=25, body_max=250) regression fixtures for issue #934, ported from the superseded PR #1183 onto PR #1163's shipped fix (auto_topic() 5-word-summary+ellipsis capping in b00t-cli/src/commands/lfmf.rs). The '_regression' cases mirror the two real _b00t_/learn/*.md entries at the center of #934: cargo-workspace-install.md was a genuine topic==body duplicate that #1163 re-emitted cleanly; guard-session-fixtures.md's topic was already a legitimate truncated summary (confirmed by #1163's own investigation), not corruption — kept here as a non-regression guard so the truncation branch of auto_topic() doesn't regress either. '_well_formed' cases use the proper 'topic: body' syntax that would re-emit those same lessons without any salvage.",
+  "topic_max": 25,
+  "body_max": 250,
+  "cases": [
+    {
+      "name": "cargo_workspace_install_regression",
+      "raw": "Use cargo install --locked for workspace path binaries to preserve the repository lockfile and MSRV-compatible resolution",
+      "expect_salvage": "no_colon",
+      "expect_topic": "Use cargo install --locked for…",
+      "assert_anti_duplication": true
+    },
+    {
+      "name": "guard_session_fixtures_no_regression",
+      "raw": "Session guards a/b/c from June 27 b00t tests persisted in ~/.b00t/session-guards.json and blocked unrelated audited commands; tests MUST isolate or remove session guards on teardown. Operator checkpoint docs also use invalid rustc --edition without a value.",
+      "expect_salvage": "no_colon",
+      "expect_topic": "Session guards a/b/c from June 27 b00t tests persisted in ~/.b00t/session-guards.json and blocked",
+      "assert_anti_duplication": true
+    },
+    {
+      "name": "cargo_workspace_install_well_formed",
+      "raw": "cargo install --locked: use it for workspace path binaries to preserve the repository lockfile and MSRV-compatible resolution",
+      "expect_salvage": null,
+      "expect_topic": "cargo install --locked",
+      "expect_body": "use it for workspace path binaries to preserve the repository lockfile and MSRV-compatible resolution"
+    },
+    {
+      "name": "guard_session_fixtures_well_formed",
+      "raw": "session guards must not leak across test runs: guards persisted in ~/.b00t/session-guards.json can block unrelated audited commands if not isolated or torn down; tests MUST clean up session guards on teardown",
+      "expect_salvage": null,
+      "expect_topic": "session guards must not leak across test runs",
+      "expect_body": "guards persisted in ~/.b00t/session-guards.json can block unrelated audited commands if not isolated or torn down; tests MUST clean up session guards on teardown"
+    }
+  ]
+}

--- a/b00t-cli/tests/lfmf_writer_test.rs
+++ b/b00t-cli/tests/lfmf_writer_test.rs
@@ -1,0 +1,159 @@
+//! Production-scale salvage writer regression tests — issue #934.
+//!
+//! Ported from the now-superseded/conflicting PR #1183 onto PR #1163's
+//! shipped fix. #1183 assumed `record_lesson_parts`/`format_stored_content`
+//! functions that were never merged; #1163 instead fixed the duplication at
+//! its actual source — `auto_topic()` in `b00t-cli/src/commands/lfmf.rs` now
+//! caps a synthesized topic to a short 5-word-prefix + ellipsis summary
+//! whenever the whole colon-free lesson would otherwise fit under
+//! `topic_max` verbatim (the case that produced a topic == body duplicate).
+//!
+//! Cases in tests/fixtures/lfmf_writer_cases.json. Unlike lfmf_salvage_test.rs
+//! (word-count token stub, small topic_max), this uses the REAL o200k_base
+//! tiktoken counter and production topic_max=25 / body_max=250 to lock in,
+//! at the scale that actually shipped the bug:
+//!
+//! 1. Anti-duplication: a colon-free lesson under body_max no longer gets
+//!    its entire text echoed back as "topic" (topic == body verbatim). The
+//!    two `_regression`/`_no_regression` cases are drawn directly from the
+//!    real `_b00t_/learn/cargo-workspace-install.md` and
+//!    `_b00t_/learn/guard-session-fixtures.md` entries at the center of
+//!    issue #934.
+//! 2. No destructive re-split: the CLI still assembles a single
+//!    `"{safe_topic}: {body}[ <!-- salvaged:kind -->]"` string and hands it
+//!    to `b00t_c0re_lib::LfmfSystem::record_lesson_scoped`, which re-splits
+//!    on the first `':'` (`parse_lesson`). That round trip is only lossless
+//!    because `handle_lfmf` strips colons out of the topic first
+//!    (`parsed.topic.replace(':', "")`) before formatting — this test
+//!    exercises that exact reformat-then-resplit pipeline (mirrored here,
+//!    since `parse_lesson` is a private method on `LfmfSystem`) to lock the
+//!    invariant in, rather than just trusting it by inspection.
+
+use b00t_cli::commands::lfmf::{ParsedLesson, parse_lesson_salvage};
+use serde::Deserialize;
+use std::path::PathBuf;
+use tiktoken_rs::o200k_base;
+
+#[derive(Deserialize)]
+struct Fixture {
+    topic_max: usize,
+    body_max: usize,
+    cases: Vec<Case>,
+}
+
+#[derive(Deserialize)]
+struct Case {
+    name: String,
+    raw: String,
+    expect_salvage: Option<String>,
+    #[serde(default)]
+    assert_anti_duplication: bool,
+    #[serde(default)]
+    expect_topic: Option<String>,
+    #[serde(default)]
+    expect_body: Option<String>,
+}
+
+/// Mirrors the storage-format assembly inline in
+/// `b00t_cli::commands::lfmf::handle_lfmf` (main's #1163 fix did not extract
+/// a separate `format_stored_content` helper — the CLI still builds one
+/// "topic: body[ marker]" string that the core crate re-splits).
+fn stored_content(safe_topic: &str, parsed: &ParsedLesson) -> String {
+    match &parsed.salvage {
+        Some(kind) => format!("{}: {} <!-- salvaged:{} -->", safe_topic, parsed.body, kind),
+        None => format!("{}: {}", safe_topic, parsed.body),
+    }
+}
+
+/// Mirrors `b00t_c0re_lib::LfmfSystem::parse_lesson`'s `split_once(':')` +
+/// `.trim()` re-parse of the stored "topic: body" string (private to that
+/// crate, so re-implemented here rather than exercised directly).
+fn resplit(stored: &str) -> (String, String) {
+    match stored.split_once(':') {
+        Some((topic_part, content_part)) => {
+            (topic_part.trim().to_string(), content_part.trim().to_string())
+        }
+        None => ("General".to_string(), stored.to_string()),
+    }
+}
+
+#[test]
+fn writer_cases_from_fixture_production_scale() {
+    let path =
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/lfmf_writer_cases.json");
+    let fixture: Fixture =
+        serde_json::from_str(&std::fs::read_to_string(&path).expect("fixture readable"))
+            .expect("fixture parses");
+
+    let bpe = o200k_base().expect("tiktoken o200k_base loads");
+    let count_tokens = |s: &str| bpe.encode_with_special_tokens(s).len();
+
+    for case in &fixture.cases {
+        let parsed =
+            parse_lesson_salvage(&case.raw, &count_tokens, fixture.topic_max, fixture.body_max);
+
+        assert_eq!(
+            parsed.salvage, case.expect_salvage,
+            "salvage mismatch in case '{}'",
+            case.name
+        );
+
+        if let Some(expect_topic) = &case.expect_topic {
+            assert_eq!(&parsed.topic, expect_topic, "topic mismatch in case '{}'", case.name);
+        }
+        if let Some(expect_body) = &case.expect_body {
+            assert_eq!(&parsed.body, expect_body, "body mismatch in case '{}'", case.name);
+        }
+
+        if case.assert_anti_duplication {
+            // The core regression this issue is about: a synthesized topic
+            // must never just BE the body (issue #934's original
+            // topic==body duplication in cargo-workspace-install.md) — it's
+            // a short derived stub or truncated prefix, not an echo.
+            assert_ne!(
+                parsed.topic, parsed.body,
+                "topic duplicated body verbatim in case '{}' — issue #934 regression",
+                case.name
+            );
+            assert!(
+                parsed.topic.len() < parsed.body.len() / 2,
+                "topic not meaningfully shorter than body in case '{}': topic={:?} body={:?}",
+                case.name,
+                parsed.topic,
+                parsed.body
+            );
+            // Payload preservation still holds even with the capped/truncated topic.
+            for word in case.raw.split_whitespace() {
+                assert!(
+                    parsed.body.contains(word) || parsed.topic.contains(word),
+                    "payload word '{}' lost in case '{}'",
+                    word,
+                    case.name
+                );
+            }
+        }
+
+        // No destructive re-split: reformat through the CLI's real
+        // "topic: body[ marker]" assembly, then re-split the way
+        // LfmfSystem::parse_lesson does on the far side of
+        // record_lesson_scoped, and confirm nothing was corrupted or lost.
+        let safe_topic = parsed.topic.replace(':', "");
+        let stored = stored_content(&safe_topic, &parsed);
+        let (resplit_topic, resplit_content) = resplit(&stored);
+
+        assert_eq!(
+            resplit_topic, safe_topic,
+            "destructive re-split: topic changed after reformat+resplit in case '{}'",
+            case.name
+        );
+        let expected_content = match &parsed.salvage {
+            Some(kind) => format!("{} <!-- salvaged:{} -->", parsed.body, kind),
+            None => parsed.body.clone(),
+        };
+        assert_eq!(
+            resplit_content, expected_content,
+            "destructive re-split: content changed after reformat+resplit in case '{}'",
+            case.name
+        );
+    }
+}

--- a/justfile
+++ b/justfile
@@ -587,6 +587,10 @@ test:
 test-b00t-mcp:
     cargo test -p b00t-mcp
 
+# Salvage-first lfmf writer regression tests -- zero duplication, zero payload loss (issue #934, ports #1183's coverage onto #1163's shipped fix).
+test-lfmf-roundtrip:
+    cargo test -p b00t-cli --test lfmf_salvage_test --test lfmf_writer_test
+
 # Format the b00t-mcp crate through the registered action surface.
 format-b00t-mcp:
     rustfmt --edition 2024 b00t-mcp/src/chat.rs b00t-mcp/src/mcp_server_rusty.rs b00t-mcp/src/mcp_tools.rs


### PR DESCRIPTION
## Summary

- Issue #934 (lfmf salvage path duplicating topic/body content) was fixed and merged via #1163 two days before #1183 was opened, using a different approach: `auto_topic()`'s 5-word-summary+ellipsis capping in `b00t-cli/src/commands/lfmf.rs`, rather than #1183's `record_lesson_parts`/`format_stored_content` refactor.
- #1183 (`fix/934-lfmf-salvage-duplication`) is now conflicting/dirty against `main` and its diff still calls pre-#1101 signatures (`record_lesson`/`handle_lfmf` without the `scope`+`force` disclosure-safety gate `main` has had since #1101). It should not be merged as-is.
- #1183 did add a genuinely valuable production-scale regression test (`lfmf_writer_test.rs`, real `o200k_base` tiktoken, `topic_max=25`) that wasn't fully covered by #1163's own `lfmf_salvage_test.rs` fixture additions. This PR ports that coverage onto current `main` instead of letting it die with #1183.

## What changed

- `b00t-cli/tests/lfmf_writer_test.rs` — adapted to call `parse_lesson_salvage` as it exists on `main` today (no `record_lesson_parts`/`format_stored_content`, since those were never merged). Asserts `topic != body` and payload-word preservation for the two real historical `learn/*.md` entries at the center of #934:
  - `cargo-workspace-install.md` — a genuine `topic == body` duplicate that #1163 fixed.
  - `guard-session-fixtures.md` — confirmed by #1163's own investigation to already be a legitimate truncated summary, not corruption; kept here as a non-regression guard on the truncation branch of `auto_topic()`.
  Also exercises the actual `"topic: body"` reformat-then-resplit round trip that `record_lesson_scoped -> parse_lesson` still performs in production, to lock in that `safe_topic`'s colon-stripping keeps that round trip lossless.
- `b00t-cli/tests/fixtures/lfmf_writer_cases.json` — fixture data; `expect_topic` values for the two regression cases are taken directly from the real recorded `learn/*.md` entries, not hand-computed.
- `justfile` — `test-lfmf-roundtrip` recipe running both lfmf regression suites (`lfmf_salvage_test` + `lfmf_writer_test`).

## Test plan

- [x] `cargo test -p b00t-cli --test lfmf_writer_test` — 1 passed
- [x] `cargo test -p b00t-cli --test lfmf_writer_test --test lfmf_salvage_test` — 2 passed, 0 failed

Refs #934, #1163, #1183.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01VcVRB8FYcM9Tw6LBpsDrAQ