### PR TITLE
fix(b00t-pgduck): Describe-before-Execute mutex fix + split type-mapping into a lib target

### DIFF
--- a/b00t-pgduck/Cargo.toml
+++ b/b00t-pgduck/Cargo.toml
@@ -5,6 +5,10 @@ edition.workspace = true
 authors.workspace = true
 description = "Postgres-wire-protocol OLAP server backed by DuckDB - drop-in replacement for the pods/postgres service, no Postgres binary required"
 
+[lib]
+name = "b00t_pgduck"
+path = "src/lib.rs"
+
 [[bin]]
 name = "b00t-pgduck"
 path = "src/main.rs"

--- a/b00t-pgduck/src/lib.rs
+++ b/b00t-pgduck/src/lib.rs
@@ -1,0 +1,105 @@
+//! Pure, unit-testable pieces of b00t-pgduck split out of main.rs so this
+//! crate has a `[lib]` target at all - main.rs alone (bin-only) meant
+//! `cargo test --lib -p b00t-pgduck` (this repo's pre-push hook always
+//! runs `--lib`, see .git/hooks/pre-push) failed outright with "no
+//! library targets found", blocking every push touching this crate
+//! regardless of what changed. Everything here is connection/IO-free by
+//! design - the wire-protocol handler code in main.rs stays there and
+//! calls into this crate.
+
+use pgwire::api::Type;
+
+/// DuckDB's `column_type()` returns arrow's DataType, not a decl-type
+/// string like SQLite - map the common scalars pgwire's wire protocol
+/// has a real Type for; unmapped kinds (List/Struct/Array/Map/Union/
+/// Dictionary/etc) fall back to UNKNOWN rather than erroring, same "not
+/// all types" honesty as the upstream sqlite.rs example this was
+/// adapted from.
+pub fn arrow_type_to_pg_type(dt: &duckdb::arrow::datatypes::DataType) -> Type {
+    use duckdb::arrow::datatypes::DataType;
+    match dt {
+        DataType::Boolean => Type::BOOL,
+        DataType::Int8 | DataType::UInt8 => Type::CHAR,
+        DataType::Int16 | DataType::UInt16 => Type::INT2,
+        DataType::Int32 | DataType::UInt32 => Type::INT4,
+        DataType::Int64 | DataType::UInt64 => Type::INT8,
+        DataType::Float32 => Type::FLOAT4,
+        DataType::Float64 => Type::FLOAT8,
+        DataType::Utf8 | DataType::LargeUtf8 => Type::TEXT,
+        DataType::Binary | DataType::LargeBinary => Type::BYTEA,
+        DataType::Date32 | DataType::Date64 => Type::DATE,
+        DataType::Timestamp(_, _) => Type::TIMESTAMP,
+        _ => Type::UNKNOWN,
+    }
+}
+
+/// DuckDB's `DESCRIBE <query>` meta-statement returns column_type as
+/// free-form SQL type text (e.g. "INTEGER", "VARCHAR", "DECIMAL(10,2)"),
+/// not the typed arrow DataType arrow_type_to_pg_type maps above - match
+/// on the leading type name, ignoring any parenthesized precision/scale.
+/// Same "not all types" honesty as arrow_type_to_pg_type: unmapped kinds
+/// fall back to UNKNOWN.
+pub fn duckdb_type_str_to_pg_type(type_str: &str) -> Type {
+    let base = type_str.split('(').next().unwrap_or(type_str).trim().to_uppercase();
+    match base.as_str() {
+        "BOOLEAN" | "BOOL" => Type::BOOL,
+        "TINYINT" | "UTINYINT" => Type::CHAR,
+        "SMALLINT" | "USMALLINT" | "INT2" => Type::INT2,
+        "INTEGER" | "UINTEGER" | "INT" | "INT4" => Type::INT4,
+        "BIGINT" | "UBIGINT" | "INT8" | "HUGEINT" | "UHUGEINT" => Type::INT8,
+        "FLOAT" | "REAL" | "FLOAT4" => Type::FLOAT4,
+        "DOUBLE" | "FLOAT8" => Type::FLOAT8,
+        "VARCHAR" | "TEXT" | "STRING" | "CHAR" | "BPCHAR" => Type::TEXT,
+        "BLOB" | "BYTEA" | "VARBINARY" => Type::BYTEA,
+        "DATE" => Type::DATE,
+        "TIMESTAMP" | "TIMESTAMP WITH TIME ZONE" | "TIMESTAMPTZ" | "DATETIME" => Type::TIMESTAMP,
+        _ => Type::UNKNOWN,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn duckdb_type_str_maps_known_scalars() {
+        assert_eq!(duckdb_type_str_to_pg_type("INTEGER"), Type::INT4);
+        assert_eq!(duckdb_type_str_to_pg_type("BIGINT"), Type::INT8);
+        assert_eq!(duckdb_type_str_to_pg_type("VARCHAR"), Type::TEXT);
+        assert_eq!(duckdb_type_str_to_pg_type("BOOLEAN"), Type::BOOL);
+        assert_eq!(duckdb_type_str_to_pg_type("DOUBLE"), Type::FLOAT8);
+    }
+
+    #[test]
+    fn duckdb_type_str_strips_precision_scale() {
+        // DESCRIBE returns "DECIMAL(10,2)" for a scaled decimal column -
+        // the leading type name still has to match despite the suffix.
+        assert_eq!(duckdb_type_str_to_pg_type("VARCHAR(255)"), Type::TEXT);
+    }
+
+    #[test]
+    fn duckdb_type_str_falls_back_to_unknown() {
+        assert_eq!(duckdb_type_str_to_pg_type("DECIMAL(10,2)"), Type::UNKNOWN);
+        assert_eq!(duckdb_type_str_to_pg_type("STRUCT(a INTEGER)"), Type::UNKNOWN);
+    }
+
+    #[test]
+    fn duckdb_type_str_is_case_insensitive() {
+        assert_eq!(duckdb_type_str_to_pg_type("integer"), Type::INT4);
+        assert_eq!(duckdb_type_str_to_pg_type("Varchar"), Type::TEXT);
+    }
+
+    #[test]
+    fn arrow_type_maps_known_scalars() {
+        use duckdb::arrow::datatypes::DataType;
+        assert_eq!(arrow_type_to_pg_type(&DataType::Boolean), Type::BOOL);
+        assert_eq!(arrow_type_to_pg_type(&DataType::Int64), Type::INT8);
+        assert_eq!(arrow_type_to_pg_type(&DataType::Utf8), Type::TEXT);
+    }
+
+    #[test]
+    fn arrow_type_falls_back_to_unknown() {
+        use duckdb::arrow::datatypes::DataType;
+        assert_eq!(arrow_type_to_pg_type(&DataType::Null), Type::UNKNOWN);
+    }
+}

--- a/b00t-pgduck/src/main.rs
+++ b/b00t-pgduck/src/main.rs
@@ -59,6 +59,8 @@ use pgwire::error::{PgWireError, PgWireResult};
 use pgwire::messages::data::DataRow;
 use pgwire::tokio::process_socket;
 
+use b00t_pgduck::{arrow_type_to_pg_type, duckdb_type_str_to_pg_type};
+
 pub struct DuckDbBackend {
     conn: Arc<Mutex<Connection>>,
     query_parser: Arc<NoopQueryParser>,
@@ -112,29 +114,6 @@ impl SimpleQueryHandler for DuckDbBackend {
                 })
                 .map_err(|e| PgWireError::ApiError(Box::new(e)))
         }
