### PR TITLE
feat(moltis): bump vendor pin +6mo, overlap analysis, standing-task profile

### DIFF
--- a/_b00t_/moltis-standing-tasks.hive.toml
+++ b/_b00t_/moltis-standing-tasks.hive.toml
@@ -1,0 +1,82 @@
+# b00t Hive Profile — moltis standing tasks (the hive's operator-facing heartbeat)
+# 🤓 moltis is the only hive agent with channel-aware durable cron + human comms
+#    (Slack/WhatsApp/telephony/voice/email). Its recurring jobs deliver hive state
+#    to humans — work `b00t task` (machine queue) deliberately does NOT do.
+#    Jobs run on moltis's own `moltis-cron` crate (sqlite-backed, survives restart),
+#    NOT systemd timers. This profile just ensures the moltis agent host is up and
+#    documents the schedule.
+# 🔗参 _b00t_/moltis.agent.toml — the agent + service spec
+# 🔗参 docs/moltis-b00t-integration.md — overlap analysis + rationale
+
+[b00t]
+name = "moltis-standing-tasks"
+type = "hive_profile"
+hint = "moltis recurring hive-ops jobs — health digest, PR triage, vendor-drift, crash escalation; via moltis-cron"
+
+[b00t.hive.resources]
+ram_gb    = 2
+gpu_mb    = 0
+cpu_cores = 1
+
+[b00t.hive.resources.gate]
+ram_free_gb = 2
+gpu_free_mb = 0
+
+[b00t.hive.exclusion]
+group    = "moltis-agent"
+priority = 40
+
+[b00t.hive.services]
+# 🤓 reuse the moltis agent unit as the cron host; this profile only asserts it's running
+start = ["b00t@moltis-agent.service"]
+stop  = []
+
+# ── Standing jobs (registered into moltis-cron once, on activate) ─────────────
+# Each is `moltis cron add --name <name> --schedule '<cron>' --channel '<ch>' -- '<prompt/cmd>'`
+# Delivery channel is a moltis connector id (configure in moltis Settings first).
+
+[[b00t.usage]]
+description = "hive-health-digest — hourly GPU/service/watchdog snapshot to ops channel"
+command = """moltis cron add --name hive-health-digest --schedule '0 * * * *' --channel ops -- \
+'Run: b00t-cli hive status; tail -n 40 /home/brianh/.b00t/.b00t/hive-watchdog.jsonl; \
+timeout 3 nats sub b00t.hive.mesh.health.> . Summarise GPU heat/temp/util, each hive \
+service active/failed, any crashloop events, and NRestarts deltas. <=12 lines.'"""
+
+[[b00t.usage]]
+description = "pr-triage — daily 09:00 unreviewed/mergeable/stale PRs + forecast accuracy"
+command = """moltis cron add --name pr-triage --schedule '0 9 * * *' --channel ops -- \
+'Run: gh pr list --state open --json number,title,reviewDecision,mergeable; b00t-cli task list --filter pending; \
+tail -n 50 /home/brianh/.b00t/.b00t/forecasts.jsonl. Report PRs with no review, mergeable ones, \
+stale branches, and forecast abs-error trend. File a b00t task for anything needing a human.'"""
+
+[[b00t.usage]]
+description = "vendor-drift-watch — weekly Mon, submodule pins vs origin/main"
+command = """moltis cron add --name vendor-drift-watch --schedule '0 8 * * 1' --channel ops -- \
+'For each path in .gitmodules: git -C <path> fetch -q; compare HEAD to origin/main; \
+report modules that advanced with the commit range and count. File a b00t task per drifted module.'"""
+
+[[b00t.usage]]
+description = "soul-snapshot — daily 23:00 export moltis/ namespace to a git-committed archive"
+command = """moltis cron add --name soul-snapshot --schedule '0 23 * * *' -- \
+'Export the moltis/ key namespace from soul http://127.0.0.1:7700 to JSONL + Markdown; \
+git add + commit to docs/moltis-soul-archive/.'"""
+
+[[b00t.usage]]
+description = "crash-escalation — EVENT (not cron): phone the operator on a crashloop trip"
+command = """moltis cron add --name crash-escalation --event 'nats:b00t.hive.mesh.health.crashloop' --channel phone -- \
+'A hive service is crash-looping: {payload}. Place a Twilio call and send a WhatsApp to the operator with the unit name and last watchdog line.'"""
+
+[[b00t.usage]]
+description = "List / remove moltis cron jobs"
+command = "moltis cron list ; moltis cron remove --name <name>"
+
+[[b00t.usage]]
+description = "Activate (ensure moltis agent host is up; register jobs manually per above)"
+command = "b00t-cli hive activate moltis-standing-tasks"
+
+# b00t:map v1
+# summary: moltis standing tasks — hourly health digest, daily PR triage, weekly vendor-drift, daily soul snapshot, event-driven crash phone-escalation; runs on moltis-cron
+# tags: moltis, cron, standing-tasks, hive-ops, slack, telephony, recurring, watchdog, pr-triage, vendor-drift
+# tier: ch0nky
+# cmds: b00t-cli hive activate moltis-standing-tasks, moltis cron list
+# complexity: 5

