### PR TITLE
feat(datum): add nsc CLI tool (NATS operator/account/user management)

### DIFF
--- a/_b00t_/nsc.cli.toml
+++ b/_b00t_/nsc.cli.toml
@@ -1,0 +1,34 @@
+[b00t]
+name = "nsc"
+type = "cli"
+desires = "latest"
+hint = "nsc — NATS account/operator credential management (nats-io/nsc)"
+depends_on = []
+
+install = "curl -L https://raw.githubusercontent.com/nats-io/nsc/master/install.sh | sh"
+update = "curl -L https://raw.githubusercontent.com/nats-io/nsc/master/install.sh | sh"
+version = "nsc --version"
+version_regex = '([0-9]+\\.[0-9]+\\.[0-9]+)'
+
+[[b00t.usage]]
+description = "Show current operator/account/user context"
+command = "nsc env"
+
+[[b00t.usage]]
+description = "List operators"
+command = "nsc list operators"
+
+[validate]
+command = "nsc --version"
+regex = "[0-9]+\\.[0-9]+\\.[0-9]+"
+
+[roles]
+required_for = []
+optional_for = ["developer"]
+
+# b00t:map v1
+# summary: nsc — NATS operator/account/user JWT + key management CLI
+# tags: nats, nsc, jwt, credentials, messaging
+# tier: ch0nky
+# cmds: nsc env, nsc list operators, nsc list accounts
+# complexity: 3


### PR DESCRIPTION
## Summary

Adds `_b00t_/nsc.cli.toml` so `b00t-cli cli install nsc` works — needed while rotating the NATS operator credentials exposed in PromptExecution/infrastructure#191 / PromptExecution/b00t-website (leaked `NATS_OPERATOR_JWT`/`NATS_OPERATOR_SEED`, now migrated to Key Vault but rotation of the operator itself is pending).

Follows the existing `.cli.toml` datum convention (modeled on `bun.cli.toml`) — installs via NATS's own official install script, matching the tool's documented install method.

## Test plan

- [x] `b00t-cli cli install nsc` — verified working on two machines (this box and fung1.lan), installs to `~/.nsccli/bin/nsc`, `nsc --version` reports `2.15.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)