### PR TITLE
feat(inference): qwen38-27b -np 2 so pi + opencode co-reside on :8001

### DIFF
--- a/_b00t_/inference-qwen38-27b.hive.toml
+++ b/_b00t_/inference-qwen38-27b.hive.toml
@@ -1,7 +1,7 @@
 # b00t Hive Profile — Qwen3.8-27B llama.cpp via Podman, weights on /c0de PCIe flash
 # 🤓 Replaces inference-qwen36-27b-mtp-podman as the exclusive local ch0nky slot.
 #    Qwen3.8-27B is dense (no MTP head in unsloth/Qwen3.8-27B-GGUF) → plain llama.cpp,
-#    no --spec-type. UD-Q4_K_XL (17.56GB) + KV@40K q8_0 (~3GB) ≈ 21GB VRAM on the 3090.
+#    no --spec-type. UD-Q4_K_XL (17.56GB) + KV@81920 q8_0 (2 slots x 40960) ~ 20.4GB VRAM on the 3090.
 #    Weights live on /c0de/models/qwen38-27b (fast NVMe) — NOT the HF cache — so the
 #    17GB file never sits in system page-cache under memory pressure (see the tmpfs/OOM
 #    lesson) and cold-load is disk-fast.
@@ -58,14 +58,14 @@ exec_start = """/usr/bin/podman run --rm \
   --host 0.0.0.0 --port 8080 \
   --alias ch0nky \
   -m /models/Qwen3.8-27B-UD-Q4_K_XL.gguf \
-  -c 40960 \
+  -c 81920 \
   -b 4096 \
   -ub 1024 \
   -ngl 99 \
   -fa on \
   --cache-type-k q8_0 \
   --cache-type-v q8_0 \
-  -np 1 \
+  -np 2 \
   --jinja \
   --reasoning off \
   --reasoning-format deepseek \
@@ -76,10 +76,11 @@ exec_start = """/usr/bin/podman run --rm \
   --repeat-penalty 1.05"""
 # 🤓 --alias ch0nky: /v1/models reports "ch0nky" so opencode `qwen36-local/ch0nky`
 #    and pi `--model ch0nky` keep working unchanged — only the weights behind :8001 change.
-# 🤓 no --spec-type: Qwen3.8-27B dense, no MTP draft head. If throughput needs a boost,
-#    add a small draft model (Qwen3-0.6B) with --model-draft, not draft-mtp.
-# 🤓 KV q8_0 (not q4_0): we have ~6.4GB VRAM headroom after weights; q8_0 KV is higher
-#    quality and 40K ctx is plenty for a coding agent.
+# 🤓 no --spec-type: Qwen3.8-27B dense, no MTP draft head.
+# 🤓 -np 2 + -c 81920: two 40960-token slots so pi (b00t-hive-pi-agent) and
+#    opencode (b00t-hive-opencode-agent) can co-reside on :8001 instead of evicting
+#    each other. Per-slot 40960 matches opencode.json's declared ch0nky context limit.
+#    KV q8_0; VRAM verified ~20.4GB used, fits the 24GB 3090.
 # 🤓 sampling: Qwen3.8 non-thinking recommended (temp 0.7 / top_p 0.8 / top_k 20).
 
 [b00t.hive.env]

--- a/_b00t_/pi.agent.toml
+++ b/_b00t_/pi.agent.toml
@@ -38,9 +38,9 @@ cli_path = "pi"
 cli_args = ["-p", "--provider", "llama-cpp", "--model", "ch0nky"]
 supports_tools = ["read", "write", "bash", "grep", "ls"]
 max_iterations = 10
-requires = ["b00t-hive-inference-qwen36-35b-a3b-llamacpp.service"]
+requires = ["b00t-hive-inference-qwen38-27b.service"]
 # hive_profile activates the currently preferred ch0nky local model before invocation
-hive_profile = "inference-qwen36-35b-a3b-llamacpp"
+hive_profile = "inference-qwen38-27b"
 
 [b00t.agent.ipc]
 # 🤓 pi --mode rpc exposes stdio RPC; pi-mcp-adapter bridges to MCP clients
@@ -82,14 +82,14 @@ service_type = "simple"
 restart = "on-failure"
 restart_sec = "10s"
 timeout_start_sec = "60"
-after = ["network.target", "b00t-hive-inference-qwen36-35b-a3b-llamacpp.service"]
+after = ["network.target", "b00t-hive-inference-qwen38-27b.service"]
 environment = [
   "PATH=/home/brianh/.nvm/versions/node/v22.15.1/bin:/usr/local/bin:/usr/bin:/bin",
   "LLAMA_CPP_BASE_URL=http://127.0.0.1:8001/v1",
   # 🤓 OPENAI_API_KEY sourced from .env / CMDB; local llama.cpp proxy accepts any non-empty string
-  "OPENAI_API_KEY=${OPENAI_API_KEY:-local-b00t}",
+  "OPENAI_API_KEY=local-b00t",
 ]
-exec_start = "pi --mode rpc --provider llama-cpp --model ch0nky"
+exec_start = "/home/brianh/.local/bin/pi-rpc-socket.sh"
 
 [b00t.hive.resources]
 ram_gb = 1
@@ -101,8 +101,9 @@ ram_free_gb = 1
 gpu_free_mb = 0
 
 [b00t.hive.exclusion]
-# 🤓 only one ch0nky coding-agent service active at a time; pi and opencode are mutually exclusive
-group = "ch0nky-coding-agent"
+# 🤓 2026-09-03: llama.cpp bumped to -np 2 (qwen38-27b unit) so pi + opencode can co-reside on :8001;
+# pi given its own exclusion group (was shared "ch0nky-coding-agent") to stop hive evicting opencode-agent on start
+group = "ch0nky-coding-agent-pi"
 priority = 50
 
 [b00t.env]


### PR DESCRIPTION
Bumps the local Qwen3.8-27B inference unit to 2 parallel slots so `b00t-hive-pi-agent` and `b00t-hive-opencode-agent` can both use :8001 instead of the hive evicting one when the other starts.

- `inference-qwen38-27b.hive.toml`: `-np 1→2`, `-c 40960→81920` (two 40960-token slots — per-slot matches `opencode.json` ch0nky limit). VRAM verified ~20.4GB / 24GB.
- `pi.agent.toml`: retarget to `inference-qwen38-27b`, `exec_start` → `pi-rpc-socket.sh` (socat wrapper; `pi --mode rpc` has no native listen mode), own exclusion group `ch0nky-coding-agent-pi`.

The running :8001 container is already `-np 2 / -c 81920` — this syncs the datums to live state (next `hive activate` is a no-op).

🤖 Generated with [Claude Code](https://claude.com/claude-code)