### PR TITLE
fix: InstallSpec untagged-enum silently swallows [install] command tables

### DIFF
--- a/_b00t_/cranelift.cli.toml
+++ b/_b00t_/cranelift.cli.toml
@@ -9,9 +9,10 @@ type = "cli"
 hint = "Rustc Cranelift codegen backend — 2x faster debug builds than LLVM"
 desires = "latest"
 depends_on = ["rustc.cli"]
-
-[install]
-command = "rustup component add rustc-codegen-cranelift-preview --toolchain nightly"
+# @tribal (b00t task #40): install MUST live here under [b00t], not in a
+# separate top-level [install] table — see sccache.cli.toml's note and
+# b00t-cli/src/config_types.rs for why the old shape silently no-op'd.
+install = "rustup component add rustc-codegen-cranelift-preview --toolchain nightly"
 
 [version]
 cmd = "rustc --print cfg 2>/dev/null | grep cranelift || echo 'not active'"

--- a/_b00t_/sccache.cli.toml
+++ b/_b00t_/sccache.cli.toml
@@ -7,13 +7,16 @@ name = "sccache"
 type = "cli"
 hint = "Shared compilation cache — wraps rustc/gcc to cache .o artifacts across rebuilds"
 desires = "latest"
+# @tribal (b00t task #40): install MUST live here under [b00t], not in a
+# separate top-level [install] table — BootDatum.install only ever reads a
+# nested `[b00t].install` key. A top-level `[install]` table (the old shape
+# here) doesn't map to any UnifiedConfig field, so it was silently dropped
+# and `b00t install sccache` was a no-op. See b00t-cli/src/config_types.rs.
+install = "cargo install sccache --locked"
 
 [version]
 cmd = "sccache --version"
 regex = "(\\d+\\.\\d+\\.\\d+)"
-
-[install]
-command = "cargo install sccache --locked"
 
 [validate]
 command = "sccache --version"

--- a/_b00t_/servo.cli.toml
+++ b/_b00t_/servo.cli.toml
@@ -68,14 +68,10 @@
 name    = "servo"
 hint    = "Rust browser engine — servoshell binary + libservo embedding API"
 type    = "cli"
-
-[version]
-desires = "0.3.0"
-cmd     = "servoshell --version 2>&1 || servo --version 2>&1"
-regex   = "(?:servo|servoshell)[/ ](\\d+\\.\\d+\\.\\d+)"
-
-[install]
-cmd = """
+# @tribal (b00t task #40): install MUST live here under [b00t], not in a
+# separate top-level [install] table — see sccache.cli.toml's note and
+# b00t-cli/src/config_types.rs for why the old shape silently no-op'd.
+install = """
 set -euo pipefail
 SERVO_VERSION="0.3.0"
 INSTALL_DIR="${HOME}/.local/share/servo"
@@ -86,6 +82,11 @@ ln -sf "$INSTALL_DIR/servoshell" ~/.local/bin/servo
 ln -sf "$INSTALL_DIR/servoshell" ~/.local/bin/servoshell
 echo "servo ${SERVO_VERSION} installed → ~/.local/share/servo/servoshell"
 """
+
+[version]
+desires = "0.3.0"
+cmd     = "servoshell --version 2>&1 || servo --version 2>&1"
+regex   = "(?:servo|servoshell)[/ ](\\d+\\.\\d+\\.\\d+)"
 
 [runtime_deps]
 # apt packages required on Linux (Ubuntu/Debian)

--- a/_b00t_/xpra.cli.toml
+++ b/_b00t_/xpra.cli.toml
@@ -106,18 +106,14 @@ name = "xpra"
 type = "cli"
 hint = "Seamless X11 app forwarding + built-in HTML5 client — replaces raw X11Forwarding for watching headed RPA browser sessions"
 source = "https://github.com/Xpra-org/xpra"
-
-[version]
-desires = "6.5"
-cmd     = "xpra --version 2>&1"
-regex   = "xpra v?(\\d+\\.\\d+(?:\\.\\d+)?)"
-
-[install]
+# @tribal (b00t task #40): install MUST live here under [b00t], not in a
+# separate top-level [install] table — see sccache.cli.toml's note and
+# b00t-cli/src/config_types.rs for why the old shape silently no-op'd.
 # 🤓 run on BOTH the RPA server node (e.g. rock-5c) and the operator's client
 #    machine (WSL2/Linux) — this bootstraps the xpra.org repo; plain
 #    `apt-get install xpra` pulls the stale, buggy Ubuntu-universe 3.1.5.
 #    `<codename>` is the Ubuntu release codename (noble/jammy/etc, `. /etc/os-release`).
-cmd = """
+install = """
 set -euo pipefail
 DISTRO_CODENAME="$(. /etc/os-release; echo "${VERSION_CODENAME:-noble}")"
 sudo apt-get install -y ca-certificates wget
@@ -130,6 +126,11 @@ sudo apt-get update
 sudo apt-get install -y xpra-server xpra-x11 xpra-html5 xpra-codecs xpra
 xpra --version
 """