-    }
-}
-
-// DuckDB's column_type() returns arrow's DataType, not a decl-type string
-// like SQLite - map the common scalars pgwire's wire protocol has a real
-// Type for; unmapped kinds (List/Struct/Array/Map/Union/Dictionary/etc)
-// fall back to UNKNOWN rather than erroring, same "not all types" honesty
-// as the upstream sqlite.rs example this was adapted from.
-fn arrow_type_to_pg_type(dt: &duckdb::arrow::datatypes::DataType) -> Type {
-    use duckdb::arrow::datatypes::DataType;
-    match dt {
-        DataType::Boolean => Type::BOOL,
-        DataType::Int8 | DataType::UInt8 => Type::CHAR,
-        DataType::Int16 | DataType::UInt16 => Type::INT2,
-        DataType::Int32 | DataType::UInt32 => Type::INT4,
-        DataType::Int64 | DataType::UInt64 => Type::INT8,
-        DataType::Float32 => Type::FLOAT4,
-        DataType::Float64 => Type::FLOAT8,
-        DataType::Utf8 | DataType::LargeUtf8 => Type::TEXT,
-        DataType::Binary | DataType::LargeBinary => Type::BYTEA,
-        DataType::Date32 | DataType::Date64 => Type::DATE,
-        DataType::Timestamp(_, _) => Type::TIMESTAMP,
-        _ => Type::UNKNOWN,
     }
 }
 
@@ -350,29 +329,6 @@ fn describe_query_fields(conn: &Connection, query: &str) -> PgWireResult<Vec<Fie
         idx += 1;
     }
     Ok(fields)
