### PR TITLE
feat(inference): qwen38-27b context 40K/slot -> 96K/slot

### DIFF
--- a/_b00t_/inference-qwen38-27b.hive.toml
+++ b/_b00t_/inference-qwen38-27b.hive.toml
@@ -1,7 +1,7 @@
 # b00t Hive Profile — Qwen3.8-27B llama.cpp via Podman, weights on /c0de PCIe flash
 # 🤓 Replaces inference-qwen36-27b-mtp-podman as the exclusive local ch0nky slot.
 #    Qwen3.8-27B is dense (no MTP head in unsloth/Qwen3.8-27B-GGUF) → plain llama.cpp,
-#    no --spec-type. UD-Q4_K_XL (17.56GB) + KV@81920 q8_0 (2 slots x 40960) ~ 20.4GB VRAM on the 3090.
+#    no --spec-type. UD-Q4_K_XL (17.56GB) + KV@196608 q4_0 (2 slots x 98304) ~ 21GB VRAM on the 3090.
 #    Weights live on /c0de/models/qwen38-27b (fast NVMe) — NOT the HF cache — so the
 #    17GB file never sits in system page-cache under memory pressure (see the tmpfs/OOM
 #    lesson) and cold-load is disk-fast.
@@ -58,13 +58,13 @@ exec_start = """/usr/bin/podman run --rm \
   --host 0.0.0.0 --port 8080 \
   --alias ch0nky \
   -m /models/Qwen3.8-27B-UD-Q4_K_XL.gguf \
-  -c 81920 \
+  -c 196608 \
   -b 4096 \
   -ub 1024 \
   -ngl 99 \
   -fa on \
-  --cache-type-k q8_0 \
-  --cache-type-v q8_0 \
+  --cache-type-k q4_0 \
+  --cache-type-v q4_0 \
   -np 2 \
   --jinja \
   --reasoning off \
@@ -77,10 +77,11 @@ exec_start = """/usr/bin/podman run --rm \
 # 🤓 --alias ch0nky: /v1/models reports "ch0nky" so opencode `qwen36-local/ch0nky`
 #    and pi `--model ch0nky` keep working unchanged — only the weights behind :8001 change.
 # 🤓 no --spec-type: Qwen3.8-27B dense, no MTP draft head.
-# 🤓 -np 2 + -c 81920: two 40960-token slots so pi (b00t-hive-pi-agent) and
-#    opencode (b00t-hive-opencode-agent) can co-reside on :8001 instead of evicting
-#    each other. Per-slot 40960 matches opencode.json's declared ch0nky context limit.
-#    KV q8_0; VRAM verified ~20.4GB used, fits the 24GB 3090.
+# 🤓 -np 2 + -c 196608: two 98304-token (96K) slots so pi (b00t-hive-pi-agent)
+#    and opencode (b00t-hive-opencode-agent) co-reside on :8001 AND each gets a
+#    whole-repo-sized window. KV is q4_0 (half of q8_0) to buy the context —
+#    ~2.85GB KV vs ~2.4GB before, total ~21GB / 24GB, ~3GB margin. Qwen3.8-27B's
+#    native context is 262K, so -c can go higher if VRAM frees up (watch OOM).
 # 🤓 sampling: Qwen3.8 non-thinking recommended (temp 0.7 / top_p 0.8 / top_k 20).
 
 [b00t.hive.env]

--- a/_b00t_/qwen38-local.ai.toml
+++ b/_b00t_/qwen38-local.ai.toml
@@ -15,7 +15,7 @@ aliases = ["ch0nky-local", "qwen38"]
 provider = "openai_compatible"
 api_type = "openai_compatible"
 models = ["ch0nky", "Qwen3.8-27B-UD-Q4_K_XL.gguf"]
-context_window = 40960          # -c 40960 (Qwen3.8 native 262K; capped for VRAM)
+context_window = 98304          # -c 196608 / -np 2 = 96K per slot (Qwen3.8 native 262K)
 pricing_model = "local"
 
 [b00t.env.defaults]


### PR DESCRIPTION
Two 40960-token slots is too small for whole-repo coding work.

- `inference-qwen38-27b.hive.toml`: `-c 81920 → 196608` (with `-np 2` = 98304 / 96K per slot), KV `q8_0 → q4_0` (half the bytes) to pay for it. Est ~21GB / 24GB VRAM, ~3GB margin. Native ctx is 262K — room to push higher later.
- `qwen38-local.ai.toml`: `context_window 40960 → 98304`.

Applied + VRAM-verified on activate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)