--- a/_b00t_/moltis.agent.toml
+++ b/_b00t_/moltis.agent.toml
@@ -2,7 +2,7 @@
 # 🤓 moltis is a Rust-native binary from vendor/moltis-b00t submodule
 #    Repo: elasticdotventures/moltis-b00t (submodule; matches .gitmodules; fork of moltis-org/moltis)
 #    Soul/memory backend: b00t soul serve HTTP K/V on :7700
-#    Hive: shares :1234 litellm gateway
+#    Model: live ch0nky slot :8001 (qwen38-27b, --alias ch0nky) — same endpoint as opencode/pi
 #    Build: cargo build --manifest-path vendor/moltis-b00t/Cargo.toml --release
 #    https://github.com/elasticdotventures/moltis-b00t
 
@@ -19,7 +19,7 @@ from = "++abstract.agent"
 [b00t.agent]
 pid = "moltis-001"
 branch = "main"
-# 🤓 ch0nky tier — shares :1234 litellm gateway with hive
+# 🤓 ch0nky tier — model served by the live :8001 ch0nky slot (qwen38-27b)
 model = "ch0nky"
 skills = ["voice", "memory", "mcp-tools", "multi-channel"]
 personality = "pragmatic"
@@ -86,8 +86,8 @@ after = ["network.target", "b00t-soul.service"]
 environment = [
   "PATH=/home/brianh/.cargo/bin:/usr/local/bin:/usr/bin:/bin",
   "MOLTIS_SOUL_URL=http://127.0.0.1:7700",
-  "OPENAI_BASE_URL=http://127.0.0.1:1234/v1",
-  "OPENAI_API_KEY=local-litellm",
+  "OPENAI_BASE_URL=http://127.0.0.1:8001/v1",
+  "OPENAI_API_KEY=local-b00t",
 ]
 exec_start = "vendor/moltis-b00t/target/release/moltis"
 
@@ -111,8 +111,8 @@ AGENT_ID = "moltis"
 AGENT_SKILLS = "code,voice,memory,mcp-tools,multi-channel,sandbox"
 MOLTIS_DIR = "vendor/moltis-b00t"
 MOLTIS_SOUL_URL = "http://127.0.0.1:7700"
-OPENAI_BASE_URL = "http://127.0.0.1:1234/v1"
-OPENAI_API_KEY = "local-litellm"
+OPENAI_BASE_URL = "http://127.0.0.1:8001/v1"
+OPENAI_API_KEY = "local-b00t"
 
 [[b00t.usage]]
 description = "Build moltis binary from vendor submodule"
@@ -135,7 +135,7 @@ description = "Stop moltis agent service"
 command = "systemctl --user stop b00t@moltis-agent.service"
 
 # b00t:map v1
