### PR TITLE
fix(hive-watchdog): exempt the real generated unit name from self-stop

### DIFF
--- a/_b00t_/hive-watchdog.hive.toml
+++ b/_b00t_/hive-watchdog.hive.toml
@@ -25,6 +25,7 @@ environment = [
   "WATCHDOG_INTERVAL_SECS=15",
   "WATCHDOG_MAX_RESTARTS=5",
   "WATCHDOG_WINDOW_SECS=120",
+  "WATCHDOG_SELF_UNIT=b00t-hive-hive-watchdog.service",
 ]
 exec_start = "bash /home/brianh/.b00t/scripts/b00t-hive-watchdog.sh"
 


### PR DESCRIPTION
Profile `hive-watchdog` generates `b00t-hive-hive-watchdog.service` (doubled name), but the script default `WATCHDOG_SELF_UNIT=b00t-hive-watchdog.service` — a restart storm on the watchdog could make it stop itself. Pin the real generated name in the datum environment.

Follow-up to #1253. Verified: re-activated, generated unit carries the env, service active.

🤖 Generated with [Claude Code](https://claude.com/claude-code)