-}
-
-// DESCRIBE's column_type comes back as free-form SQL type text (e.g.
-// "INTEGER", "VARCHAR", "DECIMAL(10,2)"), not the typed arrow DataType
-// arrow_type_to_pg_type maps above - match on the leading type name,
-// ignoring any parenthesized precision/scale. Same "not all types"
-// honesty as arrow_type_to_pg_type: unmapped kinds fall back to UNKNOWN.
-fn duckdb_type_str_to_pg_type(type_str: &str) -> Type {
-    let base = type_str.split('(').next().unwrap_or(type_str).trim().to_uppercase();
-    match base.as_str() {
-        "BOOLEAN" | "BOOL" => Type::BOOL,
-        "TINYINT" | "UTINYINT" => Type::CHAR,
-        "SMALLINT" | "USMALLINT" | "INT2" => Type::INT2,
-        "INTEGER" | "UINTEGER" | "INT" | "INT4" => Type::INT4,
-        "BIGINT" | "UBIGINT" | "INT8" | "HUGEINT" | "UHUGEINT" => Type::INT8,
-        "FLOAT" | "REAL" | "FLOAT4" => Type::FLOAT4,
-        "DOUBLE" | "FLOAT8" => Type::FLOAT8,
-        "VARCHAR" | "TEXT" | "STRING" | "CHAR" | "BPCHAR" => Type::TEXT,
-        "BLOB" | "BYTEA" | "VARBINARY" => Type::BYTEA,
-        "DATE" => Type::DATE,
-        "TIMESTAMP" | "TIMESTAMP WITH TIME ZONE" | "TIMESTAMPTZ" | "DATETIME" => Type::TIMESTAMP,
-        _ => Type::UNKNOWN,
-    }
 }
 
 impl DuckDbBackend {

--- a/b00t-pgduck/src/main.rs
+++ b/b00t-pgduck/src/main.rs
@@ -267,24 +267,23 @@ impl ExtendedQueryHandler for DuckDbBackend {
         }
     }
 
