### PR TITLE
security: blanket-ignore .env.* at repo root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -167,6 +167,7 @@
 .eggs/
 .env
 .env.test
+.env.*
 .envrc
 # 🤓 raw secret material (nats-user/nats-password/rustfs-*-key etc.) — canonical
 # location is ~/.b00t/secrets/ (see b00t-cli/scripts/sync-*-secrets.sh), but a


### PR DESCRIPTION
## Summary

\`.env.backup\` needed its own explicit \`/.env.backup\` entry before it could be gitignored — the same pattern that let it (and separately, \`b00t-website\`'s various \`.env.old\`/\`.env.backup\`/\`.env~\` variants) get committed in the first place. Adds a wildcard \`.env.*\` so any future variant is covered automatically.

Does not affect already-tracked \`.env.example\`/\`.env.defaults\` files — gitignore never retroactively untracks.

See PromptExecution/infrastructure#191.

🤖 Generated with [Claude Code](https://claude.com/claude-code)