-# summary: moltis Rust-native claw — sandboxed, secure, auditable; voice+memory+MCP+multi-channel; soul K/V :7700; litellm :1234
+# summary: moltis Rust-native claw — sandboxed, secure, auditable; voice+memory+MCP+multi-channel; soul K/V :7700; ch0nky :8001
 # tags: moltis, agent, rust, soul, kv, memory, mcp-tools, voice, multi-channel, ch0nky, hive
 # tier: ch0nky
 # cmds: just moltis-build | just moltis-run | just moltis-soul-test

--- a/_b00t_/moltis.agent.toml
+++ b/_b00t_/moltis.agent.toml
@@ -1,10 +1,10 @@
 # b00t Agent Datum — moltis as first-class hive sub-agent
 # 🤓 moltis is a Rust-native binary from vendor/moltis-b00t submodule
-#    Repo: promptexecution/moltis-b00t (submodule at vendor/moltis-b00t)
+#    Repo: elasticdotventures/moltis-b00t (submodule; matches .gitmodules; fork of moltis-org/moltis)
 #    Soul/memory backend: b00t soul serve HTTP K/V on :7700
 #    Hive: shares :1234 litellm gateway
 #    Build: cargo build --manifest-path vendor/moltis-b00t/Cargo.toml --release
-#    https://github.com/promptexecution/moltis-b00t
+#    https://github.com/elasticdotventures/moltis-b00t
 
 [b00t]
 name = "moltis"

--- a/docs/moltis-b00t-integration.md
+++ b/docs/moltis-b00t-integration.md
@@ -1,6 +1,8 @@
 # moltis ⇄ b00t — capability overlap & standing-task integration
 
-`vendor/moltis-b00t` (submodule, remote `app4dog/moltis-b00t`, upstream `moltis-org`)
+`vendor/moltis-b00t` (submodule; `.gitmodules` → `elasticdotventures/moltis-b00t`, a
+fork of `moltis-org/moltis`; some checkouts locally override `.git/config` to the
+synced `app4dog/moltis-b00t` fork)
 had drifted ~40 commits / 7 weeks past the b00t pin `5d171bb1` (2026-07-15).
 This bumps it to `4829e6a7` (2026-09-02) and proposes how moltis earns a standing
 seat in the hive.
@@ -54,8 +56,9 @@ Config surface: `_b00t_/moltis-standing-tasks.hive.toml` (this PR) lists the job
 `b00t hive activate moltis-standing-tasks`.
 
 ## Follow-ups (not in this PR)
-- `.gitmodules` / `moltis.agent.toml` name the remote as `elasticdotventures` /
-  `promptexecution`; actual is `app4dog/moltis-b00t` (upstream `moltis-org`). Reconcile.
+- Vendor link reconciled: `.gitmodules` + `moltis.agent.toml` now both point at
+  `elasticdotventures/moltis-b00t` (fork of `moltis-org/moltis`). Local `.git/config`
+  may still override to the synced `app4dog/moltis-b00t` — run `git submodule sync` to reset.
 - `moltis.agent.toml` points model at litellm `:1234` / `local-litellm`; the live
   gateway is `cli-proxy-api` `:1234` and the local slot is qwen38 `:8001`. Re-point.
 - Register moltis in `b00t chat` / the ACP mesh now that `crates/acp` is stdio-ready.

