### PR TITLE
feat(historian, capability-forge): NATS operator/JWT auth support for #1235

### DIFF
--- a/capability-forge/src/bin/mint_historian_creds.rs
+++ b/capability-forge/src/bin/mint_historian_creds.rs
@@ -1,0 +1,68 @@
+use anyhow::{Context, Result};
+use capability_forge::jwt_mint::mint_readonly_service_jwt;
+use nkeys::KeyPair;
+use std::env;
+
+/// One-time (or rotate-by-rerunning) mint of a genuinely read-only NATS user identity for
+/// `b00t-historian` under the CAPFORGE account (elasticdotventures/_b00t_#1235) — historian
+/// archives hive coordination traffic, it never needs to publish anything.
+///
+/// Deliberately under CAPFORGE's existing, already-preloaded account rather than a new
+/// dedicated account: minting a user under an account the server already trusts needs no
+/// server-config redeploy, only the account's own signing seed (already in the secret store
+/// as CAPFORGE_ACCOUNT_SEED). A cleaner, dedicated "HIVE" account is the longer-term fix (see
+/// the #1235 comment this was posted from) but needs live access to redeploy
+/// pods/nats/nats-pod-configured.yaml's resolver_preload — out of reach without it.
+///
+/// Subject coverage spans both known historian deployments: `hive.>` (the LAN bus, see
+/// historian-run.log's own "subscribing to 'hive.sm3ll-fung1.>'") and `souls.>`/`vultr.>`/
+/// `b00t.hive.mesh.>` (PR #1230's k8s manifest, the vultr1/k0s deployment). Broader than any
+/// single deployment strictly needs, but subscribe-only + publish-explicitly-denied keeps the
+/// actual risk of that breadth low - this credential can read hive traffic, it cannot
+/// originate any.
+fn main() -> Result<()> {
+    let account_seed = env::var("CAPFORGE_ACCOUNT_SEED").context("CAPFORGE_ACCOUNT_SEED not set")?;
+    let account_key = KeyPair::from_seed(&account_seed).context("invalid CAPFORGE_ACCOUNT_SEED")?;
+    let account_pubkey = account_key.public_key();
+
+    let ttl_days: i64 = env::var("HISTORIAN_CREDS_TTL_DAYS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(365);
+    let ttl = chrono::Duration::days(ttl_days);
+
+    let historian_user = KeyPair::new_user();
+    let historian_jwt = mint_readonly_service_jwt(
+        &account_key,
+        &account_pubkey,
+        &historian_user.public_key(),
+        &[
+            "hive.>".to_string(),
+            "souls.>".to_string(),
+            "vultr.>".to_string(),
+            "b00t.hive.mesh.>".to_string(),
+        ],
+        ttl,
+    )?;
+
+    println!("# historian NATS creds minted (TTL: {ttl_days} days) — subscribe-only, publish denied.");
+    println!("# Store as HISTORIAN_NATS_CREDS in the secret store; wire b00t_historian.py to");
+    println!("# connect with a .creds file (nats.connect(user_credentials=...)) instead of");
+    println!("# plain user/password once elasticdotventures/_b00t_#1235's server-side auth");
+    println!("# mode issue is otherwise addressed — this mint alone doesn't flip that switch.");
+    println!();
+    println!("-----BEGIN NATS USER JWT-----");
+    println!("{historian_jwt}");
+    println!("------END NATS USER JWT------");
+    println!();
+    println!("************************* IMPORTANT *************************");
+    println!("NKEY Seed printed below can be used to sign and prove identity.");
+    println!("NKEYs are sensitive and should be treated as secrets.");
+    println!();
+    println!("-----BEGIN USER NKEY SEED-----");
+    println!("{}", historian_user.seed()?);
+    println!("------END USER NKEY SEED------");
+    println!("*************************************************************");
+
+    Ok(())
+}

--- a/capability-forge/src/jwt_mint.rs
+++ b/capability-forge/src/jwt_mint.rs
@@ -99,6 +99,44 @@ pub fn mint_service_jwt(
     Ok(token.sign(account_signing_key))
 }
 
+/// Mints a genuinely read-only NATS user JWT: subscribe-only on `sub_allow`, publish
+/// explicitly denied on every subject (`deny_publish(">")`), not merely omitted.
+///
+/// This distinction matters and is easy to get wrong: [`mint_service_jwt`] with an empty
+/// `pub_allow` does NOT produce a read-only credential - `nats-jwt` only emits a `nats.pub`
+/// permission block when `allow_publish`/`deny_publish` is called at least once
+/// (`NatsPermissions::is_empty()`, `skip_serializing_if`d away otherwise), and an absent
+/// permission block means NATS grants unrestricted access on that axis. A caller wanting
+/// "subscribe to X, never publish anything" must explicitly deny publish, not just skip
+/// allowing it - this function exists so that requirement doesn't have to be rediscovered
+/// per caller. Used by `bin/mint_historian_creds.rs`.
+pub fn mint_readonly_service_jwt(
+    account_signing_key: &KeyPair,
+    account_pubkey: &str,
+    user_pubkey: &str,
+    sub_allow: &[String],
+    ttl: chrono::Duration,
+) -> Result<String> {
+    anyhow::ensure!(ttl > chrono::Duration::zero(), "ttl must be positive");
+    anyhow::ensure!(
+        !sub_allow.is_empty(),
+        "sub_allow must not be empty (an empty NATS permission block means unrestricted access, not none)"
+    );
+
+    let expires_at = chrono::Utc::now()
+        .checked_add_signed(ttl)
+        .context("ttl overflows a representable expiry timestamp")?
+        .timestamp();
+
+    let mut token = Token::new_user(account_pubkey, user_pubkey).deny_publish(">".to_string());
+    for subject in sub_allow {
+        token = token.allow_subscribe(subject.clone());
+    }
+    token = token.expires(expires_at);
+
+    Ok(token.sign(account_signing_key))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/historian/bin/b00t_historian.py
+++ b/historian/bin/b00t_historian.py
@@ -67,6 +67,14 @@ async def run(args: argparse.Namespace) -> None:
     subject = args.subject or f"hive.{args.id}.>"
     basename = args.basename or f"hive-{args.id}-coord"
     log_dir = Path(args.log_dir) if args.log_dir else _default_log_dir()
+    # JWT/nkey .creds file, e.g. from capability-forge's mint_historian_creds
+    # (elasticdotventures/_b00t_#1235) - falls back to CREDS_FILE env var for
+    # the same reason NATS_URL is env-first: keep the path out of argv where
+    # any local user could see it via `ps aux` (matters less for a path than
+    # a password, but keeps both auth modes consistent). Plain user/password
+    # (embedded in nats_url) is still supported when this isn't set - servers
+    # not yet running in operator/JWT mode still need that path to work.
+    creds = args.creds or os.environ.get("CREDS_FILE")
 
     async def error_cb(e):
         print(f"[nats error] {e}")
@@ -80,10 +88,11 @@ async def run(args: argparse.Namespace) -> None:
     async def closed_cb():
         print("[nats] connection closed")
 
-    print(f"connecting to {_redact_nats_url(nats_url)} as {args.id!r}")
+    print(f"connecting to {_redact_nats_url(nats_url)} as {args.id!r}" + (f" (creds: {creds})" if creds else ""))
     nc = await nats.connect(
         nats_url,
         name=args.id,
+        user_credentials=creds,
         reconnect_time_wait=2,
         max_reconnect_attempts=-1,
         error_cb=error_cb,
@@ -173,6 +182,7 @@ _COMMON_OPTS = [
     (("--subject",), dict(help="NATS subject to subscribe/filter (default: hive.{id}.>)")),
     (("--log-dir",), dict(help="Root directory for NDJSON session logs (default: historian/sessions)")),
     (("--basename",), dict(help="Log file basename (default: hive-{id}-coord)")),
+    (("--creds",), dict(help="Path to a NATS .creds file (JWT + nkey seed) for operator/JWT-mode servers - see elasticdotventures/_b00t_#1235. Falls back to CREDS_FILE env var. Omit for plain user/password auth (embedded in --nats-url)")),
 ]
 
 _ID_DEFAULT = os.environ.get("HISTORIAN_ID", "hive")


### PR DESCRIPTION
Progress on #1235 (not a full close — see below).

## What this adds

- `capability-forge/src/jwt_mint.rs`: new `mint_readonly_service_jwt()` —
  subscribe-only, publish **explicitly denied** via `deny_publish(">")`
  rather than merely omitted. This distinction is real: `nats-jwt` only
  emits a `nats.pub` permission block when `allow_publish`/`deny_publish`
  is called at least once — an omitted block means *unrestricted* access
  under NATS server semantics, not none. `mint_user_jwt`'s own doc
  comment already flags this exact gotcha for empty skill lists; this
  extends the same discipline to a genuinely read-only credential.
- `capability-forge/src/bin/mint_historian_creds.rs`: mints historian a
  read-only NATS user credential under an existing account (subscribes
  `hive.>`/`souls.>`/`vultr.>`/`b00t.hive.mesh.>`, publishes nothing),
  following `mint_service_creds.rs`'s exact existing pattern.
- `historian/bin/b00t_historian.py`: new `--creds`/`CREDS_FILE` option,
  passed through as `nats.connect()`'s `user_credentials` — the minted
  JWT/nkey creds file was otherwise unusable, since the previous version
  (from #1249) only supported plain user/password embedded in the
  connection URL. Plain auth still works when `--creds` isn't given.
- Added `nkeys` to `historian/bin/.venv` — required by `nats-py`'s
  JWT/nkey connect path, wasn't there before.

## Verified live, end-to-end (not just unit-level)

Bootstrapped a **throwaway** operator/account structure (`bootstrap_operator`,
not the real one) and ran a real `nats-server` in genuine operator/JWT
mode (matching vultr1's actual auth mode — this is what #1235 is about):

1. Minted historian a credential via `mint_historian_creds`, decoded the
   JWT and confirmed `{"pub":{"deny":[">"]}, "sub":{"allow":["hive.>",...]}}`
   — exactly right, not just claimed.
2. `b00t_historian.py --creds <file>` connected and authenticated
   successfully against the operator/JWT-mode server.
3. A message published by a *different* identity to `hive.historian.chat`
   was received and archived correctly to NDJSON.
4. Attempting to publish using historian's *own* credentials was rejected
   by the server itself: `Permissions Violation for Publish to
   "hive.historian.chat"` — the read-only enforcement is real, server-side,
   not merely cosmetic.

## What's NOT done here (still needed to actually close #1235)

The real `NATS_OPERATOR_SIGNING_SEED` (or an existing account seed) lives
in the org's secret store — a genuinely sensitive credential this PR
doesn't touch. Whoever has access needs to:

```sh
# 1. Get the operator's designated signing seed (not its root identity key)
export NATS_OPERATOR_SIGNING_SEED=<from secret store>

# 2. Mint a new dedicated HIVE account (recommended over reusing CAPFORGE -
#    keeps historian's traffic in its own trust boundary, see the #1235
#    comment thread for why)
CAPFORGE_ACCOUNT_NAME=HIVE cargo run -p capability-forge --bin mint_account
# -> prints the account entry to add to pods/nats/nats-pod-configured.yaml's
#    resolver_preload, and a HIVE account seed

# 3. Mint historian's actual credential under that new account
CAPFORGE_ACCOUNT_SEED=<HIVE account seed from step 2> \
  cargo run -p capability-forge --bin mint_historian_creds
# -> save the printed JWT+seed block as a .creds file

# 4. Update pods/nats/nats-pod-configured.yaml (add the HIVE account entry
#    from step 2), redeploy to the live vultr1 pod, then run
#    b00t_historian.py with --creds pointed at step 3's file.
```

Step 4 (live redeploy) is a real production NATS cutover — separate,
explicit go-ahead, not part of this PR.

https://claude.ai/code/session_01VcVRB8FYcM9Tw6LBpsDrAQ