-    // KNOWN LIMITATION: unlike SQLite, DuckDB only exposes column
-    // metadata (column_type/column_name) AFTER a statement has executed
-    // - calling them on a freshly-prepared, unexecuted statement panics
-    // (confirmed empirically: duckdb-1.10505.0/src/raw_statement.rs:138,
-    // "The statement was not executed yet"). do_query works around this
-    // by reading the descriptor back via Rows::as_ref() post-execution
-    // (see row_desc_from_stmt call sites above), but Describe messages
-    // are protocol-level "tell me the result shape before I Execute"
-    // requests - there's no post-execution Rows to read from yet here.
-    // A client that issues Describe before Execute on a SELECT (some
-    // prepared-statement/ORM code paths do) will panic this connection's
-    // task. Not fixed: wrapping in catch_unwind risks poisoning the
-    // shared Mutex<Connection> for every other query on this connection
-    // if the panic happens mid-lock, which is worse than the current
-    // single-connection crash. Forgejo's own migration+startup e2e test
-    // (see infrastructure repo's pods/pgduck/test-forgejo-e2e.sh) passes
-    // clean, so this gap doesn't block that specific consumer - but it's
-    // a real, disclosed gap for others.
+    // Previously panicked here: unlike SQLite, DuckDB only exposes column
+    // metadata (column_type/column_name) on a Statement AFTER it has
+    // executed - calling them on a freshly-prepared, unexecuted statement
+    // panics (confirmed empirically: duckdb-1.10505.0/src/raw_statement.rs:138,
+    // "The statement was not executed yet"). Describe protocol messages
+    // arrive before Execute, so there's no post-execution Rows to read a
+    // descriptor from the real statement. Broke live 2026-09-02: Forgejo's
+    // Postgres driver issues Describe before Execute on its startup
+    // queries, the panic poisoned the shared Mutex<Connection>, and every
+    // subsequent connection to this server failed too (not just the one
+    // that panicked - a shared connection, so a mid-lock panic doesn't
+    // stay contained to a single client). Fixed for real via
+    // describe_query_fields below: DuckDB's own `DESCRIBE <query>`
+    // meta-statement returns the result shape (as a real, executed query
+    // against a different, always-safe statement) without running the
+    // original query's side effects or ever touching the not-yet-executed
+    // Statement's own column_type/column_name.
     async fn do_describe_statement<C>(
         &self,
         _client: &mut C,
@@ -299,10 +298,8 @@ impl ExtendedQueryHandler for DuckDbBackend {
             .iter()
             .map(|t| t.clone().unwrap_or(Type::UNKNOWN))
             .collect();
-        let prepared = conn
-            .prepare(&stmt.statement)
-            .map_err(|e| PgWireError::ApiError(Box::new(e)))?;
-        row_desc_from_stmt(&prepared).map(|fields| DescribeStatementResponse::new(param_types, fields))
+        let fields = describe_query_fields(&conn, &stmt.statement)?;
+        Ok(DescribeStatementResponse::new(param_types, fields))
     }
 
     async fn do_describe_portal<C>(
@@ -314,10 +311,67 @@ impl ExtendedQueryHandler for DuckDbBackend {
         C: ClientInfo + Unpin + Send + Sync,
     {
         let conn = self.conn.lock().unwrap();
-        let stmt = conn
-            .prepare(&portal.statement.statement)
-            .map_err(|e| PgWireError::ApiError(Box::new(e)))?;
-        row_desc_from_stmt(&stmt).map(DescribePortalResponse::new)
+        let fields = describe_query_fields(&conn, &portal.statement.statement)?;
+        Ok(DescribePortalResponse::new(fields))
+    }
+}
+
+// See do_describe_statement's comment above for why this exists instead
+// of preparing+describing the real statement directly. `DESCRIBE <query>`
+// is itself a real, executable DuckDB statement (returns column_name,
+// column_type as text, null, key, default, extra - one row per result
+// column of the wrapped query) - .query()ing it is safe under the same
+// "only read metadata after executing" rule the panic above enforces,
+// because DESCRIBE's own result rows ARE what we read, not the wrapped
+// query's.
+fn describe_query_fields(conn: &Connection, query: &str) -> PgWireResult<Vec<FieldInfo>> {
+    let format = Format::UnifiedText;
+    // Not every statement DuckDB accepts is describable this way (e.g.
+    // some DDL) - no result columns is a valid, non-error Describe
+    // response for those, matching what Postgres itself returns for an
+    // INSERT/DDL statement with no RETURNING clause.
+    let mut stmt = match conn.prepare(&format!("DESCRIBE {query}")) {
+        Ok(s) => s,
+        Err(_) => return Ok(Vec::new()),
+    };
+    let mut rows = stmt.query(duckdb::params![]).map_err(|e| PgWireError::ApiError(Box::new(e)))?;
+    let mut fields = Vec::new();
+    let mut idx = 0usize;
+    while let Ok(Some(row)) = rows.next() {
+        let name: String = row.get(0).map_err(|e| PgWireError::ApiError(Box::new(e)))?;
+        let type_str: String = row.get(1).map_err(|e| PgWireError::ApiError(Box::new(e)))?;
+        fields.push(FieldInfo::new(
+            name,
+            None,
+            None,
+            duckdb_type_str_to_pg_type(&type_str),
+            format.format_for(idx),
+        ));
+        idx += 1;
+    }
+    Ok(fields)
+}
+
+// DESCRIBE's column_type comes back as free-form SQL type text (e.g.
+// "INTEGER", "VARCHAR", "DECIMAL(10,2)"), not the typed arrow DataType
+// arrow_type_to_pg_type maps above - match on the leading type name,
+// ignoring any parenthesized precision/scale. Same "not all types"
+// honesty as arrow_type_to_pg_type: unmapped kinds fall back to UNKNOWN.
+fn duckdb_type_str_to_pg_type(type_str: &str) -> Type {
+    let base = type_str.split('(').next().unwrap_or(type_str).trim().to_uppercase();
+    match base.as_str() {
+        "BOOLEAN" | "BOOL" => Type::BOOL,
+        "TINYINT" | "UTINYINT" => Type::CHAR,
+        "SMALLINT" | "USMALLINT" | "INT2" => Type::INT2,
+        "INTEGER" | "UINTEGER" | "INT" | "INT4" => Type::INT4,
+        "BIGINT" | "UBIGINT" | "INT8" | "HUGEINT" | "UHUGEINT" => Type::INT8,
+        "FLOAT" | "REAL" | "FLOAT4" => Type::FLOAT4,
+        "DOUBLE" | "FLOAT8" => Type::FLOAT8,
+        "VARCHAR" | "TEXT" | "STRING" | "CHAR" | "BPCHAR" => Type::TEXT,
+        "BLOB" | "BYTEA" | "VARBINARY" => Type::BYTEA,
+        "DATE" => Type::DATE,
+        "TIMESTAMP" | "TIMESTAMP WITH TIME ZONE" | "TIMESTAMPTZ" | "DATETIME" => Type::TIMESTAMP,
+        _ => Type::UNKNOWN,
     }
 }
 


### PR DESCRIPTION
Two commits:

**`f547d1c2` — stop Describe-before-Execute from poisoning the shared connection mutex** (pre-existing, was only local).

**`c33f5ba3` — split type-mapping fns into a lib target** (from a parked stash). `main.rs` was bin-only, so the repo's pre-push hook (`cargo test --lib -p b00t-pgduck`) failed *"no library targets found"* and blocked every push touching this crate. Moves the two pure, IO-free type-mapping fns (`arrow_type_to_pg_type`, `duckdb_type_str_to_pg_type`) into `src/lib.rs`, adds a `[lib]` target, imports them back into `main.rs`. Byte-identical fn bodies, call sites unchanged.

⚠️ `cargo check` could not be run locally — the host rust toolchain is broken (`~/.cargo/bin/cargo → rustup` dangling; same reason the pre-commit/pre-push hooks fail with `cargo: command not found`). Verified by inspection only. **CI should confirm it compiles.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)