+
+[version]
+desires = "6.5"
+cmd     = "xpra --version 2>&1"
+regex   = "xpra v?(\\d+\\.\\d+(?:\\.\\d+)?)"
 
 [runtime_deps]
 apt = ["xpra", "xpra-server", "xpra-x11", "xpra-html5", "xpra-codecs"]

--- a/b00t-cli/src/config_types.rs
+++ b/b00t-cli/src/config_types.rs
@@ -87,13 +87,41 @@ pub struct OrchestrationConfig {
 
 // ── InstallSpec types ───────────────────────────────────────────────────
 
+// 🤓 b00t task #40 (sibling of #38 / PR #1222): `InstallSpec` is untagged, so
+//    serde tries each variant in declaration order and silently falls through
+//    to the next on a mismatch rather than erroring. `PackageInstallSpec` and
+//    `ToolInstallSpec` both carry `#[serde(deny_unknown_fields)]`, but the old
+//    inline `Metadata { requires: Option<Vec<String>> } ` variant did not —
+//    and since `requires` is `Option`, an *empty* table already satisfies it.
+//    That meant a `[install]` table shaped `{ command = "..." }` or
+//    `{ cmd = "..." }` (used by sccache.cli.toml/cranelift.cli.toml via
+//    `command`, servo.cli.toml/xpra.cli.toml via `cmd`) failed `Command`
+//    (not a bare string), failed `Package`/`Tool` (deny_unknown_fields trips
+//    on the unrecognized key), and then silently matched `Metadata` anyway —
+//    dropping the unrecognized field instead of erroring — so
+//    `command_string()` returned `None` and `b00t install <name>` quietly
+//    did nothing. `CommandTable` below is a first-class variant for that
+//    table shape (accepting both the `command` and `cmd` keys actually used
+//    in the wild), and `Metadata` now denies unknown fields like its
+//    siblings, so a table that isn't recognized by any variant now errors
+//    loudly during deserialization instead of silently resolving to
+//    `Metadata`. See the `install_command_table_*` and
+//    `*_cli_install_resolves_end_to_end` tests in lib.rs.
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
 #[serde(untagged)]
 pub enum InstallSpec {
     Command(String),
+    CommandTable(CommandInstallSpec),
     Package(PackageInstallSpec),
     Tool(ToolInstallSpec),
-    Metadata { requires: Option<Vec<String>> },
+    Metadata(MetadataInstallSpec),
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct CommandInstallSpec {
+    #[serde(alias = "cmd")]
+    pub command: String,
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
@@ -118,22 +146,30 @@ pub struct ToolInstallSpec {
     pub version: Option<String>,
 }
 
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct MetadataInstallSpec {
+    pub requires: Option<Vec<String>>,
+}
+
 impl InstallSpec {
     pub fn command(&self) -> Option<&str> {
         match self {
             InstallSpec::Command(command) => Some(command),
+            InstallSpec::CommandTable(spec) => Some(&spec.command),
             InstallSpec::Package(_) => None,
             InstallSpec::Tool(_) => None,
-            InstallSpec::Metadata { .. } => None,
+            InstallSpec::Metadata(_) => None,
         }
     }
 
     pub fn command_string(&self) -> Option<String> {
         match self {
             InstallSpec::Command(command) => Some(command.clone()),
+            InstallSpec::CommandTable(spec) => Some(spec.command.clone()),
             InstallSpec::Package(package) => Some(package.install_script()),
             InstallSpec::Tool(tool) => tool.install_script(),
-            InstallSpec::Metadata { .. } => None,
+            InstallSpec::Metadata(_) => None,
         }
     }
 }

--- a/b00t-cli/src/lib.rs
+++ b/b00t-cli/src/lib.rs
@@ -719,8 +719,131 @@ hint = "containers"
         let datum: TestDatum =
             toml::from_str(r#"install = { requires = ["node", "npm"] }"#).unwrap();
 
-        assert!(matches!(datum.install, InstallSpec::Metadata { .. }));
+        assert!(matches!(datum.install, InstallSpec::Metadata(_)));
         assert!(datum.install.command_string().is_none());
+    }
+
+    #[test]
+    fn install_command_table_with_command_key_resolves() {
+        // Mirrors sccache.cli.toml / cranelift.cli.toml's `[install]\ncommand = "..."`
+        // table shape. Before the b00t task #40 fix this silently matched
+        // InstallSpec::Metadata { requires: None } instead of erroring or
+        // resolving, because Metadata had no #[serde(deny_unknown_fields)]
+        // and its only field is optional.
+        #[derive(Deserialize)]
+        struct TestDatum {
+            install: InstallSpec,
+        }
+
+        let datum: TestDatum =
+            toml::from_str(r#"install = { command = "cargo install sccache --locked" }"#)
+                .unwrap();
+
+        assert!(matches!(datum.install, InstallSpec::CommandTable(_)));
+        let command = datum
+            .install
+            .command_string()
+            .expect("command-table install must resolve to a runnable command, not Metadata");
+        assert_eq!(command, "cargo install sccache --locked");
+    }
+
+    #[test]
+    fn install_command_table_with_cmd_alias_resolves() {
+        // Mirrors servo.cli.toml / xpra.cli.toml's `[install]\ncmd = "..."`
+        // table shape (same bug, different key name for the command).
+        #[derive(Deserialize)]
+        struct TestDatum {
+            install: InstallSpec,
+        }
+
+        let datum: TestDatum =
+            toml::from_str(r#"install = { cmd = "xpra --version" }"#).unwrap();
+
+        assert!(matches!(datum.install, InstallSpec::CommandTable(_)));
+        let command = datum
+            .install
+            .command_string()
+            .expect("command-table install must resolve to a runnable command, not Metadata");
+        assert_eq!(command, "xpra --version");
+    }
+
+    #[test]
+    fn install_table_with_unrecognized_field_now_errors_loudly() {
+        // Regression guard for the root cause itself: a table that matches
+        // none of the real variants must now fail deserialization instead of
+        // silently absorbing into Metadata.
+        #[derive(Deserialize)]
+        struct TestDatum {
+            #[allow(dead_code)]
+            install: InstallSpec,
+        }
+
+        let result: Result<TestDatum, _> =
+            toml::from_str(r#"install = { totally_unknown_field = "oops" }"#);
+        assert!(
+            result.is_err(),
+            "expected deserialization to fail loudly, not silently fall through to Metadata"
+        );
+    }
+
+    /// End-to-end regression helper for b00t task #40: `b00t install
+    /// <name>` was a silent no-op for sccache/cranelift/servo/xpra because
+    /// (a) the untagged InstallSpec enum fell through to Metadata for the
+    /// `{ command = "..." }` / `{ cmd = "..." }` table shape those datums
+    /// used, AND (b) that `[install]` table lived at the top level of the
+    /// file instead of nested under `[b00t]`, so it never reached
+    /// `BootDatum.install` at all. This parses the *actual* production
+    /// config file shape (`[b00t]` table with a nested `install` key,
+    /// exactly like the already-working
+    /// node.cli.toml/corepack.cli.toml/pnpm.cli.toml datums) and returns the
+    /// resolved command string, panicking (via `.expect`) if it falls back
+    /// to `InstallSpec::Metadata` the way it used to.
+    fn resolve_cli_datum_install_command(datum_file: &str) -> String {
+        #[derive(Deserialize)]
+        struct TestDatum {
+            install: InstallSpec,
+        }
+        #[derive(Deserialize)]
+        struct TestFile {
+            b00t: TestDatum,
+        }
+
+        let toml_text = std::fs::read_to_string(format!(
+            "{}/../_b00t_/{datum_file}",
+            env!("CARGO_MANIFEST_DIR")
+        ))
+        .unwrap_or_else(|e| panic!("{datum_file} should exist: {e}"));
+        let file: TestFile = toml::from_str(&toml_text)
+            .unwrap_or_else(|e| panic!("{datum_file} should parse as a UnifiedConfig shape: {e}"));
+        file.b00t.install.command_string().unwrap_or_else(|| {
+            panic!(
+                "{datum_file} [b00t].install must resolve to a runnable command, not InstallSpec::Metadata"
+            )
+        })
+    }
+
+    #[test]
+    fn sccache_cli_install_resolves_end_to_end() {
+        let command = resolve_cli_datum_install_command("sccache.cli.toml");
+        assert!(command.contains("cargo install sccache"));
+    }
+
+    #[test]
+    fn cranelift_cli_install_resolves_end_to_end() {
+        let command = resolve_cli_datum_install_command("cranelift.cli.toml");
+        assert!(command.contains("rustup component add rustc-codegen-cranelift-preview"));
+    }
+
+    #[test]
+    fn servo_cli_install_resolves_end_to_end() {
+        let command = resolve_cli_datum_install_command("servo.cli.toml");
+        assert!(command.contains("servo-x86_64-linux-gnu.tar.gz"));
+    }
+
+    #[test]
+    fn xpra_cli_install_resolves_end_to_end() {
+        let command = resolve_cli_datum_install_command("xpra.cli.toml");
+        assert!(command.contains("xpra-server xpra-x11 xpra-html5 xpra-codecs"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `InstallSpec` (`b00t-cli/src/config_types.rs`) is `#[serde(untagged)]`. `PackageInstallSpec`/`ToolInstallSpec` both `deny_unknown_fields`, but the old inline `Metadata { requires: Option<Vec<String>> }` variant did not, and `requires` is `Option` — so an empty table already satisfies it. A `[install]` table shaped `{ command = "..." }` (sccache/cranelift) or `{ cmd = "..." }` (servo/xpra) failed `Command` (not a bare string) and failed `Package`/`Tool` (deny_unknown_fields trips on the unrecognized key), then silently matched `Metadata` anyway, dropping the command — so `command_string()` returned `None` and `b00t install <name>` quietly did nothing for all four tools.
- A second, compounding bug: all four datum files put `[install]` (along with `[version]`/`[validate]`/`[roles]`) as a **top-level** TOML table instead of nesting it under `[b00t]`. `BootDatum.install` only reads a nested `[b00t].install` key, and `UnifiedConfig` has no top-level `install` field and no `deny_unknown_fields`, so the top-level table was silently dropped before it ever reached `InstallSpec` at all — confirmed empirically by reconstructing the real struct layout and parsing the actual file content in isolation.
- This is a sibling of the bug documented/worked around in PR #1222 (b00t task #38, for `node.cli.toml`) and is tracked locally as b00t task #40 (`_b00t_/.b00t/tasks.json`).

## Fix

- `config_types.rs`: add `CommandTable(CommandInstallSpec)` variant (field `command`, `#[serde(alias = "cmd")]`, `deny_unknown_fields`) so the `command`/`cmd`-keyed table shape resolves to a real runnable command instead of falling through. `Metadata` is now a proper `MetadataInstallSpec` struct with `deny_unknown_fields` too, so a table matching none of the real variants now errors loudly during deserialization instead of silently resolving to `Metadata`.
- `sccache.cli.toml` / `cranelift.cli.toml` / `servo.cli.toml` / `xpra.cli.toml`: move `install` into `[b00t]`, matching the already-working `node.cli.toml` / `corepack.cli.toml` / `pnpm.cli.toml` convention — the same precedent PR #1222 used for the sibling `node.cli.toml` bug. `[version]`/`[validate]`/`[roles]`/`[usage]`/`[runtime_deps]` in these files are left untouched (out of scope for this fix; flagging as a related, unresolved issue since they use the same misplaced-top-level-table pattern and may be similarly inert).

## Tests

Added to `b00t-cli/src/lib.rs`:
- `install_command_table_with_command_key_resolves`, `install_command_table_with_cmd_alias_resolves` — isolated `InstallSpec` deserialization for both real-world key shapes.
- `install_table_with_unrecognized_field_now_errors_loudly` — regression guard for the root cause itself (an unrecognized shape must now error, not silently become `Metadata`).
- `sccache_cli_install_resolves_end_to_end`, `cranelift_cli_install_resolves_end_to_end`, `servo_cli_install_resolves_end_to_end`, `xpra_cli_install_resolves_end_to_end` — parse the real, now-fixed datum files through the production `[b00t].install` path and assert the resolved command string (mirrors the existing `node_cli_install_resolves_nvm_command` test's convention).
- Updated the one pre-existing test whose match arm needed to change for `Metadata`'s new struct-wrapped shape (`InstallSpec::Metadata { .. }` → `InstallSpec::Metadata(_)`); its behavior is unchanged.

`cargo test -p b00t-cli --lib`: **1613 passed; 0 failed; 6 ignored** (pre-existing/unrelated ignores).

## Test plan

- [x] `cargo test -p b00t-cli --lib` green, including all new tests
- [x] Verified via the new end-to-end tests that `sccache.cli.toml`/`cranelift.cli.toml`/`servo.cli.toml`/`xpra.cli.toml` now resolve a real install command through the actual production parsing path, instead of silently resolving to `None`
- [ ] Not run: an actual `b00t install sccache` invocation (would install real system packages/toolchains; out of scope for CI-safe verification — covered instead by the unit tests above, per the task's own guidance)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_015kUr7Kf9wN15TPqDiKsiKw