--- a/docs/moltis-b00t-integration.md
+++ b/docs/moltis-b00t-integration.md
@@ -1,0 +1,61 @@
+# moltis ⇄ b00t — capability overlap & standing-task integration
+
+`vendor/moltis-b00t` (submodule, remote `app4dog/moltis-b00t`, upstream `moltis-org`)
+had drifted ~40 commits / 7 weeks past the b00t pin `5d171bb1` (2026-07-15).
+This bumps it to `4829e6a7` (2026-09-02) and proposes how moltis earns a standing
+seat in the hive.
+
+## What moltis added in the last ~6 months (since the pin)
+
+| Area | Notable commits |
+|---|---|
+| **ACP** | `feat(acp): expose Moltis as an ACP agent over stdio` (#1169, new `crates/acp/`), auto-detect ACP agents (#1149), model/effort selection for external agents (#1125), MiniMax Code ACP agent (#1204) |
+| **Sandbox** | remote & multi-backend sandbox — Vercel/Daytona/Firecracker (#942), Podman escape hatches (#1106), per-agent runtime limits (#1066), per-turn tool controls (#1069), "agents as capability boundaries: MCP/sandbox/skills" (#1049) |
+| **Cron** | `crates/cron/` — durable (sqlite/file/memory stores), heartbeat, schedule parser, `system_events`; channel-context-aware delivery (#1226, #1243) |
+| **Memory** | `B00tSoulWriter` adapter → b00t soul :7700 (the pin), **`zvec` vector-DB memory backend** (#1158) |
+| **Channels** | Slack native live task cards + Block Kit + reaction triggers + reconnect supervision (#1166/#1195/#1238), WhatsApp LID-native addressing + media streaming (#1144/#1228/#1233), Nostr NIP-29 groups (#1168), durable calendar/channel/email connectors (#1190), **telephony via Twilio** (#920), Fastmail MCP OAuth |
+| **Voice** | whisper-local STT provider (#981), OpenAI realtime guidance (#984) |
+| **Providers** | GPT-5.6, Kimi K3, MiniMax M3, NEAR AI Cloud, Luna routing |
+| **Ops** | feedback-collection infra (#1174), managed Files library + Settings browser (#1206), Markdown copy + session export (#1176), Ed25519 challenge-response node identity / TOFU (#979), NetBird + Cloudflare Tunnel remote access (#1002/#1008) |
+
+Workspace is ~270K LOC across 59 crates; agent runner ~7.5K LOC.
+
+## Overlap with b00t
+
+| moltis | nearest b00t | verdict |
+|---|---|---|
+| Multi-channel human comms (Slack/WhatsApp/Matrix/Nostr/telephony/voice/email/CalDAV) | *none* — b00t is CLI / MCP / NATS | **No overlap. moltis is the hive's human front-door.** |
+| ACP agent over stdio (`crates/acp/`) | `b00t chat` ACP, `pi --mode rpc`, opencode ACP | **Same protocol** — moltis plugs into the existing ACP mesh like pi/opencode. Register it. |
+| Remote/multi-backend sandbox (Firecracker/Daytona/Vercel) | `b00t sh` audited exec + podman guards; `b00t hive` | moltis is well ahead (microVM isolation). **Candidate to back b00t's exec-isolation tier.** |
+| `crates/cron` durable channel-aware scheduler | `b00t maintenance` daemon, `b00t task`, systemd `.timer`, `CronCreate` (cloud) | **Complementary.** moltis-cron → human-facing recurring reports; `b00t task` → machine work. |
+| Memory: `B00tSoulWriter` (→ soul :7700) + `zvec` | `b00t soul` K/V, grok RAG, NeumannStore, codebase-memory-mcp, irontology | Keep moltis on **b00t-soul** (already wired, `key_prefix = "moltis/"`). **Do not also run `zvec`** — a second hive vector store competes with grok/irontology. |
+| MCP (OAuth client secrets, Fastmail) | `b00t-mcp`, MCP datums, `pi-mcp-adapter` | Complementary. moltis carries OAuth flows b00t-mcp doesn't. |
+| Instrumentation: Langfuse / OTLP / Prometheus | ledgrrr FOCUS, `b00t soul`, historian | Partial. Point moltis OTLP at the same Grafana; keep cost/finops in ledgrrr. |
+| Node identity: Ed25519 challenge-response / TOFU (#979) | hive peers + NATS operator/JWT auth (#1235) | Overlap. Unify later; low priority. |
+| Remote access: NetBird / CF Tunnel / Tailscale | CF Workers/DNS via wrangler; no tunnel | moltis ahead — useful for exposing the hive off-LAN. |
+
+## moltis as a standing hive citizen — recurring tasks
+
+`b00t@moltis-agent.service` stays the always-on host (after `b00t-soul.service`).
+Recurring work uses **moltis's own durable cron** (`moltis cron add …`), not systemd
+timers — because every job's value is *delivering to a human channel*, which
+moltis-cron does natively and `b00t task` does not.
+
+| job | cadence | what it does | delivery |
+|---|---|---|---|
+| `hive-health-digest` | hourly | `b00t hive status` + tail `.b00t/hive-watchdog.jsonl` + 3 s `nats sub b00t.hive.mesh.health.>` → GPU heat/temp/util, service states, crash-loop trips, NRestarts deltas | Slack #ops |
+| `pr-triage` | daily 09:00 | `gh pr list` + `b00t task list` → unreviewed / mergeable / stale-branch PRs; forecast-accuracy digest from `.b00t/forecasts.jsonl` + ledgrrr FOCUS | Slack #ops + `b00t task add` for anything needing action |
+| `vendor-drift-watch` | weekly Mon | every `vendor/*` submodule pin vs its `origin/main`; report which advanced + commit range (this doc's own trigger) | Slack #ops + `b00t task add` |
+| `soul-snapshot` | daily 23:00 | read moltis's `moltis/` namespace from soul :7700, project to JSONL/Markdown (moltis session-export), commit to a memory archive | git |
+| `crash-escalation` | **event** (not cron) | subscribe `b00t.hive.mesh.health.crashloop`; on a trip, place a Twilio call / WhatsApp to the operator | phone — the one thing b00t cannot do itself |
+
+Config surface: `_b00t_/moltis-standing-tasks.hive.toml` (this PR) lists the jobs as
+`moltis cron add` recipes + the `[b00t.hive.service]` host. Activation:
+`b00t hive activate moltis-standing-tasks`.
+
+## Follow-ups (not in this PR)
+- `.gitmodules` / `moltis.agent.toml` name the remote as `elasticdotventures` /
+  `promptexecution`; actual is `app4dog/moltis-b00t` (upstream `moltis-org`). Reconcile.
+- `moltis.agent.toml` points model at litellm `:1234` / `local-litellm`; the live
+  gateway is `cli-proxy-api` `:1234` and the local slot is qwen38 `:8001`. Re-point.
+- Register moltis in `b00t chat` / the ACP mesh now that `crates/acp` is stdio-ready.


### PR DESCRIPTION
## vendor/moltis-b00t: `5d171bb1` (2026-07-15) → `4829e6a7` (2026-09-02)
~40 commits. Brings: `crates/acp` (Moltis as a stdio **ACP agent**, #1169), `crates/cron` channel-aware delivery, `zvec` vector memory, multi-backend sandbox (Firecracker/Daytona/Vercel), Slack live task cards / WhatsApp LID / Twilio telephony / Fastmail OAuth, releases 20260824..20260902.

## `docs/moltis-b00t-integration.md` — overlap analysis
Net: moltis multi-channel human comms have **zero b00t overlap** — it is the hive human front-door. ACP / cron / MCP are complementary. Keep moltis on **b00t-soul**; do NOT also run `zvec` (competes with grok/irontology).

## `_b00t_/moltis-standing-tasks.hive.toml` — moltis earns a standing seat
Recurring jobs on moltis's own durable `moltis-cron` (not systemd timers — every job delivers to a human channel):
- `hive-health-digest` hourly — GPU/service/watchdog snapshot → #ops
- `pr-triage` daily — unreviewed/mergeable/stale PRs + forecast-accuracy → #ops + `b00t task`
- `vendor-drift-watch` weekly — submodule pins vs origin/main (this PR's own trigger)
- `soul-snapshot` daily — export `moltis/` soul namespace → git
- `crash-escalation` event — Twilio call on `b00t.hive.mesh.health.crashloop` (b00t can't phone anyone)

Follow-ups in the doc: remote name is `app4dog/moltis-b00t` not elasticdotventures/promptexecution; re-point `moltis.agent.toml` off `litellm:1234`; register moltis in the `b00t chat` ACP mesh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)