### PR TITLE
fix(datums): resolve all 45 b00t-lsp TOML parse errors (task #115)

### DIFF
--- a/_b00t_/ARCHITECTURE-REVIEW-BROWSER-RPA.tomllmd
+++ b/_b00t_/ARCHITECTURE-REVIEW-BROWSER-RPA.tomllmd
@@ -97,31 +97,31 @@ wheel_5_verdict = "⬅️ Double down. This is the key innovation. File a patent
 # The right architecture follows Browser-Use's validated pattern but with Rust
 # for performance-critical paths and our data-b00t-* enrichment as the differentiator.
 
-┌─────────────────────────────────────────────────────────────────────┐
-│                       b00t RPA Architecture v2                       │
-├─────────────────────────────────────────────────────────────────────┤
-│                                                                     │
-│  ┌──────────────┐    ┌─────────────────┐    ┌──────────────────┐    │
-│  │ LLM Agent     │───▶│  Orchestrator    │───▶│  Data Pipeline    │    │
-│  │ (Qwen3.6-27B) │    │  (state machine) │    │  (extract→store)  │    │
-│  │ sm0l/ch0nky   │    │  wrkflw engine   │    │  CSV/JSON/SQLite  │    │
-│  └──────────────┘    └─────────────────┘    └──────────────────┘    │
-│                           │                                         │
-│                           ▼                                         │
-│  ┌──────────────────────────────────────────────────────────────┐   │
-│  │              Playwright Python (standard RPA)                 │   │
-│  │  +90% of automation: navigate, click, type, screenshot        │   │
-│  │  Cross-browser, auto-waiting, network intercept, codegen      │   │
-│  └────────────┬─────────────────────────────────────────────┬───┘   │
-│               │                                             │       │
-│               ▼                                             ▼       │
-│  ┌─────────────────────┐              ┌──────────────────────────┐  │
-│  │ Playwright (std)     │              │ b00t-rpa (chromiumoxide) │  │
-│  │ Normal pages, forms, │              │ High-throughput, stealth │  │
-│  │ cross-browser         │              │ DOM enrichment injection │  │
-│  └─────────────────────┘              │ data-b00t-* deep access  │  │
-│                                        └──────────────────────────┘  │
-└─────────────────────────────────────────────────────────────────────┘
+# ┌─────────────────────────────────────────────────────────────────────┐
+# │                       b00t RPA Architecture v2                       │
+# ├─────────────────────────────────────────────────────────────────────┤
+# │                                                                     │
+# │  ┌──────────────┐    ┌─────────────────┐    ┌──────────────────┐    │
+# │  │ LLM Agent     │───▶│  Orchestrator    │───▶│  Data Pipeline    │    │
+# │  │ (Qwen3.6-27B) │    │  (state machine) │    │  (extract→store)  │    │
+# │  │ sm0l/ch0nky   │    │  wrkflw engine   │    │  CSV/JSON/SQLite  │    │
+# │  └──────────────┘    └─────────────────┘    └──────────────────┘    │
+# │                           │                                         │
+# │                           ▼                                         │
+# │  ┌──────────────────────────────────────────────────────────────┐   │
+# │  │              Playwright Python (standard RPA)                 │   │
+# │  │  +90% of automation: navigate, click, type, screenshot        │   │
+# │  │  Cross-browser, auto-waiting, network intercept, codegen      │   │
+# │  └────────────┬─────────────────────────────────────────────┬───┘   │
+# │               │                                             │       │
+# │               ▼                                             ▼       │
+# │  ┌─────────────────────┐              ┌──────────────────────────┐  │
+# │  │ Playwright (std)     │              │ b00t-rpa (chromiumoxide) │  │
+# │  │ Normal pages, forms, │              │ High-throughput, stealth │  │
+# │  │ cross-browser         │              │ DOM enrichment injection │  │
+# │  └─────────────────────┘              │ data-b00t-* deep access  │  │
+# │                                        └──────────────────────────┘  │
+# └─────────────────────────────────────────────────────────────────────┘
 
 [llm_integration_plan]
 tier_sm0l = "Qwen2.5-3B (local vLLM) — DOM parsing, element selection from __b00t.find(). Cost: ~0. 'Given user wants to X, which element should I click?'"

--- a/_b00t_/PIPELINE-DATUM-UFO-FOUNDATION.tomllmd
+++ b/_b00t_/PIPELINE-DATUM-UFO-FOUNDATION.tomllmd
@@ -20,126 +20,126 @@
 
 ## Scope note: NATS
 
-Per operator instruction: do not invest in rebuilding/fixing the NATS layer
-(`b00t-lib-chat`'s `nats_transport.rs`) as part of this work. The only NATS-adjacent
-requirement is that inter-node (cross-machine) pipeline execution stays *feasible* —
-which it already is, via the existing, real `ComputeProvider` (RunPod/HF Jobs dispatch
-to remote compute) — no new transport work is needed to satisfy that. If a future need
-for pub/sub-style cross-node coordination emerges beyond simple job dispatch, revisit
-NATS then; it is out of scope here.
+# Per operator instruction: do not invest in rebuilding/fixing the NATS layer
+# (`b00t-lib-chat`'s `nats_transport.rs`) as part of this work. The only NATS-adjacent
+# requirement is that inter-node (cross-machine) pipeline execution stays *feasible* —
+# which it already is, via the existing, real `ComputeProvider` (RunPod/HF Jobs dispatch
+# to remote compute) — no new transport work is needed to satisfy that. If a future need
+# for pub/sub-style cross-node coordination emerges beyond simple job dispatch, revisit
+# NATS then; it is out of scope here.
 
 ## Decomposition — 3 independent sub-tasks + 2 dependent follow-ons
 
-Tasks 1-3 touch disjoint files and can run in parallel, isolated worktrees. Tasks 4-5
-depend on 1-3 landing first (sequenced after, not parallel with them).
+# Tasks 1-3 touch disjoint files and can run in parallel, isolated worktrees. Tasks 4-5
+# depend on 1-3 landing first (sequenced after, not parallel with them).
 
 ### Task 1 (independent, trivial): fix-forward `ufo-types` module framing
-- `~/.b00t/crates/ufo-types/src/lib.rs`'s module docs say "for the Tax-Lawyer platform"
-  despite `Cargo.toml`'s description already saying "+ b00t governance." The types
-  themselves are domain-generic (confirmed by direct read: nothing tax-specific in
-  `stereotype.rs`/`satisfies.rs`/`capability.rs`). One-line doc fix, not a redesign.
-- Verify `cargo test -p ufo-types` still passes untouched (doc-only change).
+# - `~/.b00t/crates/ufo-types/src/lib.rs`'s module docs say "for the Tax-Lawyer platform"
+#   despite `Cargo.toml`'s description already saying "+ b00t governance." The types
+#   themselves are domain-generic (confirmed by direct read: nothing tax-specific in
+#   `stereotype.rs`/`satisfies.rs`/`capability.rs`). One-line doc fix, not a redesign.
+# - Verify `cargo test -p ufo-types` still passes untouched (doc-only change).
 
 ### Task 2 (independent of 1 and 3): `DatumType::Pipeline`
-- Mirror `DatumType::Justfile` exactly: `datum_type_table!` entry
-  (`Pipeline => ["pipeline"] => ".pipeline"`), `SemanticClass::Skill` arm (alongside
-  `Job | Hook | Gate`).
-- New `datum_pipeline.rs` (mirrors `datum_justfile.rs`'s structure): `PipelineDatum`
-  struct implementing `DatumChecker`/`StatusProvider`/`FilterLogic`/
-  `ConstraintEvaluator`/`DatumProvider` (the same trait set `JustfileDatum` implements —
-  check that file first, match its shape, don't invent a new pattern).
-- This makes `*.pipeline.tomllm` files (already the naming convention `sam.pipeline.tomllm`
-  in app4dog uses, currently unregistered/free-form TOML) real, typed, discoverable
-  datums instead of ad-hoc files nothing validates.
+# - Mirror `DatumType::Justfile` exactly: `datum_type_table!` entry
+#   (`Pipeline => ["pipeline"] => ".pipeline"`), `SemanticClass::Skill` arm (alongside
+#   `Job | Hook | Gate`).
+# - New `datum_pipeline.rs` (mirrors `datum_justfile.rs`'s structure): `PipelineDatum`
+#   struct implementing `DatumChecker`/`StatusProvider`/`FilterLogic`/
+#   `ConstraintEvaluator`/`DatumProvider` (the same trait set `JustfileDatum` implements —
+#   check that file first, match its shape, don't invent a new pattern).
+# - This makes `*.pipeline.tomllm` files (already the naming convention `sam.pipeline.tomllm`
+#   in app4dog uses, currently unregistered/free-form TOML) real, typed, discoverable
+#   datums instead of ad-hoc files nothing validates.
 
 ### Task 3 (independent of 1 and 2, different files in the same crate): `JobExecutor` → `ComputeProvider` bridge
-- `~/.b00t/b00t-cli/src/job_executor.rs` currently only executes `JobTask::Bash`,
-  sequential-mode only (explicitly MVP-scoped per its own code comment). Two additions:
-  1. New `JobTask::Python { script: String, requirements: Vec<String>, ... }` variant in
-     `datum_job.rs`'s `JobTask` enum, executed the same way `Bash` is (shell out), but
-     via `python3 <script>` with a requirements-install step first (keep it simple —
-     don't build a full venv manager, a requirements.txt + pip install is enough for v1).
-  2. Bridge: give `JobExecutor` a path to dispatch a step via
-     `ComputeProvider::submit_batch_job` (from `commands/provider.rs`) instead of only
-     local `duct::cmd` shell-out — this is what lets a `JobDatum`'s steps run on
-     local-GPU/RunPod/HF, not just spawn a bare process. Keep the existing Bash-local
-     path working; add the provider-dispatch path as an alternative, selected per-step
-     (e.g. a step declares `backend: Option<RunnerBackend>` — `None` = today's local
-     shell-out behavior, `Some(backend)` = dispatch via `ComputeProvider`).
-  3. Parallel/fan-out mode: `JobConfig.mode` currently only supports `"sequential"`
-     (hard `bail!` otherwise). Add `"parallel"` mode — run all steps in one "wave"
-     concurrently (tokio join, not a full DAG scheduler — that's more than v1 needs),
-     collect all results before proceeding. This is what a future A/B fan-out
-     (N candidate stage implementations) will build on.
-- Explicit non-goal: do not build a general DAG engine here. `JobConfig.mode` gets
-  exactly two values (`sequential`, `parallel`) — a real DAG scheduler is out of scope
-  until there's a demonstrated need beyond "run these N things and wait for all."
+# - `~/.b00t/b00t-cli/src/job_executor.rs` currently only executes `JobTask::Bash`,
+#   sequential-mode only (explicitly MVP-scoped per its own code comment). Two additions:
+#   1. New `JobTask::Python { script: String, requirements: Vec<String>, ... }` variant in
+#      `datum_job.rs`'s `JobTask` enum, executed the same way `Bash` is (shell out), but
+#      via `python3 <script>` with a requirements-install step first (keep it simple —
+#      don't build a full venv manager, a requirements.txt + pip install is enough for v1).
+#   2. Bridge: give `JobExecutor` a path to dispatch a step via
+#      `ComputeProvider::submit_batch_job` (from `commands/provider.rs`) instead of only
+#      local `duct::cmd` shell-out — this is what lets a `JobDatum`'s steps run on
+#      local-GPU/RunPod/HF, not just spawn a bare process. Keep the existing Bash-local
+#      path working; add the provider-dispatch path as an alternative, selected per-step
+#      (e.g. a step declares `backend: Option<RunnerBackend>` — `None` = today's local
+#      shell-out behavior, `Some(backend)` = dispatch via `ComputeProvider`).
+#   3. Parallel/fan-out mode: `JobConfig.mode` currently only supports `"sequential"`
+#      (hard `bail!` otherwise). Add `"parallel"` mode — run all steps in one "wave"
+#      concurrently (tokio join, not a full DAG scheduler — that's more than v1 needs),
+#      collect all results before proceeding. This is what a future A/B fan-out
+#      (N candidate stage implementations) will build on.
+# - Explicit non-goal: do not build a general DAG engine here. `JobConfig.mode` gets
+#   exactly two values (`sequential`, `parallel`) — a real DAG scheduler is out of scope
+#   until there's a demonstrated need beyond "run these N things and wait for all."
 
 ### Task 4 (depends on 1+2 landing; app4dog repo, not this one): critter-keeper integration
-- Add `ufo-types` as a `git` dependency in `critter-keeper/Cargo.toml` (pinned rev —
-  the exact rev/tag is chosen once Task 1's fix is merged, not before).
-- Define the app4dog-side pipeline types using `ufo-types` directly per the mapping
-  table in `PHOTO-CRITTER-GENERATION-PIPELINE.tomllmd` §5.2 — do not reinvent
-  `Task`/`Attempt`/`ActionRecord`/`ReviewVerdict`/`Solution`, import and use them.
-- Define `PipelineExecutor` (`UfoStereotype::Kind`) +
-  `LocalPipelineExecutor`/`CloudPipelineExecutor` (`SubKind`s), each bridging to
-  `job_dispatch.rs`'s already-real `JobRuntime`/`RunnerBackend`.
-- NOT in scope for this task: the actual SAM runner / characteristic-identification
-  model work (that's Phase 2/3 of the app4dog pipeline doc, separate from this
-  foundation work).
+# - Add `ufo-types` as a `git` dependency in `critter-keeper/Cargo.toml` (pinned rev —
+#   the exact rev/tag is chosen once Task 1's fix is merged, not before).
+# - Define the app4dog-side pipeline types using `ufo-types` directly per the mapping
+#   table in `PHOTO-CRITTER-GENERATION-PIPELINE.tomllmd` §5.2 — do not reinvent
+#   `Task`/`Attempt`/`ActionRecord`/`ReviewVerdict`/`Solution`, import and use them.
+# - Define `PipelineExecutor` (`UfoStereotype::Kind`) +
+#   `LocalPipelineExecutor`/`CloudPipelineExecutor` (`SubKind`s), each bridging to
+#   `job_dispatch.rs`'s already-real `JobRuntime`/`RunnerBackend`.
+# - NOT in scope for this task: the actual SAM runner / characteristic-identification
+#   model work (that's Phase 2/3 of the app4dog pipeline doc, separate from this
+#   foundation work).
 
 ### Task 5 (depends on 2 landing): b00t-mcp exposure
-- ⚠️需 Correction from initial assumption: b00t-mcp's tool generation is **not fully
-  automatic** from `DatumType` variants — `derive_mcp.rs`'s `impl_mcp_tool!` macro must
-  be explicitly invoked per command (see existing calls in `b00t-mcp/src/*.rs` for the
-  pattern: `impl_mcp_tool!(StructName, "tool_name", ["cli","subcommand","path"])`).
-- ⚠️需 Second, deeper correction (found while starting Task 5, post-#656): "discoverable
-  the same way `b00t-cli justfile` commands are" is a **false premise** — there is no
-  `b00t-cli justfile` subcommand. Confirmed by direct search: `DatumType::Justfile` is
-  referenced in exactly one place outside `lib.rs`'s registration macro
-  (`datum_proof.rs`'s `prove_justfile` match arm). `CliExecutor` — implemented by
-  `CliDatum`, `JustfileDatum`, and now `PipelineDatum` — has **zero callers** anywhere in
-  `b00t-cli` or `b00t-mcp`. It is a fully-built trait with no CLI entry point wired to it
-  for any of its three implementors, not just `Pipeline`. This predates this plan; Task 2
-  did not introduce the gap, it just made it visible for a third type.
-- What Task 2's actual Definition-of-Done item 3 ("real, typed, `b00t .`-discoverable
-  datum") already means and already satisfies: the generic `b00t learn`/`b00t .`
-  datum-search path picks up `*.pipeline.tomllm` files the same way it picks up any
-  other typed datum (verified: `b00t learn systematic-debugging` resolves through this
-  path). That is NOT the same claim as "has a runnable CLI subcommand" — the original
-  Task 2 DoD item 2 ("`b00t-cli pipeline` subcommand(s) exist... consistent UX, not a
-  one-off") cannot be satisfied as written because its reference point (`b00t-cli
-  justfile`) does not exist to be consistent with.
-- Building `pipeline list`/`pipeline run` now means designing the **first-ever**
-  CLI dispatch surface for any `CliExecutor` implementor — a real architectural choice
-  (does `justfile`/`cli` get the same subcommand shape at the same time, or does
-  `pipeline` set a precedent alone?), not a "find and match" mirror job. Per this repo's
-  own stated preference (reuse proven patterns, don't invent architecture solo), this is
-  flagged for an operator decision rather than built speculatively. The closest existing
-  *proven* precedent for a multi-verb datum-type subcommand is `StoreCommands` in
-  `b00t-cli/src/commands/store.rs` (`Subcommand` enum + `handle_store_command` match) —
-  if/when this is greenlit, mirror that shape, not an imagined `justfile` one.
-- Verify locally (once built): restart the b00t-mcp process (however it's currently
-  launched — check whether it's spawned by a client config vs. a long-running process;
-  there's no systemd unit for it, confirmed) and confirm the new tool appears via
-  whatever local `b00t-mcp` listing/discovery mechanism exists.
+# - ⚠️需 Correction from initial assumption: b00t-mcp's tool generation is **not fully
+#   automatic** from `DatumType` variants — `derive_mcp.rs`'s `impl_mcp_tool!` macro must
+#   be explicitly invoked per command (see existing calls in `b00t-mcp/src/*.rs` for the
+#   pattern: `impl_mcp_tool!(StructName, "tool_name", ["cli","subcommand","path"])`).
+# - ⚠️需 Second, deeper correction (found while starting Task 5, post-#656): "discoverable
+#   the same way `b00t-cli justfile` commands are" is a **false premise** — there is no
+#   `b00t-cli justfile` subcommand. Confirmed by direct search: `DatumType::Justfile` is
+#   referenced in exactly one place outside `lib.rs`'s registration macro
+#   (`datum_proof.rs`'s `prove_justfile` match arm). `CliExecutor` — implemented by
+#   `CliDatum`, `JustfileDatum`, and now `PipelineDatum` — has **zero callers** anywhere in
+#   `b00t-cli` or `b00t-mcp`. It is a fully-built trait with no CLI entry point wired to it
+#   for any of its three implementors, not just `Pipeline`. This predates this plan; Task 2
+#   did not introduce the gap, it just made it visible for a third type.
+# - What Task 2's actual Definition-of-Done item 3 ("real, typed, `b00t .`-discoverable
+#   datum") already means and already satisfies: the generic `b00t learn`/`b00t .`
+#   datum-search path picks up `*.pipeline.tomllm` files the same way it picks up any
+#   other typed datum (verified: `b00t learn systematic-debugging` resolves through this
+#   path). That is NOT the same claim as "has a runnable CLI subcommand" — the original
+#   Task 2 DoD item 2 ("`b00t-cli pipeline` subcommand(s) exist... consistent UX, not a
+#   one-off") cannot be satisfied as written because its reference point (`b00t-cli
+#   justfile`) does not exist to be consistent with.
+# - Building `pipeline list`/`pipeline run` now means designing the **first-ever**
+#   CLI dispatch surface for any `CliExecutor` implementor — a real architectural choice
+#   (does `justfile`/`cli` get the same subcommand shape at the same time, or does
+#   `pipeline` set a precedent alone?), not a "find and match" mirror job. Per this repo's
+#   own stated preference (reuse proven patterns, don't invent architecture solo), this is
+#   flagged for an operator decision rather than built speculatively. The closest existing
+#   *proven* precedent for a multi-verb datum-type subcommand is `StoreCommands` in
+#   `b00t-cli/src/commands/store.rs` (`Subcommand` enum + `handle_store_command` match) —
+#   if/when this is greenlit, mirror that shape, not an imagined `justfile` one.
+# - Verify locally (once built): restart the b00t-mcp process (however it's currently
+#   launched — check whether it's spawned by a client config vs. a long-running process;
+#   there's no systemd unit for it, confirmed) and confirm the new tool appears via
+#   whatever local `b00t-mcp` listing/discovery mechanism exists.
 
 ## Definition of Done
-1. `cargo test -p ufo-types` and `cargo test -p b00t-cli` (or equivalent per-crate)
-   green, no regressions from baseline
-2. `b00t-cli pipeline` subcommand(s) exist, discoverable the same way `b00t-cli
-   justfile` commands are (consistent UX, not a one-off)
-3. A `*.pipeline.tomllm` file is a real, typed, `b00t .` -discoverable datum, not
-   free-form TOML
-4. `JobExecutor` can dispatch at least one step through `ComputeProvider` (proven with
-   a `local` provider test, mirroring how `job_dispatch.rs`'s existing tests avoid
-   needing a real `b00t` binary)
-5. `JobConfig.mode = "parallel"` runs steps concurrently and collects all results
-6. The new pipeline subcommand(s) are callable via b00t-mcp, verified locally
+# 1. `cargo test -p ufo-types` and `cargo test -p b00t-cli` (or equivalent per-crate)
+#    green, no regressions from baseline
+# 2. `b00t-cli pipeline` subcommand(s) exist, discoverable the same way `b00t-cli
+#    justfile` commands are (consistent UX, not a one-off)
+# 3. A `*.pipeline.tomllm` file is a real, typed, `b00t .` -discoverable datum, not
+#    free-form TOML
+# 4. `JobExecutor` can dispatch at least one step through `ComputeProvider` (proven with
+#    a `local` provider test, mirroring how `job_dispatch.rs`'s existing tests avoid
+#    needing a real `b00t` binary)
+# 5. `JobConfig.mode = "parallel"` runs steps concurrently and collects all results
+# 6. The new pipeline subcommand(s) are callable via b00t-mcp, verified locally
 
 ## Agent dispatch
 
-Tasks 1-3: independent-context sub-agents, isolated worktrees (this repo has active
-concurrent work in other worktrees — `task-517-tax-skills`, `runpod-ci-fix` — confirmed
-present; isolation avoids collision, not just paranoia). Task 4: app4dog repo, after 1+2
-merge. Task 5: after 2 merges.
+# Tasks 1-3: independent-context sub-agents, isolated worktrees (this repo has active
+# concurrent work in other worktrees — `task-517-tax-skills`, `runpod-ci-fix` — confirmed
+# present; isolation avoids collision, not just paranoia). Task 4: app4dog repo, after 1+2
+# merge. Task 5: after 2 merges.

--- a/_b00t_/ai-source-engine.datum.toml
+++ b/_b00t_/ai-source-engine.datum.toml
@@ -57,8 +57,7 @@ action = "digest"
 
 [ponytail.rung_7]
 name = "minimum"
-answer = "Digest ENGINEERING_GUIDE.md + src/al10/math.py + src/al10/receipt.py.
-         Skip CLI (30KB boilerplate), server (8KB FastAPI wrapper), README (manifesto)."
+answer = "Digest ENGINEERING_GUIDE.md + src/al10/math.py + src/al10/receipt.py. Skip CLI (30KB boilerplate), server (8KB FastAPI wrapper), README (manifesto)."
 action = "digest minimal set"
 
 # ── What to Digest ───────────────────────────────────────────────────────────

--- a/_b00t_/datums/AGENT-RECRUITMENT.tomllmd
+++ b/_b00t_/datums/AGENT-RECRUITMENT.tomllmd
@@ -25,124 +25,124 @@ content = "stable"
 
 ## ── Recruitment Sources ─────────────────────────────────────────────────────────
 
-The operator scouts agents from these sources:
+# The operator scouts agents from these sources:
 
 ### 1. Internal — b00t Ontology
-Query the live capability ontology from agent datums.
+# Query the live capability ontology from agent datums.
 
-| Source | Method | Returns |
-|--------|--------|---------|
-| `b00t ontology query --role <role>` | Structured query | Agent datums matching role with skill lists |
-| `b00t agent discover --capabilities <...>` | Capability-based discovery | Agents with matching capability scores |
-| `_b00t_/*.agent.toml` | Direct datum scan | Full agent configuration metadata |
+# | Source | Method | Returns |
+# |--------|--------|---------|
+# | `b00t ontology query --role <role>` | Structured query | Agent datums matching role with skill lists |
+# | `b00t agent discover --capabilities <...>` | Capability-based discovery | Agents with matching capability scores |
+# | `_b00t_/*.agent.toml` | Direct datum scan | Full agent configuration metadata |
 
 ### 2. External — agency-agents (github.com/msitarzewski/agency-agents)
-Curated AI agent personality profiles with identity, mission, workflows, deliverables.
+# Curated AI agent personality profiles with identity, mission, workflows, deliverables.
 
-| Profile Format | Key Fields | Recruitment Mapping |
-|----------------|------------|---------------------|
-| Markdown files | identity, mission, workflows, deliverables | Maps to b00t agent: personality, skills, crew role |
-| Agent archetypes | "Researcher", "Writer", "Analyst", "Strategist" | Maps to specialist or executor roles |
+# | Profile Format | Key Fields | Recruitment Mapping |
+# |----------------|------------|---------------------|
+# | Markdown files | identity, mission, workflows, deliverables | Maps to b00t agent: personality, skills, crew role |
+# | Agent archetypes | "Researcher", "Writer", "Analyst", "Strategist" | Maps to specialist or executor roles |
 
-**Recruitment Process:**
-1. Clone/search agency-agents repo for matching profiles
-2. Parse profile markdown for capability signals (tools, frameworks, domains)
-3. Score against open crew roles
-4. Generate agent datum skeleton from parsed profile
-5. Present to captain for enlistment approval
+# **Recruitment Process:**
+# 1. Clone/search agency-agents repo for matching profiles
+# 2. Parse profile markdown for capability signals (tools, frameworks, domains)
+# 3. Score against open crew roles
+# 4. Generate agent datum skeleton from parsed profile
+# 5. Present to captain for enlistment approval
 
 ### 3. External — skillsgate (github.com/skillsgate/skillsgate)
-91,000+ skills catalog with 20+ agent archetypes, desktop app, TUI.
+# 91,000+ skills catalog with 20+ agent archetypes, desktop app, TUI.
 
-| Feature | Description | Recruitment Value |
-|---------|-------------|-------------------|
-| Skills catalog | 91k+ skills organized by domain | Fill skill gaps in crew |
-| Agent archetypes | 20+ pre-built agent personalities | Quick crew composition |
-| Desktop app + TUI | Interactive agent/skill browsing | Manual exploration |
+# | Feature | Description | Recruitment Value |
+# |---------|-------------|-------------------|
+# | Skills catalog | 91k+ skills organized by domain | Fill skill gaps in crew |
+# | Agent archetypes | 20+ pre-built agent personalities | Quick crew composition |
+# | Desktop app + TUI | Interactive agent/skill browsing | Manual exploration |
 
-**Recruitment Process:**
-1. Search skillsgate catalog by skill domain
-2. Match agent archetypes to open roles
-3. Extract skill lists for training plan generation
-4. Cross-reference with existing b00t agents to avoid duplicates
-5. Generate integration recommendation
+# **Recruitment Process:**
+# 1. Search skillsgate catalog by skill domain
+# 2. Match agent archetypes to open roles
+# 3. Extract skill lists for training plan generation
+# 4. Cross-reference with existing b00t agents to avoid duplicates
+# 5. Generate integration recommendation
 
 ## ── Scouting Workflow ───────────────────────────────────────────────────────────
 
-When captain invokes operator for scouting:
+# When captain invokes operator for scouting:
 
-```
-CAPTAIN → OPERATOR: scout(role="specialist", capabilities=["code","refactor","debug"])
-OPERATOR → INTERNAL:  b00t ontology query --role specialist
-OPERATOR → INTERNAL:  b00t agent discover --capabilities code,refactor,debug
-OPERATOR → EXTERNAL:  search agency-agents for "coding agent" profiles
-OPERATOR → EXTERNAL:  search skillsgate for "code" + "refactor" skills
-OPERATOR -> CAPTAIN:   candidates = [pi-001 (score 0.92), opencode (score 0.88), ...]
+# ```
+# CAPTAIN → OPERATOR: scout(role="specialist", capabilities=["code","refactor","debug"])
+# OPERATOR → INTERNAL:  b00t ontology query --role specialist
+# OPERATOR → INTERNAL:  b00t agent discover --capabilities code,refactor,debug
+# OPERATOR → EXTERNAL:  search agency-agents for "coding agent" profiles
+# OPERATOR → EXTERNAL:  search skillsgate for "code" + "refactor" skills
+# OPERATOR -> CAPTAIN:   candidates = [pi-001 (score 0.92), opencode (score 0.88), ...]
 
-CAPTAIN -> OPERATOR: enlist(agent_id="pi-001", role="specialist")
-OPERATOR → REGISTRY:  enlist("pi-001", "specialist", contract={...})
-OPERATOR → CAPTAIN:   crew binding complete for pi-001 as specialist
-```
+# CAPTAIN -> OPERATOR: enlist(agent_id="pi-001", role="specialist")
+# OPERATOR → REGISTRY:  enlist("pi-001", "specialist", contract={...})
+# OPERATOR → CAPTAIN:   crew binding complete for pi-001 as specialist
+# ```
 
 ## ── Capability Scoring ──────────────────────────────────────────────────────────
 
-Candidate agents are scored on these dimensions:
+# Candidate agents are scored on these dimensions:
 
-| Dimension | Weight | Description | Measurement |
-|-----------|--------|-------------|-------------|
-| skill_match | 0.40 | Direct skill overlap with requirements | Jaccard similarity of skill sets |
-| role_fit | 0.25 | Role alignment with crew need | Exact match or nearest role |
-| tier_appropriateness | 0.15 | Model tier matches task complexity | frontier=1.0, ch0nky=0.7, sm0l=0.4 |
-| availability | 0.10 | Agent is not already deployed | 1.0 if available, 0.0 if deployed |
-| past_performance | 0.10 | Historical readiness scores | Average of last 3 readiness scores |
+# | Dimension | Weight | Description | Measurement |
+# |-----------|--------|-------------|-------------|
+# | skill_match | 0.40 | Direct skill overlap with requirements | Jaccard similarity of skill sets |
+# | role_fit | 0.25 | Role alignment with crew need | Exact match or nearest role |
+# | tier_appropriateness | 0.15 | Model tier matches task complexity | frontier=1.0, ch0nky=0.7, sm0l=0.4 |
+# | availability | 0.10 | Agent is not already deployed | 1.0 if available, 0.0 if deployed |
+# | past_performance | 0.10 | Historical readiness scores | Average of last 3 readiness scores |
 
-**Total Score** = Σ(weight_i × score_i) — range [0.0, 1.0]
+# **Total Score** = Σ(weight_i × score_i) — range [0.0, 1.0]
 
 ## ── Enlistment Contract ─────────────────────────────────────────────────────────
 
-When operator enlists an agent, a capability contract is created:
+# When operator enlists an agent, a capability contract is created:
 
-```toml
-[contract]
+# ```toml
+# [contract]
 # Agent identification
-agent_id = "pi-001"
+# agent_id = "pi-001"
 # Assigned crew role
-role = "specialist"
+# role = "specialist"
 # Whether this agent is captain
-captain = false
+# captain = false
 # Declared capabilities
-capabilities = ["code", "refactor", "debug", "edit", "bash", "read", "write"]
+# capabilities = ["code", "refactor", "debug", "edit", "bash", "read", "write"]
 # Bouncer gates required for this agent
-gates = ["sanitize", "credential-check", "security-scan"]
+# gates = ["sanitize", "credential-check", "security-scan"]
 # Minimum quality thresholds
-thresholds = { min_quality_score = 0.8, max_response_time_ms = 30000 }
+# thresholds = { min_quality_score = 0.8, max_response_time_ms = 30000 }
 # Availability commitment
-availability = "on-demand"
+# availability = "on-demand"
 # Contract expiry (rotation trigger)
-rotation_period_days = 90
-```
+# rotation_period_days = 90
+# ```
 
 ## ── Recruitment Audit Log ──────────────────────────────────────────────────────
 
-All recruitment actions are logged to `.b00t/recruitment-audit.jsonl`:
+# All recruitment actions are logged to `.b00t/recruitment-audit.jsonl`:
 
-```jsonl
-{"ts":"2026-05-08T00:00:00Z","action":"scout","query":"code,refactor,debug","source":"internal","results":["pi-001","opencode"]}
-{"ts":"2026-05-08T00:01:00Z","action":"enlist","agent_id":"pi-001","role":"specialist","score":0.92}
-{"ts":"2026-05-08T00:02:00Z","action":"train-start","agent_id":"pi-001","phases":["context-ingest","skill-validation","capability-register","bouncer-verify"]}
-{"ts":"2026-05-08T00:05:00Z","action":"train-complete","agent_id":"pi-001","readiness":0.95}
-```
+# ```jsonl
+# {"ts":"2026-05-08T00:00:00Z","action":"scout","query":"code,refactor,debug","source":"internal","results":["pi-001","opencode"]}
+# {"ts":"2026-05-08T00:01:00Z","action":"enlist","agent_id":"pi-001","role":"specialist","score":0.92}
+# {"ts":"2026-05-08T00:02:00Z","action":"train-start","agent_id":"pi-001","phases":["context-ingest","skill-validation","capability-register","bouncer-verify"]}
+# {"ts":"2026-05-08T00:05:00Z","action":"train-complete","agent_id":"pi-001","readiness":0.95}
+# ```
 
 ## ── Crew Composition Rules ─────────────────────────────────────────────────────
 
-| Rule | Description | Enforcement |
-|------|-------------|-------------|
-| No duplicate roles | Only one agent per role in same crew scope | Operator warns, captain overrides |
-| Captain mandatory | Every crew needs exactly 1 captain | Executive auto-assigned as captain |
-| Specialist optional | Zero or more specialists per crew | No minimum |
-| Operator on-demand | Operator is not standing crew; deployed by captain | Spawned per recruitment mission |
-| Bouncer default | All agents have bouncer gates | Embedded in agent datum |
-| Rotation period | Agents rotate after contract period | 90 days default, configurable |
+# | Rule | Description | Enforcement |
+# |------|-------------|-------------|
+# | No duplicate roles | Only one agent per role in same crew scope | Operator warns, captain overrides |
+# | Captain mandatory | Every crew needs exactly 1 captain | Executive auto-assigned as captain |
+# | Specialist optional | Zero or more specialists per crew | No minimum |
+# | Operator on-demand | Operator is not standing crew; deployed by captain | Spawned per recruitment mission |
+# | Bouncer default | All agents have bouncer gates | Embedded in agent datum |
+# | Rotation period | Agents rotate after contract period | 90 days default, configurable |
 
 # b00t:map v1
 # summary: Agent recruitment system — scouting (internal ontology + external agency-agents/skillsgate), capability scoring (skill_match, role_fit, tier, availability, past_performance), enlistment contracts, recruitment audit logging for hive crew formation

--- a/_b00t_/datums/AGENT-REGISTRY.tomllmd
+++ b/_b00t_/datums/AGENT-REGISTRY.tomllmd
@@ -25,152 +25,152 @@ content = "stable"
 
 ## ── Registry Operations ────────────────────────────────────────────────────────
 
-The operator agent exposes these registry operations to the captain:
+# The operator agent exposes these registry operations to the captain:
 
 ### search(query, filters)
-Search for candidate agents matching capability requirements.
+# Search for candidate agents matching capability requirements.
 
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| query | string | yes | Natural language or keyword search for agent capabilities |
-| role | string | no | Filter by crew role (captain, executor, operator, specialist, bouncer) |
-| min_score | float | no | Minimum capability score threshold (0.0 - 1.0) |
-| source | string | no | Search source: "internal" (ontology), "external" (agency-agents/skillsgate), "all" (default) |
-| limit | u32 | no | Maximum results to return (default: 10) |
+# | Parameter | Type | Required | Description |
+# |-----------|------|----------|-------------|
+# | query | string | yes | Natural language or keyword search for agent capabilities |
+# | role | string | no | Filter by crew role (captain, executor, operator, specialist, bouncer) |
+# | min_score | float | no | Minimum capability score threshold (0.0 - 1.0) |
+# | source | string | no | Search source: "internal" (ontology), "external" (agency-agents/skillsgate), "all" (default) |
+# | limit | u32 | no | Maximum results to return (default: 10) |
 
-**Returns**: Array of candidate agents with capability scores.
+# **Returns**: Array of candidate agents with capability scores.
 
 ### enlist(agent_id, role, contract)
-Register an agent into the crew with a capability contract.
+# Register an agent into the crew with a capability contract.
 
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| agent_id | string | yes | Agent PID to register (e.g. "pi-001") |
-| role | string | yes | Crew role to assign (captain, executor, operator, specialist, bouncer) |
-| contract | table | yes | Capability contract (see Contract format) |
-| captain | bool | no | Whether this agent is the crew captain (default: false) |
+# | Parameter | Type | Required | Description |
+# |-----------|------|----------|-------------|
+# | agent_id | string | yes | Agent PID to register (e.g. "pi-001") |
+# | role | string | yes | Crew role to assign (captain, executor, operator, specialist, bouncer) |
+# | contract | table | yes | Capability contract (see Contract format) |
+# | captain | bool | no | Whether this agent is the crew captain (default: false) |
 
-**Returns**: Crew binding record with status.
+# **Returns**: Crew binding record with status.
 
 ### train(agent_id, plan)
-Execute a training plan for an agent using b00t grok learn.
+# Execute a training plan for an agent using b00t grok learn.
 
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| agent_id | string | yes | Agent PID to train |
-| plan | table | yes | Training plan definition (see Training Plan format) |
+# | Parameter | Type | Required | Description |
+# |-----------|------|----------|-------------|
+# | agent_id | string | yes | Agent PID to train |
+# | plan | table | yes | Training plan definition (see Training Plan format) |
 
-**Returns**: Training progress report with readiness score.
+# **Returns**: Training progress report with readiness score.
 
 ### status(agent_id)
-Query the current status and training progress of an agent.
+# Query the current status and training progress of an agent.
 
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| agent_id | string | yes | Agent PID to query |
+# | Parameter | Type | Required | Description |
+# |-----------|------|----------|-------------|
+# | agent_id | string | yes | Agent PID to query |
 
-**Returns**: Agent status record (see Agent Status format).
+# **Returns**: Agent status record (see Agent Status format).
 
 ### dismiss(agent_id, reason)
-Remove an agent from the crew, archiving performance data.
+# Remove an agent from the crew, archiving performance data.
 
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| agent_id | string | yes | Agent PID to dismiss |
-| reason | string | yes | Reason for dismissal (role-change, underperformance, mission-complete) |
+# | Parameter | Type | Required | Description |
+# |-----------|------|----------|-------------|
+# | agent_id | string | yes | Agent PID to dismiss |
+# | reason | string | yes | Reason for dismissal (role-change, underperformance, mission-complete) |
 
-**Returns**: Archived crew record with performance summary.
+# **Returns**: Archived crew record with performance summary.
 
 ## ── Data Structures ─────────────────────────────────────────────────────────────
 
 ### Candidate Agent
-Returned by `search()`:
+# Returned by `search()`:
 
-| Field | Type | Description |
-|-------|------|-------------|
-| agent_id | string | Agent PID |
-| name | string | Agent display name |
-| current_role | string | Current crew role |
-| capability_score | float | Match score against query (0.0 - 1.0) |
-| skills | string[] | Agent's declared skills |
-| model_tier | string | Model tier (frontier, ch0nky, sm0l) |
-| source | string | Discovery source (internal, agency-agents, skillsgate) |
-| status | string | Current lifecycle status (available, enlisted, training, deployed, dismissed) |
+# | Field | Type | Description |
+# |-------|------|-------------|
+# | agent_id | string | Agent PID |
+# | name | string | Agent display name |
+# | current_role | string | Current crew role |
+# | capability_score | float | Match score against query (0.0 - 1.0) |
+# | skills | string[] | Agent's declared skills |
+# | model_tier | string | Model tier (frontier, ch0nky, sm0l) |
+# | source | string | Discovery source (internal, agency-agents, skillsgate) |
+# | status | string | Current lifecycle status (available, enlisted, training, deployed, dismissed) |
 
 ### Capability Contract
-Submitted to `enlist()`:
+# Submitted to `enlist()`:
 
-```toml
-[contract]
+# ```toml
+# [contract]
 # Declared capabilities the agent commits to providing
-capabilities = ["code-gen", "refactor", "debug", "bash"]
+# capabilities = ["code-gen", "refactor", "debug", "bash"]
 # Minimum quality thresholds
-min_quality_score = 0.8
+# min_quality_score = 0.8
 # Expected availability
-availability = "on-demand"  # on-demand | persistent | scheduled
+# availability = "on-demand"  # on-demand | persistent | scheduled
 # Bouncer gates required
-gates = ["sanitize", "credential-check"]
-```
+# gates = ["sanitize", "credential-check"]
+# ```
 
 ### Training Plan
-Submitted to `train()`:
+# Submitted to `train()`:
 
-```toml
-[plan]
+# ```toml
+# [plan]
 # Target role to train for
-role = "specialist"
+# role = "specialist"
 # Training phases to execute
-phases = [
-  { name = "context-ingest", type = "grok-learn", topic = "coding-agent", source = "https://docs.example.com/coding-agent" },
-  { name = "skill-validation", type = "validate", schema = "CREW-ROLES" },
-  { name = "capability-register", type = "register", target = "sub-agent" },
-  { name = "bouncer-verify", type = "verify", gates = ["sanitize", "security-scan"] },
-]
-```
+# phases = [
+#   { name = "context-ingest", type = "grok-learn", topic = "coding-agent", source = "https://docs.example.com/coding-agent" },
+#   { name = "skill-validation", type = "validate", schema = "CREW-ROLES" },
+#   { name = "capability-register", type = "register", target = "sub-agent" },
+#   { name = "bouncer-verify", type = "verify", gates = ["sanitize", "security-scan"] },
+# ]
+# ```
 
 ### Agent Status
-Returned by `status()`:
+# Returned by `status()`:
 
-| Field | Type | Description |
-|-------|------|-------------|
-| agent_id | string | Agent PID |
-| lifecycle | string | Current lifecycle phase (FORM, ASSIGN, TRAIN, DEPLOY, REVIEW, ROTATE) |
-| training_progress | float | Training completion percentage (0.0 - 1.0) |
-| readiness_score | float | Overall readiness score (0.0 - 1.0) |
-| last_enlisted | string | ISO 8601 timestamp of last enlistment |
-| last_trained | string | ISO 8601 timestamp of last training completion |
-| performance_log | string[] | Performance history entries |
+# | Field | Type | Description |
+# |-------|------|-------------|
+# | agent_id | string | Agent PID |
+# | lifecycle | string | Current lifecycle phase (FORM, ASSIGN, TRAIN, DEPLOY, REVIEW, ROTATE) |
+# | training_progress | float | Training completion percentage (0.0 - 1.0) |
+# | readiness_score | float | Overall readiness score (0.0 - 1.0) |
+# | last_enlisted | string | ISO 8601 timestamp of last enlistment |
+# | last_trained | string | ISO 8601 timestamp of last training completion |
+# | performance_log | string[] | Performance history entries |
 
 ## ── Registry Storage ────────────────────────────────────────────────────────────
 
-The registry state is persisted as `.b00t/agent-registry.jsonl` — one JSON record per
-state transition:
+# The registry state is persisted as `.b00t/agent-registry.jsonl` — one JSON record per
+# state transition:
 
-```jsonl
-{"ts":"2026-05-08T00:00:00Z","action":"enlist","agent_id":"pi-001","role":"specialist","status":"enlisted"}
-{"ts":"2026-05-08T00:01:00Z","action":"train","agent_id":"pi-001","phase":"context-ingest","progress":0.25}
-{"ts":"2026-05-08T00:02:00Z","action":"deploy","agent_id":"pi-001","status":"deployed","readiness":0.95}
-```
+# ```jsonl
+# {"ts":"2026-05-08T00:00:00Z","action":"enlist","agent_id":"pi-001","role":"specialist","status":"enlisted"}
+# {"ts":"2026-05-08T00:01:00Z","action":"train","agent_id":"pi-001","phase":"context-ingest","progress":0.25}
+# {"ts":"2026-05-08T00:02:00Z","action":"deploy","agent_id":"pi-001","status":"deployed","readiness":0.95}
+# ```
 
 ## ── Query Examples ──────────────────────────────────────────────────────────────
 
 ### Search for coding agents
-```
-b00t ontology query --role specialist
-→ Returns: pi-001 (specialist, score 0.92), opencode (specialist, score 0.88)
-```
+# ```
+# b00t ontology query --role specialist
+# → Returns: pi-001 (specialist, score 0.92), opencode (specialist, score 0.88)
+# ```
 
 ### Enlist a discovered agent
-```
-b00t agent enlist pi-001 specialist --contract "..."
-→ Returns: Crew binding for pi-001 as specialist
-```
+# ```
+# b00t agent enlist pi-001 specialist --contract "..."
+# → Returns: Crew binding for pi-001 as specialist
+# ```
 
 ### Check training status
-```
-b00t agent status pi-001
-→ Returns: lifecycle=TRAIN, progress=0.5, readiness=0.3
-```
+# ```
+# b00t agent status pi-001
+# → Returns: lifecycle=TRAIN, progress=0.5, readiness=0.3
+# ```
 
 # b00t:map v1
 # summary: Agent registry protocol — search (capability scoring), enlist (contract binding), train (grok learn plans), status (progress tracking), dismiss (archive + performance) for hive crew management by operator agent

--- a/_b00t_/datums/ANTHROPIC-DESKTOP-EXTENSIONS.tomllmd
+++ b/_b00t_/datums/ANTHROPIC-DESKTOP-EXTENSIONS.tomllmd
@@ -24,354 +24,354 @@ content = "stable"
 
 ## ── Overview ───────────────────────────────────────────────────────────────────
 
-Anthropic Desktop Extensions (`.mcpb` files, formerly `.dxt`) solve the MCP server
-installation problem by bundling an entire MCP server — including all dependencies —
-into a single installable package. Users install with one double-click instead of
-manually editing JSON config files, installing runtimes, and resolving dependencies.
+# Anthropic Desktop Extensions (`.mcpb` files, formerly `.dxt`) solve the MCP server
+# installation problem by bundling an entire MCP server — including all dependencies —
+# into a single installable package. Users install with one double-click instead of
+# manually editing JSON config files, installing runtimes, and resolving dependencies.
 
-Published: 2025-06-26
-File extension update: 2025-09-11 (`.dxt` → `.mcpb`)
-Manifest spec version: 0.3 (as of 2025-12-02)
+# Published: 2025-06-26
+# File extension update: 2025-09-11 (`.dxt` → `.mcpb`)
+# Manifest spec version: 0.3 (as of 2025-12-02)
 
 ### Before vs. After
 
-| Before | After |
-|--------|-------|
-| Install Node.js/Python first | Download a `.mcpb` file |
-| `npm install -g @example/mcp-server` | Double-click to open with Claude Desktop |
-| Edit `~/.claude/claude_desktop_config.json` manually | Click "Install" |
-| Restart Claude Desktop | Done |
-| Hope it works | No terminal, no config files, no dependency conflicts |
+# | Before | After |
+# |--------|-------|
+# | Install Node.js/Python first | Download a `.mcpb` file |
+# | `npm install -g @example/mcp-server` | Double-click to open with Claude Desktop |
+# | Edit `~/.claude/claude_desktop_config.json` manually | Click "Install" |
+# | Restart Claude Desktop | Done |
+# | Hope it works | No terminal, no config files, no dependency conflicts |
 
 ## ── Architecture ────────────────────────────────────────────────────────────────
 
-A Desktop Extension is a **zip archive** (`.mcpb` extension) containing:
+# A Desktop Extension is a **zip archive** (`.mcpb` extension) containing:
 
-1. **manifest.json** — Required. Describes everything Claude Desktop needs to know
-2. **Server code** — The actual MCP server implementation with bundled dependencies
-3. **Assets** — Icons, screenshots, localization resources
+# 1. **manifest.json** — Required. Describes everything Claude Desktop needs to know
+# 2. **Server code** — The actual MCP server implementation with bundled dependencies
+# 3. **Assets** — Icons, screenshots, localization resources
 
 ### Server types supported
 
-| type | runtime | dependency model | bundle size |
-|------|---------|-----------------|-------------|
-| `node` | Node.js | Bundled `node_modules/` | Larger (deps included) |
-| `python` | Python | Bundled `server/lib/` or `server/venv/` | Larger (deps included) |
-| `binary` | None (self-contained) | Pre-compiled executable | Platform-specific |
-| `uv` | UV runtime (v0.4+) | Declared in `pyproject.toml` | ~100 KB (deps streamed) |
+# | type | runtime | dependency model | bundle size |
+# |------|---------|-----------------|-------------|
+# | `node` | Node.js | Bundled `node_modules/` | Larger (deps included) |
+# | `python` | Python | Bundled `server/lib/` or `server/venv/` | Larger (deps included) |
+# | `binary` | None (self-contained) | Pre-compiled executable | Platform-specific |
+# | `uv` | UV runtime (v0.4+) | Declared in `pyproject.toml` | ~100 KB (deps streamed) |
 
-The `uv` server type is the most portable — dependencies are declared in
-`pyproject.toml` and installed by the host app via UV at install time. No bundled
-`.venv` or `server/lib/` directory.
+# The `uv` server type is the most portable — dependencies are declared in
+# `pyproject.toml` and installed by the host app via UV at install time. No bundled
+# `.venv` or `server/lib/` directory.
 
 ## ── Manifest.json specification ────────────────────────────────────────────────
 
-The `manifest.json` is the sole required file. It declares:
+# The `manifest.json` is the sole required file. It declares:
 
 ### Required fields
 
-| field | type | description |
-|-------|------|-------------|
-| `manifest_version` | string | Spec version this extension conforms to (e.g. "0.3") |
-| `name` | string | Machine-readable name (used for CLI, APIs) |
-| `version` | string | Semantic version (semver) |
-| `description` | string | Brief description of what the extension does (localizable) |
-| `author` | object | Author info: `name` (required, localizable), `email`, `url` |
-| `server` | object | Server configuration (see Server Configuration section) |
+# | field | type | description |
+# |-------|------|-------------|
+# | `manifest_version` | string | Spec version this extension conforms to (e.g. "0.3") |
+# | `name` | string | Machine-readable name (used for CLI, APIs) |
+# | `version` | string | Semantic version (semver) |
+# | `description` | string | Brief description of what the extension does (localizable) |
+# | `author` | object | Author info: `name` (required, localizable), `email`, `url` |
+# | `server` | object | Server configuration (see Server Configuration section) |
 
 ### Optional fields
 
-| field | type | description |
-|-------|------|-------------|
-| `display_name` | string | Human-friendly name for UI (localizable) |
-| `long_description` | string | Detailed markdown description for extension stores (localizable) |
-| `icon` | string | Path to PNG icon (relative or `https://` URL) |
-| `icons` | array | Array of icon descriptors: `src`, `size`, optional `theme` |
-| `screenshots` | array | Array of screenshot paths |
-| `repository` | object | Source code repository: `type` and `url` |
-| `homepage` | string | Extension homepage URL |
-| `documentation` | string | Documentation URL |
-| `support` | string | Support/issues URL |
-| `tools` | array | Array of tools the extension provides (localizable) |
-| `tools_generated` | bool | Server generates additional tools at runtime (default: false) |
-| `prompts` | array | Array of prompts the extension provides (localizable) |
-| `prompts_generated` | bool | Server generates additional prompts at runtime (default: false) |
-| `keywords` | array | Search keywords (localizable) |
-| `license` | string | License identifier (e.g. "MIT") |
-| `privacy_policies` | array | URLs to privacy policies for external services handling user data |
-| `compatibility` | object | Client, platform, and runtime requirements |
-| `user_config` | object | User-configurable options the host app collects via UI |
-| `localization` | object | Per-locale resource files for translation |
-| `_meta` | object | Platform-specific client metadata (reverse-DNS keys) |
+# | field | type | description |
+# |-------|------|-------------|
+# | `display_name` | string | Human-friendly name for UI (localizable) |
+# | `long_description` | string | Detailed markdown description for extension stores (localizable) |
+# | `icon` | string | Path to PNG icon (relative or `https://` URL) |
+# | `icons` | array | Array of icon descriptors: `src`, `size`, optional `theme` |
+# | `screenshots` | array | Array of screenshot paths |
+# | `repository` | object | Source code repository: `type` and `url` |
+# | `homepage` | string | Extension homepage URL |
+# | `documentation` | string | Documentation URL |
+# | `support` | string | Support/issues URL |
+# | `tools` | array | Array of tools the extension provides (localizable) |
+# | `tools_generated` | bool | Server generates additional tools at runtime (default: false) |
+# | `prompts` | array | Array of prompts the extension provides (localizable) |
+# | `prompts_generated` | bool | Server generates additional prompts at runtime (default: false) |
+# | `keywords` | array | Search keywords (localizable) |
+# | `license` | string | License identifier (e.g. "MIT") |
+# | `privacy_policies` | array | URLs to privacy policies for external services handling user data |
+# | `compatibility` | object | Client, platform, and runtime requirements |
+# | `user_config` | object | User-configurable options the host app collects via UI |
+# | `localization` | object | Per-locale resource files for translation |
+# | `_meta` | object | Platform-specific client metadata (reverse-DNS keys) |
 
 ### Server configuration object
 
-```json
-{
-  "server": {
-    "type": "node",
-    "entry_point": "server/index.js",
-    "mcp_config": {
-      "command": "node",
-      "args": ["${__dirname}/server/index.js"],
-      "env": {
-        "API_KEY": "${user_config.api_key}"
-      },
-      "platform_overrides": {
-        "win32": {
-          "command": "server/my-server.exe"
-        }
-      }
-    }
-  }
-}
-```
+# ```json
+# {
+#   "server": {
+#     "type": "node",
+#     "entry_point": "server/index.js",
+#     "mcp_config": {
+#       "command": "node",
+#       "args": ["${__dirname}/server/index.js"],
+#       "env": {
+#         "API_KEY": "${user_config.api_key}"
+#       },
+#       "platform_overrides": {
+#         "win32": {
+#           "command": "server/my-server.exe"
+#         }
+#       }
+#     }
+#   }
+# }
+# ```
 
-| field | type | description |
-|-------|------|-------------|
-| `type` | string | One of: `node`, `python`, `binary`, `uv` |
-| `entry_point` | string | Relative path to main server file |
-| `mcp_config` | object | MCP server execution config (replaces manual JSON config) |
-| `mcp_config.command` | string | Command to run |
-| `mcp_config.args` | array | CLI arguments (supports variable substitution) |
-| `mcp_config.env` | object | Environment variables (supports variable substitution) |
-| `mcp_config.platform_overrides` | object | Per-platform `{command, args, env}` overrides |
+# | field | type | description |
+# |-------|------|-------------|
+# | `type` | string | One of: `node`, `python`, `binary`, `uv` |
+# | `entry_point` | string | Relative path to main server file |
+# | `mcp_config` | object | MCP server execution config (replaces manual JSON config) |
+# | `mcp_config.command` | string | Command to run |
+# | `mcp_config.args` | array | CLI arguments (supports variable substitution) |
+# | `mcp_config.env` | object | Environment variables (supports variable substitution) |
+# | `mcp_config.platform_overrides` | object | Per-platform `{command, args, env}` overrides |
 
 ### Variable substitution
 
-The following variables are replaced at install/launch time:
+# The following variables are replaced at install/launch time:
 
-| variable | resolves to |
-|----------|-------------|
-| `${__dirname}` | Absolute path to the extension's unpacked directory |
-| `${HOME}` | User's home directory |
-| `${DESKTOP}` | User's desktop directory |
-| `${DOCUMENTS}` | User's documents directory |
-| `${DOWNLOADS}` | User's downloads directory |
-| `${pathSeparator}` or `${/}` | Platform path separator |
-| `${user_config.KEY}` | User-provided value for configuration KEY |
+# | variable | resolves to |
+# |----------|-------------|
+# | `${__dirname}` | Absolute path to the extension's unpacked directory |
+# | `${HOME}` | User's home directory |
+# | `${DESKTOP}` | User's desktop directory |
+# | `${DOCUMENTS}` | User's documents directory |
+# | `${DOWNLOADS}` | User's downloads directory |
+# | `${pathSeparator}` or `${/}` | Platform path separator |
+# | `${user_config.KEY}` | User-provided value for configuration KEY |
 
 ### User configuration (user_config)
 
-Extensions can declare configuration options collected via the host app's UI.
-Supported types: `string`, `number`, `boolean`, `directory`, `file`.
+# Extensions can declare configuration options collected via the host app's UI.
+# Supported types: `string`, `number`, `boolean`, `directory`, `file`.
 
-| field | description |
-|-------|-------------|
-| `type` | Data type: `string`, `number`, `boolean`, `directory`, `file` |
-| `title` | Display name in UI |
-| `description` | Help text explaining the option |
-| `required` | Must be provided (default: false) |
-| `default` | Default value (supports variable substitution) |
-| `multiple` | Allow multiple selections (directory/file types, default: false) |
-| `sensitive` | Mask input and store in OS keychain (string types, default: false) |
-| `min` / `max` | Numeric validation constraints |
+# | field | description |
+# |-------|-------------|
+# | `type` | Data type: `string`, `number`, `boolean`, `directory`, `file` |
+# | `title` | Display name in UI |
+# | `description` | Help text explaining the option |
+# | `required` | Must be provided (default: false) |
+# | `default` | Default value (supports variable substitution) |
+# | `multiple` | Allow multiple selections (directory/file types, default: false) |
+# | `sensitive` | Mask input and store in OS keychain (string types, default: false) |
+# | `min` / `max` | Numeric validation constraints |
 
 ### Compatibility object
 
-```json
-{
-  "compatibility": {
-    "claude_desktop": ">=1.0.0",
-    "platforms": ["darwin", "win32", "linux"],
-    "runtimes": {
-      "python": ">=3.8",
-      "node": ">=16.0.0"
-    }
-  }
-}
-```
+# ```json
+# {
+#   "compatibility": {
+#     "claude_desktop": ">=1.0.0",
+#     "platforms": ["darwin", "win32", "linux"],
+#     "runtimes": {
+#       "python": ">=3.8",
+#       "node": ">=16.0.0"
+#     }
+#   }
+# }
+# ```
 
 ### Localization
 
-Localized strings live in per-locale resource files without bloating the manifest:
+# Localized strings live in per-locale resource files without bloating the manifest:
 
-```json
-"localization": {
-  "resources": "mcpb-resources/${locale}.json",
-  "default_locale": "en-US"
-}
-```
+# ```json
+# "localization": {
+#   "resources": "mcpb-resources/${locale}.json",
+#   "default_locale": "en-US"
+# }
+# ```
 
-Fields marked 🌎 in the spec are localizable. The default locale's values stay in
-the manifest; locale-specific files only need override values.
+# Fields marked 🌎 in the spec are localizable. The default locale's values stay in
+# the manifest; locale-specific files only need override values.
 
 ## ── Toolchain (dxt CLI) ────────────────────────────────────────────────────────
 
-Anthropic open-sourced the toolchain at https://github.com/anthropics/dxt:
+# Anthropic open-sourced the toolchain at https://github.com/anthropics/dxt:
 
-| command | purpose |
-|---------|---------|
-| `npx @anthropic-ai/dxt init` | Initialize manifest.json (interactive) |
-| `npx @anthropic-ai/dxt init --yes` | Speed-run minimal manifest.json |
-| `npx @anthropic-ai/dxt build` | Bundle everything into `.mcpb` file |
-| `npx @anthropic-ai/dxt validate` | Validate manifest and packaging |
-| `npx @anthropic-ai/dxt watch` | Watch mode for development |
+# | command | purpose |
+# |---------|---------|
+# | `npx @anthropic-ai/dxt init` | Initialize manifest.json (interactive) |
+# | `npx @anthropic-ai/dxt init --yes` | Speed-run minimal manifest.json |
+# | `npx @anthropic-ai/dxt build` | Bundle everything into `.mcpb` file |
+# | `npx @anthropic-ai/dxt validate` | Validate manifest and packaging |
+# | `npx @anthropic-ai/dxt watch` | Watch mode for development |
 
-What `dxt build` does:
-1.  Validates manifest.json
-2.  Copies server files
-3.  Installs dependencies (npm install, pip install)
-4.  Creates platform-specific builds
-5.  Outputs a .mcpb archive
+# What `dxt build` does:
+# 1.  Validates manifest.json
+# 2.  Copies server files
+# 3.  Installs dependencies (npm install, pip install)
+# 4.  Creates platform-specific builds
+# 5.  Outputs a .mcpb archive
 
 ## ── Extension directory / marketplace ──────────────────────────────────────────
 
-Claude Desktop ships with a curated extension directory where users can browse,
-search, and install with one click. Submission process:
+# Claude Desktop ships with a curated extension directory where users can browse,
+# search, and install with one click. Submission process:
 
-1.  Ensure the extension follows submission guidelines
-2.  Test across Windows and macOS
-3.  Anthropic team reviews for quality and security
-4.  Published to the directory
+# 1.  Ensure the extension follows submission guidelines
+# 2.  Test across Windows and macOS
+# 3.  Anthropic team reviews for quality and security
+# 4.  Published to the directory
 
 ## ── Security model ─────────────────────────────────────────────────────────────
 
-| feature | description |
-|---------|-------------|
-| OS keychain storage | Sensitive user config values stored in OS secret vault |
-| Automatic updates | Extensions can declare `update_url` in manifest for self-update |
-| Auditability | Users can see what extensions are installed |
-| Group Policy (Windows) | IT admins can manage extensions via Group Policy |
-| MDM (macOS) | Mobile Device Management support for enterprise |
-| Pre-approved extensions | Admins can pre-install approved extensions |
-| Blocklist | Block specific extensions or publishers |
-| Directory disable | Disable the extension directory entirely |
-| Private directories | Deploy private extension directories for enterprises |
+# | feature | description |
+# |---------|-------------|
+# | OS keychain storage | Sensitive user config values stored in OS secret vault |
+# | Automatic updates | Extensions can declare `update_url` in manifest for self-update |
+# | Auditability | Users can see what extensions are installed |
+# | Group Policy (Windows) | IT admins can manage extensions via Group Policy |
+# | MDM (macOS) | Mobile Device Management support for enterprise |
+# | Pre-approved extensions | Admins can pre-install approved extensions |
+# | Blocklist | Block specific extensions or publishers |
+# | Directory disable | Disable the extension directory entirely |
+# | Private directories | Deploy private extension directories for enterprises |
 
 ## ── Open-source commitment ─────────────────────────────────────────────────────
 
-Anthropic open-sourced the following:
+# Anthropic open-sourced the following:
 
-- Complete MCPB specification
-- Packaging and validation tools (`dxt` CLI)
-- Reference implementation code
-- TypeScript types and schemas
-- All in https://github.com/anthropics/dxt (versioned 0.1, community-driven evolution)
+# - Complete MCPB specification
+# - Packaging and validation tools (`dxt` CLI)
+# - Reference implementation code
+# - TypeScript types and schemas
+# - All in https://github.com/anthropics/dxt (versioned 0.1, community-driven evolution)
 
 ## ── Integration with b00t MCP system ───────────────────────────────────────────
 
-b00t's MCP infrastructure (see `_b00t_/datums/MCP-SERVER-SCHEMA.tomllmd`) uses
-`.mcpb` files as an alternative install pathway. Where traditional MCP servers
-require manual `b00t mcp add` with stdio/http config, Desktop Extensions can be:
+# b00t's MCP infrastructure (see `_b00t_/datums/MCP-SERVER-SCHEMA.tomllmd`) uses
+# `.mcpb` files as an alternative install pathway. Where traditional MCP servers
+# require manual `b00t mcp add` with stdio/http config, Desktop Extensions can be:
 
-1. **Discovered** — Via Claude Desktop's built-in extension directory
-2. **Installed** — Via double-click `.mcpb` → Claude Desktop handles all config
-3. **Managed** — b00t can detect and interact with extensions installed in
-   `~/.claude/claude_desktop_config.json` alongside traditional MCP servers
+# 1. **Discovered** — Via Claude Desktop's built-in extension directory
+# 2. **Installed** — Via double-click `.mcpb` → Claude Desktop handles all config
+# 3. **Managed** — b00t can detect and interact with extensions installed in
+#    `~/.claude/claude_desktop_config.json` alongside traditional MCP servers
 
-The `mcp_config.command` / `mcp_config.args` in a `.mcpb` manifest.json maps
-directly to the `command` / `args` fields in b00t's MCP server transport schema.
+# The `mcp_config.command` / `mcp_config.args` in a `.mcpb` manifest.json maps
+# directly to the `command` / `args` fields in b00t's MCP server transport schema.
 
 ### Installation targets comparison
 
-| target | config file | install method |
-|--------|------------|----------------|
-| hermes | `~/.hermes/config.yaml` | `b00t mcp install <name> hermes` |
-| claudecode | `~/.claude/claude_desktop_config.json` | `b00t mcp install <name> claudecode` OR `.mcpb` double-click |
-| vscode | `~/.config/Code/.../claude_mcp.json` | `b00t mcp install <name> vscode` |
-| geminicli | `.mcp.json` or `~/.gemini/mcp.json` | `b00t mcp install <name> geminicli` |
+# | target | config file | install method |
+# |--------|------------|----------------|
+# | hermes | `~/.hermes/config.yaml` | `b00t mcp install <name> hermes` |
+# | claudecode | `~/.claude/claude_desktop_config.json` | `b00t mcp install <name> claudecode` OR `.mcpb` double-click |
+# | vscode | `~/.config/Code/.../claude_mcp.json` | `b00t mcp install <name> vscode` |
+# | geminicli | `.mcp.json` or `~/.gemini/mcp.json` | `b00t mcp install <name> geminicli` |
 
 ## ── Example: Minimal manifest.json ─────────────────────────────────────────────
 
-```json
-{
-  "manifest_version": "0.3",
-  "name": "my-extension",
-  "version": "1.0.0",
-  "description": "A simple MCP extension",
-  "author": {
-    "name": "Extension Author"
-  },
-  "server": {
-    "type": "node",
-    "entry_point": "server/index.js",
-    "mcp_config": {
-      "command": "node",
-      "args": ["${__dirname}/server/index.js"]
-    }
-  }
-}
-```
+# ```json
+# {
+#   "manifest_version": "0.3",
+#   "name": "my-extension",
+#   "version": "1.0.0",
+#   "description": "A simple MCP extension",
+#   "author": {
+#     "name": "Extension Author"
+#   },
+#   "server": {
+#     "type": "node",
+#     "entry_point": "server/index.js",
+#     "mcp_config": {
+#       "command": "node",
+#       "args": ["${__dirname}/server/index.js"]
+#     }
+#   }
+# }
+# ```
 
 ## ── Example: Full manifest.json ────────────────────────────────────────────────
 
-```json
-{
-  "manifest_version": "0.3",
-  "name": "filesystem-server",
-  "display_name": "Filesystem Server",
-  "version": "1.0.0",
-  "description": "Give Claude access to your file system",
-  "author": {
-    "name": "Example Developer",
-    "email": "dev@example.com"
-  },
-  "server": {
-    "type": "node",
-    "entry_point": "server/index.js",
-    "mcp_config": {
-      "command": "node",
-      "args": [
-        "${__dirname}/server/index.js",
-        "${user_config.allowed_directories}"
-      ]
-    }
-  },
-  "compatibility": {
-    "claude_desktop": ">=1.0.0",
-    "platforms": ["darwin", "win32"],
-    "runtimes": {
-      "node": ">=18.0.0"
-    }
-  },
-  "user_config": {
-    "allowed_directories": {
-      "type": "directory",
-      "title": "Allowed Directories",
-      "description": "Directories the server can access",
-      "multiple": true,
-      "required": true,
-      "default": ["${HOME}/Desktop", "${HOME}/Documents"]
-    }
-  },
-  "tools": [
-    { "name": "list_directory", "description": "List files in a directory" },
-    { "name": "read_file", "description": "Read a file's contents" },
-    { "name": "write_file", "description": "Write content to a file" }
-  ],
-  "keywords": ["filesystem", "file", "directory"],
-  "license": "MIT"
-}
-```
+# ```json
+# {
+#   "manifest_version": "0.3",
+#   "name": "filesystem-server",
+#   "display_name": "Filesystem Server",
+#   "version": "1.0.0",
+#   "description": "Give Claude access to your file system",
+#   "author": {
+#     "name": "Example Developer",
+#     "email": "dev@example.com"
+#   },
+#   "server": {
+#     "type": "node",
+#     "entry_point": "server/index.js",
+#     "mcp_config": {
+#       "command": "node",
+#       "args": [
+#         "${__dirname}/server/index.js",
+#         "${user_config.allowed_directories}"
+#       ]
+#     }
+#   },
+#   "compatibility": {
+#     "claude_desktop": ">=1.0.0",
+#     "platforms": ["darwin", "win32"],
+#     "runtimes": {
+#       "node": ">=18.0.0"
+#     }
+#   },
+#   "user_config": {
+#     "allowed_directories": {
+#       "type": "directory",
+#       "title": "Allowed Directories",
+#       "description": "Directories the server can access",
+#       "multiple": true,
+#       "required": true,
+#       "default": ["${HOME}/Desktop", "${HOME}/Documents"]
+#     }
+#   },
+#   "tools": [
+#     { "name": "list_directory", "description": "List files in a directory" },
+#     { "name": "read_file", "description": "Read a file's contents" },
+#     { "name": "write_file", "description": "Write content to a file" }
+#   ],
+#   "keywords": ["filesystem", "file", "directory"],
+#   "license": "MIT"
+# }
+# ```
 
 ## ── Getting started for developers ─────────────────────────────────────────────
 
-```bash
+# ```bash
 # 1. Initialize a manifest
-npx @anthropic-ai/dxt init
+# npx @anthropic-ai/dxt init
 
 # 2. Declare user config (API keys, allowed directories, etc.)
 #    Edit manifest.json to add user_config section
 
 # 3. Bundle
-npx @anthropic-ai/dxt build
+# npx @anthropic-ai/dxt build
 
 # 4. Test — drag .mcpb into Claude Desktop Settings → Extensions
 #    OR double-click the .mcpb file
 
 # 5. Submit for the directory
 #    https://forms.gle/tyiAZvch1kDADKoP9
-```
+# ```
 
 ## ── Building with Claude Code ──────────────────────────────────────────────────
 
-Claude Code can generate Desktop Extensions with minimal intervention. Recommended
-prompt context:
+# Claude Code can generate Desktop Extensions with minimal intervention. Recommended
+# prompt context:
 
-> Build an MCPB extension. Run `npx @anthropic-ai/dxt init --yes` to create the
-> manifest, then modify it appropriately for the server's needs. After writing
-> the server code, run `npx @anthropic-ai/dxt build` to create the `.mcpb` file.
+# > Build an MCPB extension. Run `npx @anthropic-ai/dxt init --yes` to create the
+# > manifest, then modify it appropriately for the server's needs. After writing
+# > the server code, run `npx @anthropic-ai/dxt build` to create the `.mcpb` file.
 
 # b00t:map v1
 # summary: Anthropic Desktop Extensions (.mcpb) specification — one-click MCP server packaging, manifest.json schema (v0.3), server types (node/python/binary/uv), user_config, variable substitution, platform overrides, localization, security model, extension directory, toolchain (dxt CLI), and integration with b00t's MCP infrastructure

--- a/_b00t_/datums/COPILOT-EXTENSIONS.tomllmd
+++ b/_b00t_/datums/COPILOT-EXTENSIONS.tomllmd
@@ -35,478 +35,478 @@ content = "draft"
 
 ## ── Overview ───────────────────────────────────────────────────────────────────
 
-GitHub Copilot has evolved beyond IDE autocomplete into a full agent platform with
-multiple extension points. b00t-cli should act as a bridge between the b00t
-ecosystem (datums, MCP servers, tools, agents) and the GitHub Copilot platform,
-enabling b00t's capabilities to be available wherever users interact with Copilot.
+# GitHub Copilot has evolved beyond IDE autocomplete into a full agent platform with
+# multiple extension points. b00t-cli should act as a bridge between the b00t
+# ecosystem (datums, MCP servers, tools, agents) and the GitHub Copilot platform,
+# enabling b00t's capabilities to be available wherever users interact with Copilot.
 
 ### Copilot surfaces b00t should target
 
-| Surface | Entry Point | Extension Mechanism | Priority |
-|---------|------------|---------------------|----------|
-| **Copilot CLI** | `copilot` in terminal | MCP servers, custom agents (.agent.md), skills (SKILL.md), hooks, plugins | HIGH |
-| **Copilot cloud agent** | GitHub.com agents panel | Repository MCP config, custom agents (.md), hooks, skills | HIGH |
-| **VS Code / JetBrains / Xcode** | IDE Copilot Chat | MCP servers (via .mcp.json), custom agents (.agent.md) | MEDIUM |
-| **gh copilot** | `gh copilot` CLI | MCP servers, custom agents | MEDIUM |
+# | Surface | Entry Point | Extension Mechanism | Priority |
+# |---------|------------|---------------------|----------|
+# | **Copilot CLI** | `copilot` in terminal | MCP servers, custom agents (.agent.md), skills (SKILL.md), hooks, plugins | HIGH |
+# | **Copilot cloud agent** | GitHub.com agents panel | Repository MCP config, custom agents (.md), hooks, skills | HIGH |
+# | **VS Code / JetBrains / Xcode** | IDE Copilot Chat | MCP servers (via .mcp.json), custom agents (.agent.md) | MEDIUM |
+# | **gh copilot** | `gh copilot` CLI | MCP servers, custom agents | MEDIUM |
 
 ### Extension points at a glance
 
-| Mechanism | What it does | File Format | Location |
-|-----------|-------------|-------------|----------|
-| **MCP servers** | Add collections of tools | JSON / YAML | Repo settings, agent profile, .mcp.json |
-| **Custom agents** | Specialized AI sub-agents | .agent.md (YAML frontmatter + markdown) | `.github/agents/`, `~/.copilot/agents/` |
-| **Skills** | Task-specific instructions + scripts | SKILL.md in skill directories | `.github/skills/`, `.claude/skills/`, `~/.copilot/skills/` |
-| **Hooks** | Lifecycle event handlers | JSON hook configs | `.github/hooks/*.json` |
-| **Plugins** | Installable bundles of agents/skills/hooks/MCP | Directory with standard structure | Marketplace, repo, local path |
-| **Custom instructions** | Persistent behavioral guidance | .md files | `.github/copilot-instructions.md`, `~/.copilot/copilot-instructions.md` |
-| **Copilot Memory** | Persistent context store | Built-in (no user files) | Internal to Copilot |
+# | Mechanism | What it does | File Format | Location |
+# |-----------|-------------|-------------|----------|
+# | **MCP servers** | Add collections of tools | JSON / YAML | Repo settings, agent profile, .mcp.json |
+# | **Custom agents** | Specialized AI sub-agents | .agent.md (YAML frontmatter + markdown) | `.github/agents/`, `~/.copilot/agents/` |
+# | **Skills** | Task-specific instructions + scripts | SKILL.md in skill directories | `.github/skills/`, `.claude/skills/`, `~/.copilot/skills/` |
+# | **Hooks** | Lifecycle event handlers | JSON hook configs | `.github/hooks/*.json` |
+# | **Plugins** | Installable bundles of agents/skills/hooks/MCP | Directory with standard structure | Marketplace, repo, local path |
+# | **Custom instructions** | Persistent behavioral guidance | .md files | `.github/copilot-instructions.md`, `~/.copilot/copilot-instructions.md` |
+# | **Copilot Memory** | Persistent context store | Built-in (no user files) | Internal to Copilot |
 
 ## ── Architecture ────────────────────────────────────────────────────────────────
 
 ### How b00t-cli maps to Copilot extension points
 
-```
-b00t-cli
-  │
-  ├── b00t mcp install <name> copilot    ──►  Writes .mcp.json / repo MCP config
-  │
-  ├── b00t copilot agent create          ──►  Generates .agent.md profile
-  │
-  ├── b00t copilot skill install         ──►  Installs SKILL.md + scripts
-  │
-  ├── b00t copilot hook install          ──►  Writes hooks JSON config
-  │
-  ├── b00t copilot plugin build          ──►  Bundles into plugin package
-  │
-  └── b00t copilot discover              ──►  Scans b00t datums → recommends Copilot configs
-```
+# ```
+# b00t-cli
+#   │
+#   ├── b00t mcp install <name> copilot    ──►  Writes .mcp.json / repo MCP config
+#   │
+#   ├── b00t copilot agent create          ──►  Generates .agent.md profile
+#   │
+#   ├── b00t copilot skill install         ──►  Installs SKILL.md + scripts
+#   │
+#   ├── b00t copilot hook install          ──►  Writes hooks JSON config
+#   │
+#   ├── b00t copilot plugin build          ──►  Bundles into plugin package
+#   │
+#   └── b00t copilot discover              ──►  Scans b00t datums → recommends Copilot configs
+# ```
 
 ### Existing foundation
 
-b00t-cli already has:
+# b00t-cli already has:
 
-1. **MCP install infrastructure** — `b00t mcp install <name> <target>` dispatches
-   to claudecode, vscode, geminicli, dotmcpjson, roocode, codex, stdout.
-   Adding `copilot` as a target follows this pattern exactly.
+# 1. **MCP install infrastructure** — `b00t mcp install <name> <target>` dispatches
+#    to claudecode, vscode, geminicli, dotmcpjson, roocode, codex, stdout.
+#    Adding `copilot` as a target follows this pattern exactly.
 
-2. **Copilot runtime adapter** — `b00t-cli/src/install/runtimes/copilot.rs`
-   already implements `RuntimeAdapter` for Copilot with:
-   - `target_dir()` → `~/.copilot/` (global) or `<repo>/.copilot/` (local)
-   - `settings_path()` → `~/.copilot/copilot-instructions.md`
-   - `hooks_dir()` → `~/.copilot/hooks/`
-   - `agents_dir()` → `~/.copilot/agents/`
-   - `skills_dir()` → `~/.copilot/skills/`
-   - Detection via `~/.copilot/` directory existence
+# 2. **Copilot runtime adapter** — `b00t-cli/src/install/runtimes/copilot.rs`
+#    already implements `RuntimeAdapter` for Copilot with:
+#    - `target_dir()` → `~/.copilot/` (global) or `<repo>/.copilot/` (local)
+#    - `settings_path()` → `~/.copilot/copilot-instructions.md`
+#    - `hooks_dir()` → `~/.copilot/hooks/`
+#    - `agents_dir()` → `~/.copilot/agents/`
+#    - `skills_dir()` → `~/.copilot/skills/`
+#    - Detection via `~/.copilot/` directory existence
 
-3. **Copilot hook scripts** — Five compiled JavaScript hooks in
-   `_b00t_/runtimes/copilot/hooks/`: b00t-bug-capture, b00t-context-monitor,
-   b00t-datum-guard, b00t-statusline, b00t-update-check.
+# 3. **Copilot hook scripts** — Five compiled JavaScript hooks in
+#    `_b00t_/runtimes/copilot/hooks/`: b00t-bug-capture, b00t-context-monitor,
+#    b00t-datum-guard, b00t-statusline, b00t-update-check.
 
-4. **gh-copilot CLI extension** — `gh extension install github/gh-copilot` is
-   run during `setup.sh`.
+# 4. **gh-copilot CLI extension** — `gh extension install github/gh-copilot` is
+#    run during `setup.sh`.
 
 ## ── MCP server registration for Copilot ────────────────────────────────────────
 
 ### The problem
 
-Copilot cloud agent supports MCP servers but with a different configuration format
-than Claude Code / VS Code. Copilot's config is:
+# Copilot cloud agent supports MCP servers but with a different configuration format
+# than Claude Code / VS Code. Copilot's config is:
 
-1. **Repository-level**: JSON config entered via GitHub.com repo Settings → Copilot → Cloud agent
-   OR via `.github/copilot-mcp.json`
-2. **Agent-level**: YAML in custom agent profile frontmatter (`mcp-servers` property)
-3. **CLI-level**: `.mcp.json` file (same format as VS Code)
+# 1. **Repository-level**: JSON config entered via GitHub.com repo Settings → Copilot → Cloud agent
+#    OR via `.github/copilot-mcp.json`
+# 2. **Agent-level**: YAML in custom agent profile frontmatter (`mcp-servers` property)
+# 3. **CLI-level**: `.mcp.json` file (same format as VS Code)
 
 ### Configuration format for Copilot cloud agent (repo-level)
 
-```json
-{
-  "mcpServers": {
-    "b00t-tools": {
-      "type": "local",
-      "command": "b00t",
-      "args": ["mcp", "serve"],
-      "tools": ["*"],
-      "env": {
-        "B00T_HOME": "$COPILOT_MCP_B00T_HOME"
-      }
-    },
-    "b00t-grok": {
-      "type": "local",
-      "command": "b00t",
-      "args": ["grok", "mcp-serve"],
-      "tools": ["search", "ask", "digest"],
-      "env": {
-        "B00T_HOME": "$COPILOT_MCP_B00T_HOME"
-      }
-    }
-  }
-}
-```
+# ```json
+# {
+#   "mcpServers": {
+#     "b00t-tools": {
+#       "type": "local",
+#       "command": "b00t",
+#       "args": ["mcp", "serve"],
+#       "tools": ["*"],
+#       "env": {
+#         "B00T_HOME": "$COPILOT_MCP_B00T_HOME"
+#       }
+#     },
+#     "b00t-grok": {
+#       "type": "local",
+#       "command": "b00t",
+#       "args": ["grok", "mcp-serve"],
+#       "tools": ["search", "ask", "digest"],
+#       "env": {
+#         "B00T_HOME": "$COPILOT_MCP_B00T_HOME"
+#       }
+#     }
+#   }
+# }
+# ```
 
 ### Configuration format for Copilot CLI (.mcp.json)
 
-Same `.mcp.json` format used by VS Code and Claude Code:
+# Same `.mcp.json` format used by VS Code and Claude Code:
 
-```json
-{
-  "mcpServers": {
-    "b00t-tools": {
-      "command": "b00t",
-      "args": ["mcp", "serve"],
-      "env": {}
-    }
-  }
-}
-```
+# ```json
+# {
+#   "mcpServers": {
+#     "b00t-tools": {
+#       "command": "b00t",
+#       "args": ["mcp", "serve"],
+#       "env": {}
+#     }
+#   }
+# }
+# ```
 
 ### Key differences from Claude Code MCP config
 
-| Aspect | Claude Code / VS Code | Copilot cloud agent |
-|--------|----------------------|---------------------|
-| Config location | `~/.claude/claude_desktop_config.json` or `.mcp.json` | GitHub.com repo settings or agent profile YAML |
-| `type` field | Not used (stdio assumed) | Required: `"local"`, `"stdio"`, `"http"`, or `"sse"` |
-| `tools` field | Not used | Required: array of tool names or `["*"]` |
-| `env` secrets | Plain env vars | `$COPILOT_MCP_*` prefix, Agents secrets |
-| Variable syntax | `${ENV_VAR}` | `$VAR`, `${VAR}`, `${VAR:-default}`, `${{ secrets.NAME }}` |
-| OAuth support | Yes | Not yet supported for remote MCP |
+# | Aspect | Claude Code / VS Code | Copilot cloud agent |
+# |--------|----------------------|---------------------|
+# | Config location | `~/.claude/claude_desktop_config.json` or `.mcp.json` | GitHub.com repo settings or agent profile YAML |
+# | `type` field | Not used (stdio assumed) | Required: `"local"`, `"stdio"`, `"http"`, or `"sse"` |
+# | `tools` field | Not used | Required: array of tool names or `["*"]` |
+# | `env` secrets | Plain env vars | `$COPILOT_MCP_*` prefix, Agents secrets |
+# | Variable syntax | `${ENV_VAR}` | `$VAR`, `${VAR}`, `${VAR:-default}`, `${{ secrets.NAME }}` |
+# | OAuth support | Yes | Not yet supported for remote MCP |
 
 ### b00t mcp install copilot target
 
-New install target `copilot` will:
+# New install target `copilot` will:
 
-1. **For Copilot CLI** (`b00t mcp install <name> copilot --cli`): Write to
-   `.mcp.json` in repo root or `~/.copilot/.mcp.json`
-2. **For Copilot cloud agent** (`b00t mcp install <name> copilot --cloud`):
-   - Generate the JSON config snippet
-   - Print instructions for adding via GitHub.com repo settings
-   - Optionally write to `.github/copilot-mcp-config.json` for reference
-3. **For agent-level** (`b00t mcp install <name> copilot --agent <agent-name>`):
-   - Generate YAML `mcp-servers` block for custom agent profile
-   - Append or create `.agent.md` file
+# 1. **For Copilot CLI** (`b00t mcp install <name> copilot --cli`): Write to
+#    `.mcp.json` in repo root or `~/.copilot/.mcp.json`
+# 2. **For Copilot cloud agent** (`b00t mcp install <name> copilot --cloud`):
+#    - Generate the JSON config snippet
+#    - Print instructions for adding via GitHub.com repo settings
+#    - Optionally write to `.github/copilot-mcp-config.json` for reference
+# 3. **For agent-level** (`b00t mcp install <name> copilot --agent <agent-name>`):
+#    - Generate YAML `mcp-servers` block for custom agent profile
+#    - Append or create `.agent.md` file
 
 ## ── Custom agents ──────────────────────────────────────────────────────────────
 
 ### Agent profile format
 
-Custom agents for Copilot CLI use `.agent.md` files with YAML frontmatter:
+# Custom agents for Copilot CLI use `.agent.md` files with YAML frontmatter:
 
-```markdown
----
-name: b00t-expert
-description: Agent that uses b00t-cli tools and MCP servers for system management
-tools: ["read", "edit", "search", "execute"]
-mcp-servers:
-  b00t-tools:
-    type: "local"
-    command: "b00t"
-    args: ["mcp", "serve"]
-    tools: ["*"]
-    env:
-      B00T_HOME: "${{ secrets.COPILOT_MCP_B00T_HOME }}"
----
+# ```markdown
+# ---
+# name: b00t-expert
+# description: Agent that uses b00t-cli tools and MCP servers for system management
+# tools: ["read", "edit", "search", "execute"]
+# mcp-servers:
+#   b00t-tools:
+#     type: "local"
+#     command: "b00t"
+#     args: ["mcp", "serve"]
+#     tools: ["*"]
+#     env:
+#       B00T_HOME: "${{ secrets.COPILOT_MCP_B00T_HOME }}"
+# ---
 
-You are a b00t system management expert. You have access to b00t-cli's full
-tool suite via MCP. Use b00t tools to:
+# You are a b00t system management expert. You have access to b00t-cli's full
+# tool suite via MCP. Use b00t tools to:
 
-- Install and manage CLI tools via `b00t cli install`
-- Register and configure MCP servers via `b00t mcp install`
-- Query the b00t knowledgebase via `b00t grok ask`
-- Learn new topics via `b00t grok learn`
-- Check tool versions via `b00t cli detect`
+# - Install and manage CLI tools via `b00t cli install`
+# - Register and configure MCP servers via `b00t mcp install`
+# - Query the b00t knowledgebase via `b00t grok ask`
+# - Learn new topics via `b00t grok learn`
+# - Check tool versions via `b00t cli detect`
 
-When the user asks about system setup, tool installation, or b00t management,
-use the appropriate MCP tools. Always prefer b00t-managed installation over
-manual steps.
-```
+# When the user asks about system setup, tool installation, or b00t management,
+# use the appropriate MCP tools. Always prefer b00t-managed installation over
+# manual steps.
+# ```
 
 ### Custom agents for Copilot cloud agent
 
-Cloud agent uses `.md` files (not `.agent.md`) in `.github/agents/`:
+# Cloud agent uses `.md` files (not `.agent.md`) in `.github/agents/`:
 
-```markdown
----
-name: b00t-sysadmin
-description: System administrator agent with b00t-cli access for managing tools and MCP servers
----
+# ```markdown
+# ---
+# name: b00t-sysadmin
+# description: System administrator agent with b00t-cli access for managing tools and MCP servers
+# ---
 
-You are a system administrator with access to b00t-cli. Your capabilities include:
-- Installing development tools
-- Managing MCP server configurations
-- Diagnosing system issues
-- Keeping tools updated
-```
+# You are a system administrator with access to b00t-cli. Your capabilities include:
+# - Installing development tools
+# - Managing MCP server configurations
+# - Diagnosing system issues
+# - Keeping tools updated
+# ```
 
 ### b00t copilot agent commands
 
-| Command | Action |
-|---------|--------|
-| `b00t copilot agent create <name>` | Generate .agent.md profile from template |
-| `b00t copilot agent list` | List installed custom agents |
-| `b00t copilot agent install <agent-file>` | Copy .agent.md to agents directory |
-| `b00t copilot agent init` | Create default b00t agent profile |
+# | Command | Action |
+# |---------|--------|
+# | `b00t copilot agent create <name>` | Generate .agent.md profile from template |
+# | `b00t copilot agent list` | List installed custom agents |
+# | `b00t copilot agent install <agent-file>` | Copy .agent.md to agents directory |
+# | `b00t copilot agent init` | Create default b00t agent profile |
 
 ## ── Skills ─────────────────────────────────────────────────────────────────────
 
 ### Skill format
 
-Skills are directories containing a `SKILL.md` file:
+# Skills are directories containing a `SKILL.md` file:
 
-```markdown
----
-name: b00t-tool-install
-description: Install CLI tools using b00t-cli. Use when asked to install programming languages, tools, or runtimes.
-allowed-tools: shell
----
+# ```markdown
+# ---
+# name: b00t-tool-install
+# description: Install CLI tools using b00t-cli. Use when asked to install programming languages, tools, or runtimes.
+# allowed-tools: shell
+# ---
 
-When asked to install a tool:
+# When asked to install a tool:
 
-1. Check if the tool is available via `b00t cli detect <tool>`
-2. If not installed, run `b00t cli install <tool>`
-3. Verify installation with `b00t cli detect <tool>`
-4. If the tool isn't in b00t's registry, suggest adding it via `b00t cli add`
-```
+# 1. Check if the tool is available via `b00t cli detect <tool>`
+# 2. If not installed, run `b00t cli install <tool>`
+# 3. Verify installation with `b00t cli detect <tool>`
+# 4. If the tool isn't in b00t's registry, suggest adding it via `b00t cli add`
+# ```
 
 ### b00t copilot skill commands
 
-| Command | Action |
-|---------|--------|
-| `b00t copilot skill list` | List available skills |
-| `b00t copilot skill install <name>` | Install a b00t-provided skill |
-| `b00t copilot skill create <name>` | Create a new skill from template |
-| `b00t copilot skill build <datum>` | Convert a b00t datum into a skill |
+# | Command | Action |
+# |---------|--------|
+# | `b00t copilot skill list` | List available skills |
+# | `b00t copilot skill install <name>` | Install a b00t-provided skill |
+# | `b00t copilot skill create <name>` | Create a new skill from template |
+# | `b00t copilot skill build <datum>` | Convert a b00t datum into a skill |
 
 ### Default b00t skills for Copilot
 
-| Skill | Description |
-|-------|-------------|
-| `b00t-tool-install` | Install CLI tools via b00t |
-| `b00t-mcp-manage` | Manage MCP server installations |
-| `b00t-grok-query` | Query b00t knowledgebase |
-| `b00t-datum-validate` | Validate and check datum conformance |
-| `b00t-sysdiag` | System diagnostics and version checking |
+# | Skill | Description |
+# |-------|-------------|
+# | `b00t-tool-install` | Install CLI tools via b00t |
+# | `b00t-mcp-manage` | Manage MCP server installations |
+# | `b00t-grok-query` | Query b00t knowledgebase |
+# | `b00t-datum-validate` | Validate and check datum conformance |
+# | `b00t-sysdiag` | System diagnostics and version checking |
 
 ## ── Hooks ──────────────────────────────────────────────────────────────────────
 
 ### Hook format for Copilot
 
-Hooks are JSON files in `.github/hooks/*.json`:
+# Hooks are JSON files in `.github/hooks/*.json`:
 
-```json
-{
-  "version": 1,
-  "hooks": {
-    "sessionStart": [
-      {
-        "type": "command",
-        "bash": "b00t status",
-        "timeoutSec": 5
-      }
-    ],
-    "preToolUse": [
-      {
-        "type": "command",
-        "bash": "_b00t_/runtimes/copilot/hooks/b00t-datum-guard.js \"$INPUT\"",
-        "timeoutSec": 10
-      }
-    ],
-    "sessionEnd": [
-      {
-        "type": "command",
-        "bash": "b00t session end",
-        "timeoutSec": 5
-      }
-    ]
-  }
-}
-```
+# ```json
+# {
+#   "version": 1,
+#   "hooks": {
+#     "sessionStart": [
+#       {
+#         "type": "command",
+#         "bash": "b00t status",
+#         "timeoutSec": 5
+#       }
+#     ],
+#     "preToolUse": [
+#       {
+#         "type": "command",
+#         "bash": "_b00t_/runtimes/copilot/hooks/b00t-datum-guard.js \"$INPUT\"",
+#         "timeoutSec": 10
+#       }
+#     ],
+#     "sessionEnd": [
+#       {
+#         "type": "command",
+#         "bash": "b00t session end",
+#         "timeoutSec": 5
+#       }
+#     ]
+#   }
+# }
+# ```
 
 ### Existing hooks ready for Copilot
 
-The hooks already compiled in `_b00t_/runtimes/copilot/hooks/` are compatible
-with Copilot's hook system. They need a Copilot-specific hook JSON config:
+# The hooks already compiled in `_b00t_/runtimes/copilot/hooks/` are compatible
+# with Copilot's hook system. They need a Copilot-specific hook JSON config:
 
-| Hook | Hook Type | Purpose |
-|------|-----------|---------|
-| `b00t-bug-capture.js` | errorOccurred | Capture and log errors |
-| `b00t-context-monitor.js` | sessionStart / sessionEnd | Track context usage |
-| `b00t-datum-guard.js` | preToolUse | Guard dangerous commands |
-| `b00t-statusline.js` | sessionStart | Display b00t status |
-| `b00t-update-check.js` | sessionStart | Check for tool updates |
+# | Hook | Hook Type | Purpose |
+# |------|-----------|---------|
+# | `b00t-bug-capture.js` | errorOccurred | Capture and log errors |
+# | `b00t-context-monitor.js` | sessionStart / sessionEnd | Track context usage |
+# | `b00t-datum-guard.js` | preToolUse | Guard dangerous commands |
+# | `b00t-statusline.js` | sessionStart | Display b00t status |
+# | `b00t-update-check.js` | sessionStart | Check for tool updates |
 
 ### b00t copilot hook commands
 
-| Command | Action |
-|---------|--------|
-| `b00t copilot hook install` | Install hook JSON config to `.github/hooks/` |
-| `b00t copilot hook list` | List installed hooks |
-| `b00t copilot hook enable <name>` | Enable a specific hook |
-| `b00t copilot hook disable <name>` | Disable a specific hook |
+# | Command | Action |
+# |---------|--------|
+# | `b00t copilot hook install` | Install hook JSON config to `.github/hooks/` |
+# | `b00t copilot hook list` | List installed hooks |
+# | `b00t copilot hook enable <name>` | Enable a specific hook |
+# | `b00t copilot hook disable <name>` | Disable a specific hook |
 
 ## ── Plugins ─────────────────────────────────────────────────────────────────────
 
 ### Plugin structure
 
-A Copilot CLI plugin is a directory with a standard structure:
+# A Copilot CLI plugin is a directory with a standard structure:
 
-```
-b00t-copilot-plugin/
-├── plugin.json             # Plugin manifest (required)
-├── README.md               # Documentation
-├── agents/                 # Custom agent profiles
-│   ├── b00t-expert.agent.md
-│   └── b00t-diagnostician.agent.md
-├── skills/                 # Skill directories
-│   ├── b00t-tool-install/
-│   │   └── SKILL.md
-│   └── b00t-mcp-manage/
-│       └── SKILL.md
-├── hooks/                  # Hook JSON configs
-│   └── b00t-hooks.json
-└── .mcp.json               # MCP server config
-```
+# ```
+# b00t-copilot-plugin/
+# ├── plugin.json             # Plugin manifest (required)
+# ├── README.md               # Documentation
+# ├── agents/                 # Custom agent profiles
+# │   ├── b00t-expert.agent.md
+# │   └── b00t-diagnostician.agent.md
+# ├── skills/                 # Skill directories
+# │   ├── b00t-tool-install/
+# │   │   └── SKILL.md
+# │   └── b00t-mcp-manage/
+# │       └── SKILL.md
+# ├── hooks/                  # Hook JSON configs
+# │   └── b00t-hooks.json
+# └── .mcp.json               # MCP server config
+# ```
 
 ### plugin.json manifest
 
-```json
-{
-  "name": "b00t",
-  "version": "0.1.0",
-  "description": "b00t system management tools for Copilot CLI",
-  "agents": ["b00t-expert", "b00t-diagnostician"],
-  "skills": ["b00t-tool-install", "b00t-mcp-manage"],
-  "hooks": ["b00t-hooks"],
-  "mcp_servers": ["b00t-tools"]
-}
-```
+# ```json
+# {
+#   "name": "b00t",
+#   "version": "0.1.0",
+#   "description": "b00t system management tools for Copilot CLI",
+#   "agents": ["b00t-expert", "b00t-diagnostician"],
+#   "skills": ["b00t-tool-install", "b00t-mcp-manage"],
+#   "hooks": ["b00t-hooks"],
+#   "mcp_servers": ["b00t-tools"]
+# }
+# ```
 
 ### b00t copilot plugin commands
 
-| Command | Action |
-|---------|--------|
-| `b00t copilot plugin build` | Build plugin from b00t datums |
-| `b00t copilot plugin install` | Install plugin to Copilot CLI |
-| `b00t copilot plugin publish` | Publish to marketplace (future) |
+# | Command | Action |
+# |---------|--------|
+# | `b00t copilot plugin build` | Build plugin from b00t datums |
+# | `b00t copilot plugin install` | Install plugin to Copilot CLI |
+# | `b00t copilot plugin publish` | Publish to marketplace (future) |
 
 ## ── Datum-to-Copilot mapping ───────────────────────────────────────────────────
 
-b00t datums contain everything needed to generate Copilot configurations:
+# b00t datums contain everything needed to generate Copilot configurations:
 
-| b00t Datum Type | Copilot Extension | Generation Method |
-|-----------------|-------------------|-------------------|
-| `.cli.toml` (CLI tool) | Skill (tool install guide) + MCP tool | Generate SKILL.md + add tool to MCP config |
-| `.mcp.toml` (MCP server) | MCP server config | Generate Copilot-format JSON/YAML config |
-| `.agent.toml` (agent profile) | Custom agent .agent.md | Translate TOML to YAML frontmatter |
-| `.role.toml` (agent role) | Custom agent | Generate agent profile with role prompt |
-| Datum collection | Plugin | Bundle multiple datums into plugin dir |
+# | b00t Datum Type | Copilot Extension | Generation Method |
+# |-----------------|-------------------|-------------------|
+# | `.cli.toml` (CLI tool) | Skill (tool install guide) + MCP tool | Generate SKILL.md + add tool to MCP config |
+# | `.mcp.toml` (MCP server) | MCP server config | Generate Copilot-format JSON/YAML config |
+# | `.agent.toml` (agent profile) | Custom agent .agent.md | Translate TOML to YAML frontmatter |
+# | `.role.toml` (agent role) | Custom agent | Generate agent profile with role prompt |
+# | Datum collection | Plugin | Bundle multiple datums into plugin dir |
 
 ## ── Implementation plan ─────────────────────────────────────────────────────────
 
 ### Phase 1: MCP install target for Copilot (HIGH priority)
 
-**Goal**: `b00t mcp install <name> copilot` works and generates correct config.
+# **Goal**: `b00t mcp install <name> copilot` works and generates correct config.
 
-Steps:
-1. Add `"copilot"` to the list of valid install targets in
-   `b00t-cli/src/commands/mcp.rs`
-2. Create installation logic that:
-   - For Copilot CLI: writes to `.mcp.json` (same format as VS Code)
-   - For cloud agent: generates JSON snippet with `type`, `tools`, `env` fields
-   - Handles `$COPILOT_MCP_*` env var prefix for secrets
-3. Add `--cli` and `--cloud` flags to distinguish targets
-4. Write Copilot-format config generator function in
-   `b00t-cli/src/install/runtimes/copilot.rs` or new module
-5. Add tests for config generation
+# Steps:
+# 1. Add `"copilot"` to the list of valid install targets in
+#    `b00t-cli/src/commands/mcp.rs`
+# 2. Create installation logic that:
+#    - For Copilot CLI: writes to `.mcp.json` (same format as VS Code)
+#    - For cloud agent: generates JSON snippet with `type`, `tools`, `env` fields
+#    - Handles `$COPILOT_MCP_*` env var prefix for secrets
+# 3. Add `--cli` and `--cloud` flags to distinguish targets
+# 4. Write Copilot-format config generator function in
+#    `b00t-cli/src/install/runtimes/copilot.rs` or new module
+# 5. Add tests for config generation
 
-**Files to modify**:
-- `b00t-cli/src/commands/mcp.rs` — Add "copilot" target
-- `b00t-cli/src/install/runtimes/copilot.rs` — Add MCP config generation
-- `b00t-cli/CLAUDE.md` — Document new target
+# **Files to modify**:
+# - `b00t-cli/src/commands/mcp.rs` — Add "copilot" target
+# - `b00t-cli/src/install/runtimes/copilot.rs` — Add MCP config generation
+# - `b00t-cli/CLAUDE.md` — Document new target
 
 ### Phase 2: Custom agent generation (HIGH priority)
 
-**Goal**: `b00t copilot agent create <name>` generates valid `.agent.md` files.
+# **Goal**: `b00t copilot agent create <name>` generates valid `.agent.md` files.
 
-Steps:
-1. Create `b00t-cli/src/commands/copilot.rs` with `CopilotCommands` enum
-2. Implement agent profile template engine
-3. Add `agent create`, `agent list`, `agent install` subcommands
-4. Register in `b00t-cli/src/commands/mod.rs`
+# Steps:
+# 1. Create `b00t-cli/src/commands/copilot.rs` with `CopilotCommands` enum
+# 2. Implement agent profile template engine
+# 3. Add `agent create`, `agent list`, `agent install` subcommands
+# 4. Register in `b00t-cli/src/commands/mod.rs`
 
-**Files to create**:
-- `b00t-cli/src/commands/copilot.rs` — Copilot subcommands
+# **Files to create**:
+# - `b00t-cli/src/commands/copilot.rs` — Copilot subcommands
 
-**Files to modify**:
-- `b00t-cli/src/commands/mod.rs` — Register CopilotCommands
+# **Files to modify**:
+# - `b00t-cli/src/commands/mod.rs` — Register CopilotCommands
 
 ### Phase 3: Skill management (MEDIUM priority)
 
-**Goal**: `b00t copilot skill install` installs b00t skills for Copilot.
+# **Goal**: `b00t copilot skill install` installs b00t skills for Copilot.
 
-Steps:
-1. Create default skill templates in `_b00t_/runtimes/copilot/skills/`
-2. Implement skill install/ls/create commands
-3. Map b00t datums to skill SKILL.md files
+# Steps:
+# 1. Create default skill templates in `_b00t_/runtimes/copilot/skills/`
+# 2. Implement skill install/ls/create commands
+# 3. Map b00t datums to skill SKILL.md files
 
-**Files to create**:
-- `_b00t_/runtimes/copilot/skills/b00t-tool-install/SKILL.md`
-- `_b00t_/runtimes/copilot/skills/b00t-mcp-manage/SKILL.md`
-- `_b00t_/runtimes/copilot/skills/b00t-grok-query/SKILL.md`
-- `_b00t_/runtimes/copilot/skills/b00t-datum-validate/SKILL.md`
-- `_b00t_/runtimes/copilot/skills/b00t-sysdiag/SKILL.md`
+# **Files to create**:
+# - `_b00t_/runtimes/copilot/skills/b00t-tool-install/SKILL.md`
+# - `_b00t_/runtimes/copilot/skills/b00t-mcp-manage/SKILL.md`
+# - `_b00t_/runtimes/copilot/skills/b00t-grok-query/SKILL.md`
+# - `_b00t_/runtimes/copilot/skills/b00t-datum-validate/SKILL.md`
+# - `_b00t_/runtimes/copilot/skills/b00t-sysdiag/SKILL.md`
 
 ### Phase 4: Hook installation (MEDIUM priority)
 
-**Goal**: Existing b00t hooks are installable to Copilot CLI via `b00t copilot hook install`.
+# **Goal**: Existing b00t hooks are installable to Copilot CLI via `b00t copilot hook install`.
 
-Steps:
-1. Create Copilot-specific hook JSON config file
-2. Implement hook install command
-3. Map existing `_b00t_/runtimes/copilot/hooks/*.js` to Copilot hook types
+# Steps:
+# 1. Create Copilot-specific hook JSON config file
+# 2. Implement hook install command
+# 3. Map existing `_b00t_/runtimes/copilot/hooks/*.js` to Copilot hook types
 
-**Files to create**:
-- `_b00t_/runtimes/copilot/hooks.json` — Copilot hook config
+# **Files to create**:
+# - `_b00t_/runtimes/copilot/hooks.json` — Copilot hook config
 
 ### Phase 5: Plugin packaging (LOW priority)
 
-**Goal**: `b00t copilot plugin build` creates a Copilot CLI plugin from datums.
+# **Goal**: `b00t copilot plugin build` creates a Copilot CLI plugin from datums.
 
-Steps:
-1. Create plugin manifest template
-2. Implement plugin build command that collects agents, skills, hooks, MCP configs
-3. Create plugin install command
-4. Optionally publish to a marketplace
+# Steps:
+# 1. Create plugin manifest template
+# 2. Implement plugin build command that collects agents, skills, hooks, MCP configs
+# 3. Create plugin install command
+# 4. Optionally publish to a marketplace
 
 ### Phase 6: Discovery & auto-config (LOW priority)
 
-**Goal**: `b00t copilot discover` scans installed MCP servers and recommends
-Copilot configurations.
+# **Goal**: `b00t copilot discover` scans installed MCP servers and recommends
+# Copilot configurations.
 
-Steps:
-1. Scan `_b00t_/*.mcp.toml` files
-2. Generate Copilot-format config snippets
-3. Print recommendations and setup instructions
+# Steps:
+# 1. Scan `_b00t_/*.mcp.toml` files
+# 2. Generate Copilot-format config snippets
+# 3. Print recommendations and setup instructions
 
 ## ── Security considerations ────────────────────────────────────────────────────
 
-| Concern | Mitigation |
-|---------|------------|
-| **Secret exposure** | Use `$COPILOT_MCP_*` prefix for secrets stored as Agents secrets |
-| **Dangerous tools** | Copilot cloud agent requires explicit `tools` allowlist — b00t should default to read-only tools |
-| **Command injection** | Hook scripts should validate and sanitize input from Copilot |
-| **Trust boundary** | Copilot CLI asks for directory trust — b00t hooks should respect existing trust settings |
-| **MCP tool access** | Copilot uses MCP tools autonomously without approval — only register safe tools |
+# | Concern | Mitigation |
+# |---------|------------|
+# | **Secret exposure** | Use `$COPILOT_MCP_*` prefix for secrets stored as Agents secrets |
+# | **Dangerous tools** | Copilot cloud agent requires explicit `tools` allowlist — b00t should default to read-only tools |
+# | **Command injection** | Hook scripts should validate and sanitize input from Copilot |
+# | **Trust boundary** | Copilot CLI asks for directory trust — b00t hooks should respect existing trust settings |
+# | **MCP tool access** | Copilot uses MCP tools autonomously without approval — only register safe tools |
 
 ## ── Future considerations ───────────────────────────────────────────────────────
 
-| Area | Description |
-|------|-------------|
-| **Copilot Memory** | b00t could seed Copilot Memory with b00t conventions and tool knowledge |
-| **VS Code custom agents** | Copilot custom agents also work in VS Code — agent profiles generated by b00t should be compatible |
-| **Enterprise agents** | Organization-level custom agents via `.github-private` repo |
-| **Cross-platform MCP** | b00t MCP servers running as HTTP/SSE could be registered with Copilot cloud agent as remote MCP |
-| **Plugin marketplace** | b00t plugin could be published to github/copilot-plugins marketplace |
-| **OAuth for remote MCP** | When Copilot supports OAuth for remote MCP, b00t could offer an HTTP MCP endpoint |
+# | Area | Description |
+# |------|-------------|
+# | **Copilot Memory** | b00t could seed Copilot Memory with b00t conventions and tool knowledge |
+# | **VS Code custom agents** | Copilot custom agents also work in VS Code — agent profiles generated by b00t should be compatible |
+# | **Enterprise agents** | Organization-level custom agents via `.github-private` repo |
+# | **Cross-platform MCP** | b00t MCP servers running as HTTP/SSE could be registered with Copilot cloud agent as remote MCP |
+# | **Plugin marketplace** | b00t plugin could be published to github/copilot-plugins marketplace |
+# | **OAuth for remote MCP** | When Copilot supports OAuth for remote MCP, b00t could offer an HTTP MCP endpoint |
 
 # b00t:map v1
 # summary: GitHub Copilot Extensions integration for b00t-cli — MCP server registration (copilot install target), custom agents (.agent.md generation), skills (SKILL.md), hooks (JSON config), plugins (bundled distribution), and 6-phase implementation plan mapping all 7 Copilot extension points

--- a/_b00t_/datums/CREW-ROLES.tomllmd
+++ b/_b00t_/datums/CREW-ROLES.tomllmd
@@ -26,113 +26,113 @@ content = "stable"
 
 ## ── Crew Role Definitions ──────────────────────────────────────────────────────
 
-Each crew member has a `role` (authority tier) and optional `captain` flag.
-Only one agent per crew has `captain = true`.
+# Each crew member has a `role` (authority tier) and optional `captain` flag.
+# Only one agent per crew has `captain = true`.
 
-Role names are the four canonical HiveCrew identifiers defined in
-`_b00t_/linkml/schema/hive_role_vocabulary.yaml`, which is the source of truth
-(b00t-c0re-role's `KnownRole` is coherence-tested against it). Descriptions
-below mirror that schema's `enums.HiveRole.permissible_values`.
+# Role names are the four canonical HiveCrew identifiers defined in
+# `_b00t_/linkml/schema/hive_role_vocabulary.yaml`, which is the source of truth
+# (b00t-c0re-role's `KnownRole` is coherence-tested against it). Descriptions
+# below mirror that schema's `enums.HiveRole.permissible_values`.
 
-| Role | Captain? | Authority | Description | Agent Examples |
-|------|----------|-----------|-------------|----------------|
-| executive | true (only one) | Full command | Hive-level decision authority — release gate, tier routing, resource management. Commands the crew, sets mission, delegates tasks, manages lifecycle | executive |
-| worker | false | Task execution | Default hive worker — general-purpose executor with governance safety gates. A single generalized name, no sub-stereotyping (contrast with specialist) | ralph, pi |
-| operator | false | Dispatch + recruitment | Crew dispatch, recruitment, and specialist routing — spins typed crews via k0mmand3r; administrative privileges (recruits, trains, enlists agents). Previously two separate roles across two parallel role systems; unified as one (#905/#909) | operator |
-| specialist | false | Domain expertise | Domain-specific work — an open-ended stereotype family, not a single fixed meaning. The bare "specialist" name covers unspecified domain work; specific stereotypes (e.g. "appprovider", "rust-specialist", "security-auditor") resolve into this same role with their name preserved for role-datum lookup | alpha, beta, experiment-controller |
+# | Role | Captain? | Authority | Description | Agent Examples |
+# |------|----------|-----------|-------------|----------------|
+# | executive | true (only one) | Full command | Hive-level decision authority — release gate, tier routing, resource management. Commands the crew, sets mission, delegates tasks, manages lifecycle | executive |
+# | worker | false | Task execution | Default hive worker — general-purpose executor with governance safety gates. A single generalized name, no sub-stereotyping (contrast with specialist) | ralph, pi |
+# | operator | false | Dispatch + recruitment | Crew dispatch, recruitment, and specialist routing — spins typed crews via k0mmand3r; administrative privileges (recruits, trains, enlists agents). Previously two separate roles across two parallel role systems; unified as one (#905/#909) | operator |
+# | specialist | false | Domain expertise | Domain-specific work — an open-ended stereotype family, not a single fixed meaning. The bare "specialist" name covers unspecified domain work; specific stereotypes (e.g. "appprovider", "rust-specialist", "security-auditor") resolve into this same role with their name preserved for role-datum lookup | alpha, beta, experiment-controller |
 
 ## ── Legacy Role Names ───────────────────────────────────────────────────────────
 
-Pre-unification datums and persisted crew metadata used the older
-`b00t-c0re-hierarchy::Role` names. They are read for backward compatibility and
-mapped as below; write the canonical name in new datums.
+# Pre-unification datums and persisted crew metadata used the older
+# `b00t-c0re-hierarchy::Role` names. They are read for backward compatibility and
+# mapped as below; write the canonical name in new datums.
 
-| Legacy Name | Canonical Name | Note |
-|-------------|----------------|------|
-| captain | executive | Same role; the `captain = true` boolean flag is unchanged |
-| executor | worker | The general task-runner |
-| operator | operator | Unchanged name; see the resolved collision above |
-| specialist | specialist | Unchanged |
-| bouncer | (retired) | No 1:1 replacement — quality gating is embedded per agent datum; falls back to specialist with the name preserved |
+# | Legacy Name | Canonical Name | Note |
+# |-------------|----------------|------|
+# | captain | executive | Same role; the `captain = true` boolean flag is unchanged |
+# | executor | worker | The general task-runner |
+# | operator | operator | Unchanged name; see the resolved collision above |
+# | specialist | specialist | Unchanged |
+# | bouncer | (retired) | No 1:1 replacement — quality gating is embedded per agent datum; falls back to specialist with the name preserved |
 
 ## ── Assignment Rules ────────────────────────────────────────────────────────────
 
-These rules are evaluated by the operator during crew formation:
+# These rules are evaluated by the operator during crew formation:
 
-| Rule | Condition | Action |
-|------|-----------|--------|
-| unique-captain | Only one agent with `captain = true` per crew | Reject duplicate captains |
-| role-unique | No duplicate roles for identical crew scope | Warn on duplicate roles |
-| captain-mandatory | Every crew must have exactly one agent with `captain = true` | The executive-role agent is always the default |
-| operator-optional | Operator is deployed on-demand by the executive | Not part of standing crew |
-| bouncer-default | Quality gates enabled by default for all agents | Embedded in each agent datum |
+# | Rule | Condition | Action |
+# |------|-----------|--------|
+# | unique-captain | Only one agent with `captain = true` per crew | Reject duplicate captains |
+# | role-unique | No duplicate roles for identical crew scope | Warn on duplicate roles |
+# | captain-mandatory | Every crew must have exactly one agent with `captain = true` | The executive-role agent is always the default |
+# | operator-optional | Operator is deployed on-demand by the executive | Not part of standing crew |
+# | bouncer-default | Quality gates enabled by default for all agents | Embedded in each agent datum |
 
 ## ── Crew Lifecycle ──────────────────────────────────────────────────────────────
 
-Every crew member progresses through these lifecycle stages:
+# Every crew member progresses through these lifecycle stages:
 
-| Phase | Trigger | Description | Responsible |
-|-------|---------|-------------|-------------|
-| FORM | Executive initiates crew formation | Define crew mission, identify required roles | Executive |
-| ASSIGN | Operator scouts candidates | Match candidates to roles via capability assessment | Operator |
-| TRAIN | Operator executes training plans | grok learn for role-specific skills, context ingestion | Operator |
-| DEPLOY | Executive activates crew | Register sub-agents, establish IPC channels, enable quality gates | Executive |
-| REVIEW | Executive or Operator evaluates | Performance review, capability score update, rotation decision | Executive/Operator |
-| ROTATE | Executive decides | Reassign roles, cycle agents, archive performance data | Executive |
+# | Phase | Trigger | Description | Responsible |
+# |-------|---------|-------------|-------------|
+# | FORM | Executive initiates crew formation | Define crew mission, identify required roles | Executive |
+# | ASSIGN | Operator scouts candidates | Match candidates to roles via capability assessment | Operator |
+# | TRAIN | Operator executes training plans | grok learn for role-specific skills, context ingestion | Operator |
+# | DEPLOY | Executive activates crew | Register sub-agents, establish IPC channels, enable quality gates | Executive |
+# | REVIEW | Executive or Operator evaluates | Performance review, capability score update, rotation decision | Executive/Operator |
+# | ROTATE | Executive decides | Reassign roles, cycle agents, archive performance data | Executive |
 
 ## ── Agent Datum Crew Section ────────────────────────────────────────────────────
 
-Every agent datum MUST include a `[b00t.agent.crew]` section:
+# Every agent datum MUST include a `[b00t.agent.crew]` section:
 
-```toml
-[b00t.agent.crew]
-role = "worker"     # worker | executive | operator | specialist
-captain = false     # true only for the single crew captain (an executive-role agent)
-```
+# ```toml
+# [b00t.agent.crew]
+# role = "worker"     # worker | executive | operator | specialist
+# captain = false     # true only for the single crew captain (an executive-role agent)
+# ```
 
 ## ── Field Reference ─────────────────────────────────────────────────────────────
 
-| TOML Path | Type | Required | Default | Description |
-|-----------|------|----------|---------|-------------|
-| b00t.agent.crew.role | string | yes | — | One of: worker, executive, operator, specialist (legacy names in the table above are still read) |
-| b00t.agent.crew.captain | bool | yes | false | True only for the single crew captain |
+# | TOML Path | Type | Required | Default | Description |
+# |-----------|------|----------|---------|-------------|
+# | b00t.agent.crew.role | string | yes | — | One of: worker, executive, operator, specialist (legacy names in the table above are still read) |
+# | b00t.agent.crew.captain | bool | yes | false | True only for the single crew captain |
 
 ## ── Capability Requirements by Role ─────────────────────────────────────────────
 
-| Role | Required Skills | Min Model Tier | Example Skills |
-|------|----------------|----------------|----------------|
-| executive | hive-cmdb, resource-scheduling, agent-delegation | frontier | systemd, vllm, rust, autonomous-loop |
-| worker | autonomous-loop, workflow-execution | ch0nky | todo-backlog, prd-parsing |
-| operator | agent-discovery, agent-recruitment, crew-formation, training-plan-execution | frontier | ontology-query, grok-learn, search |
-| specialist | domain-specific expertise | ch0nky or sm0l | code, refactor, debug (pi); experiment-controller (experiment-controller) |
+# | Role | Required Skills | Min Model Tier | Example Skills |
+# |------|----------------|----------------|----------------|
+# | executive | hive-cmdb, resource-scheduling, agent-delegation | frontier | systemd, vllm, rust, autonomous-loop |
+# | worker | autonomous-loop, workflow-execution | ch0nky | todo-backlog, prd-parsing |
+# | operator | agent-discovery, agent-recruitment, crew-formation, training-plan-execution | frontier | ontology-query, grok-learn, search |
+# | specialist | domain-specific expertise | ch0nky or sm0l | code, refactor, debug (pi); experiment-controller (experiment-controller) |
 
 ## ── Crew Manifest Format ────────────────────────────────────────────────────────
 
-When operator reports to the executive, the crew manifest follows this structure:
+# When operator reports to the executive, the crew manifest follows this structure:
 
-```toml
+# ```toml
 # crew-manifest.toml — generated by operator after FORM→ASSIGN→TRAIN
-[[crew.members]]
-id = "executive-001"
-role = "executive"
-captain = true
-status = "active"
-tier = "frontier"
+# [[crew.members]]
+# id = "executive-001"
+# role = "executive"
+# captain = true
+# status = "active"
+# tier = "frontier"
 
-[[crew.members]]
-id = "ralph-001"
-role = "worker"
-captain = false
-status = "active"
-tier = "ch0nky"
+# [[crew.members]]
+# id = "ralph-001"
+# role = "worker"
+# captain = false
+# status = "active"
+# tier = "ch0nky"
 
-[[crew.members]]
-id = "pi-001"
-role = "specialist"
-captain = false
-status = "active"
-tier = "ch0nky"
-```
+# [[crew.members]]
+# id = "pi-001"
+# role = "specialist"
+# captain = false
+# status = "active"
+# tier = "ch0nky"
+# ```
 
 # b00t:map v1
 # summary: Canonical hive crew role schema — worker, executive, operator, specialist roles with lifecycle FORM→ASSIGN→TRAIN→DEPLOY→REVIEW→ROTATE

--- a/_b00t_/datums/DARED-001.tomllmd
+++ b/_b00t_/datums/DARED-001.tomllmd
@@ -1,175 +1,172 @@
----
-name: DARED-001
-description: |
-  DARED-001: eliminate 20 vendor submodules via josh-proxy filtered projections.
-  Summary classification: SubmoduleElimination ⊆ VendorGovernance ⊆ ArchitectureDecision
-version: 2.0.0
-tags: [DARED, DARE, josh, submodule, vendor, proposal, agent-safety]
-tier: frontier
-complexity: 8
-applies_to:
-  - "vendor submodule management"
-  - "agent git safety"
-  - "CI pipeline"
-  - "b00tyverse architecture"
-output_types: [.tomllmd, .rs]
-depends_on: ["DARED", "josh"]
-unlocks:
-  - "DARED-JOSH-AGENT-PROTOCOL"
-  - "just vendor-sync recipe"
-  - "just vendor-status recipe"
-metadata:
-  ufo_stereotype: Relator
-  proposal_id: "DARED-001"
-  status: "proposed"
-  ooda_phase: "Decide"
-  rust_type: "DaredProposal"
----
+# b00t DARED-001 datum
+# 🤓 converted from stray YAML-frontmatter .tomllmd (task #115 datum-errors cleanup):
+#    original content preserved, reformatted as valid TOML frontmatter + comment-prose body
+
+[b00t]
+name = "DARED-001"
+type = "specification"
+hint = "DARED-001: eliminate 20 vendor submodules via josh-proxy filtered projections. Summary classification: SubmoduleElimination ⊆ VendorGovernance ⊆ ArchitectureDecision"
+version = "2.0.0"
+tags = ["DARED", "DARE", "josh", "submodule", "vendor", "proposal", "agent-safety"]
+tier = "frontier"
+complexity = 8
+applies_to = ["vendor submodule management", "agent git safety", "CI pipeline", "b00tyverse architecture"]
+output_types = [".tomllmd", ".rs"]
+depends_on = ["DARED", "josh"]
+unlocks = ["DARED-JOSH-AGENT-PROTOCOL", "just vendor-sync recipe", "just vendor-status recipe"]
+
+[b00t.metadata]
+ufo_stereotype = "Relator"
+proposal_id = "DARED-001"
+status = "proposed"
+ooda_phase = "Decide"
+rust_type = "DaredProposal"
+
 ## DARED-001: Eliminate vendor submodules via josh
 
-<|🤓|>20 submodules ⊆ vendor/ burden. Each git submodule update --init
---recursive is a ∅→N risk surface expansion — agent hallucination of submodule
-commands mutates .git/modules/ state. Josh collapses the surface to 1 clone
-with N filtered projections. The ExecutiveDecision signs off on the vendor.josh
-contract: artifacts persist, submodule gitlinks removed, agent protocol datum
-published. DARED acceptance gate: 5 alternatives considered, 5 risks mitigated,
-summary chain `SubmoduleElimination ⊆ VendorGovernance ⊆ ArchitectureDecision`
-grounds this in b00t's FOL query space.</🤓|>
+# <|🤓|>20 submodules ⊆ vendor/ burden. Each git submodule update --init
+# --recursive is a ∅→N risk surface expansion — agent hallucination of submodule
+# commands mutates .git/modules/ state. Josh collapses the surface to 1 clone
+# with N filtered projections. The ExecutiveDecision signs off on the vendor.josh
+# contract: artifacts persist, submodule gitlinks removed, agent protocol datum
+# published. DARED acceptance gate: 5 alternatives considered, 5 risks mitigated,
+# summary chain `SubmoduleElimination ⊆ VendorGovernance ⊆ ArchitectureDecision`
+# grounds this in b00t's FOL query space.</🤓|>
 
 ### Decision — Perdurant
 
-```toml
-[decision]
-what = """
-Replace 20 vendor/ git submodules with josh-proxy filtered projections
-from a single unified vendor history. Each vendor/X becomes a josh
-filter ::vendor/X/ — cloned once, projected infinitely. Agents never
-run git submodule commands again.
-"""
-who = "b00t-core (operator approval required per PAIR-CONCEPT)"
-when = "post-#527 merge, pre-#516 MCP action layer"
-scope = [
-    "vendor/ tree (20 submodules → 20 filtered projections)",
-    "CI pipeline (remove git submodule update --init --recursive)",
-    "agent sandboxing (read-only per-agent projections via josh proxy)",
-    "justfile (new vendor-sync, vendor-status recipes)",
-]
-explicitly_out_of_scope = [
-    "b00t-cli/ crate",
-    "b00t-mcp/ crate",
-    "crates/ufo-types",
-    "Full monorepo migration",
-]
-```
+# ```toml
+# [decision]
+# what = """
+# Replace 20 vendor/ git submodules with josh-proxy filtered projections
+# from a single unified vendor history. Each vendor/X becomes a josh
+# filter ::vendor/X/ — cloned once, projected infinitely. Agents never
+# run git submodule commands again.
+# """
+# who = "b00t-core (operator approval required per PAIR-CONCEPT)"
+# when = "post-#527 merge, pre-#516 MCP action layer"
+# scope = [
+#     "vendor/ tree (20 submodules → 20 filtered projections)",
+#     "CI pipeline (remove git submodule update --init --recursive)",
+#     "agent sandboxing (read-only per-agent projections via josh proxy)",
+#     "justfile (new vendor-sync, vendor-status recipes)",
+# ]
+# explicitly_out_of_scope = [
+#     "b00t-cli/ crate",
+#     "b00t-mcp/ crate",
+#     "crates/ufo-types",
+#     "Full monorepo migration",
+# ]
+# ```
 
 ### Alternative — Abstract
 
-```toml
-[[alternatives]]
-name = "Do nothing — keep 20 submodules"
-viable = "Zero migration cost; zero risk"
-rejected_because = "Agent safety surface compounds; CI time grows; submodule drift creates invisible coupling"
+# ```toml
+# [[alternatives]]
+# name = "Do nothing — keep 20 submodules"
+# viable = "Zero migration cost; zero risk"
+# rejected_because = "Agent safety surface compounds; CI time grows; submodule drift creates invisible coupling"
 
-[[alternatives]]
-name = "git-subrepo — merge externals into single repo"
-viable = "No external tool dependency; history preserved in-repo"
-rejected_because = "Loses upstream remote tracking; manual resync burden; 21k+ commits bloat"
+# [[alternatives]]
+# name = "git-subrepo — merge externals into single repo"
+# viable = "No external tool dependency; history preserved in-repo"
+# rejected_because = "Loses upstream remote tracking; manual resync burden; 21k+ commits bloat"
 
-[[alternatives]]
-name = "git-filter-repo — one-time split/merge"
-viable = "Well-maintained Python tool; used by large orgs"
-rejected_because = "One-time operation; no live proxy; no agent safety gain"
+# [[alternatives]]
+# name = "git-filter-repo — one-time split/merge"
+# viable = "Well-maintained Python tool; used by large orgs"
+# rejected_because = "One-time operation; no live proxy; no agent safety gain"
 
-[[alternatives]]
-name = "GitButler but CLI only — no josh backend"
-viable = "Agent-friendly undoable git; already packaged"
-rejected_because = "Solves UX layer but not submodule problem; complementary to josh, not alternative"
+# [[alternatives]]
+# name = "GitButler but CLI only — no josh backend"
+# viable = "Agent-friendly undoable git; already packaged"
+# rejected_because = "Solves UX layer but not submodule problem; complementary to josh, not alternative"
 
-[[alternatives]]
-name = "git-subtree — built-in git, no external dep"
-viable = "Zero external dependencies; std git only"
-rejected_because = "Push/pull friction with upstreams; no filtered projection concept; merge conflicts on subtree splits"
-```
+# [[alternatives]]
+# name = "git-subtree — built-in git, no external dep"
+# viable = "Zero external dependencies; std git only"
+# rejected_because = "Push/pull friction with upstreams; no filtered projection concept; merge conflicts on subtree splits"
+# ```
 
 ### Risk — Moment
 
-```toml
-[[risks]]
-name = "josh project maturity"
-severity = "HIGH"
-description = "josh has ~1 active maintainer, 1.9k stars. Project could go unmaintained."
-mitigation = "Pin to known-good SHA; keep .gitmodules fallback 90 days; b00t controls proxy layer"
+# ```toml
+# [[risks]]
+# name = "josh project maturity"
+# severity = "HIGH"
+# description = "josh has ~1 active maintainer, 1.9k stars. Project could go unmaintained."
+# mitigation = "Pin to known-good SHA; keep .gitmodules fallback 90 days; b00t controls proxy layer"
 
-[[risks]]
-name = "Agent retraining failure"
-severity = "HIGH"
-description = "Agents trained on git submodule commands may hallucinate them post-migration."
-mitigation = "DARED agent protocol datum; just vendor-sync wraps ALL ops; block-git-submodule gate"
+# [[risks]]
+# name = "Agent retraining failure"
+# severity = "HIGH"
+# description = "Agents trained on git submodule commands may hallucinate them post-migration."
+# mitigation = "DARED agent protocol datum; just vendor-sync wraps ALL ops; block-git-submodule gate"
 
-[[risks]]
-name = "CI pipeline breakage"
-severity = "MEDIUM"
-description = "All workflows use git submodule update --init --recursive today."
-mitigation = "Replace with josh proxy service; dual-run 2 weeks; CI diff gate between paths"
+# [[risks]]
+# name = "CI pipeline breakage"
+# severity = "MEDIUM"
+# description = "All workflows use git submodule update --init --recursive today."
+# mitigation = "Replace with josh proxy service; dual-run 2 weeks; CI diff gate between paths"
 
-[[risks]]
-name = "Vendor contribution workflow friction"
-severity = "MEDIUM"
-description = "Contributing upstream changes becomes different."
-mitigation = "josh-link bidirectional sync; just vendor-contribute recipe"
+# [[risks]]
+# name = "Vendor contribution workflow friction"
+# severity = "MEDIUM"
+# description = "Contributing upstream changes becomes different."
+# mitigation = "josh-link bidirectional sync; just vendor-contribute recipe"
 
-[[risks]]
-name = "Operator unfamiliarity with josh"
-severity = "LOW"
-description = "Operator has not used josh before."
-mitigation = "DARED documents provide complete context; just vendor-status shows health at a glance"
-```
+# [[risks]]
+# name = "Operator unfamiliarity with josh"
+# severity = "LOW"
+# description = "Operator has not used josh before."
+# mitigation = "DARED documents provide complete context; just vendor-status shows health at a glance"
+# ```
 
 ### ExecutiveDecision — Relator
 
-```toml
-[executive_decision]
-summary = "SubmoduleElimination ⊆ VendorGovernance ⊆ ArchitectureDecision"
+# ```toml
+# [executive_decision]
+# summary = "SubmoduleElimination ⊆ VendorGovernance ⊆ ArchitectureDecision"
 
-artifacts = [
-    "vendor.josh — declarative workspace file for all 20 vendor projections",
-    "just vendor-sync — update all projections to pinned revs",
-    "just vendor-status — show projection health: rev, upstream, drift",
-    "just vendor-contribute <name> — open PR against upstream",
-    "_b00t_/datums/DARED-JOSH-AGENT-PROTOCOL.tomllmd — agent-safe josh rules",
-    "_b00t_/scripts/josh-recovery.rhai — projection recovery script",
-    "gate: validate-vendor-workspace — CI gate for vendor.josh parseability",
-    "gate: vendor-drift-check — CI gate comparing trees against pinned revs",
-    "fine-tune/corpus/josh-agent-examples.jsonl — training data",
-]
+# artifacts = [
+#     "vendor.josh — declarative workspace file for all 20 vendor projections",
+#     "just vendor-sync — update all projections to pinned revs",
+#     "just vendor-status — show projection health: rev, upstream, drift",
+#     "just vendor-contribute <name> — open PR against upstream",
+#     "_b00t_/datums/DARED-JOSH-AGENT-PROTOCOL.tomllmd — agent-safe josh rules",
+#     "_b00t_/scripts/josh-recovery.rhai — projection recovery script",
+#     "gate: validate-vendor-workspace — CI gate for vendor.josh parseability",
+#     "gate: vendor-drift-check — CI gate comparing trees against pinned revs",
+#     "fine-tune/corpus/josh-agent-examples.jsonl — training data",
+# ]
 
-removed = [
-    ".gitmodules (all 20 vendor entries)",
-    "All vendor/ gitlinks from git index",
-    "git submodule update --init --recursive from all CI workflows",
-    "git submodule update --remote from all just recipes",
-    "Submodule drift warnings from pre-commit hook",
-]
+# removed = [
+#     ".gitmodules (all 20 vendor entries)",
+#     "All vendor/ gitlinks from git index",
+#     "git submodule update --init --recursive from all CI workflows",
+#     "git submodule update --remote from all just recipes",
+#     "Submodule drift warnings from pre-commit hook",
+# ]
 
-acceptance_criteria = [
-    "vendor.josh exists and is parseable by josh-compose",
-    "just vendor-sync succeeds; all 20 projections at pinned revs",
-    "CI passes without any git submodule commands",
-    "Agent protocol datum loaded by b00t learn josh-agent-protocol",
-    "Gate validate-vendor-workspace passes in CI",
-    "All removed artifacts confirmed absent from codebase",
-]
-```
+# acceptance_criteria = [
+#     "vendor.josh exists and is parseable by josh-compose",
+#     "just vendor-sync succeeds; all 20 projections at pinned revs",
+#     "CI passes without any git submodule commands",
+#     "Agent protocol datum loaded by b00t learn josh-agent-protocol",
+#     "Gate validate-vendor-workspace passes in CI",
+#     "All removed artifacts confirmed absent from codebase",
+# ]
+# ```
 
 ### Transition Plan
 
-```
-Week 1-2:  vendor.josh created, josh proxy running alongside submodules
-Week 3:    Agent protocol datum published, training examples in corpus
-Week 4:    Submodule gitlinks removed, CI switched to josh-only
-Week 5-12: Fallback .gitmodules kept (read-only), agents retrained
-Week 13:   Fallback removed, DARED verified against acceptance criteria
-```
+# ```
+# Week 1-2:  vendor.josh created, josh proxy running alongside submodules
+# Week 3:    Agent protocol datum published, training examples in corpus
+# Week 4:    Submodule gitlinks removed, CI switched to josh-only
+# Week 5-12: Fallback .gitmodules kept (read-only), agents retrained
+# Week 13:   Fallback removed, DARED verified against acceptance criteria
+# ```
 
 # b00t:map v1
 # summary: DARED-001 — eliminate 20 vendor submodules via josh-proxy filtered projections

--- a/_b00t_/datums/DARED.tomllmd
+++ b/_b00t_/datums/DARED.tomllmd
@@ -1,141 +1,137 @@
----
-name: DARED
-description: |
-  DARED::DecisionAlternativeRiskExecutiveDecision — codified OODA state-change
-  proposal framework for b00t architecture governance. Each section maps to UFO
-  stereotypes in Rust generics (crates/ufo-types/src/dare.rs). A DARED is an
-  OODA Act-phase transition from Observe/Orient → Decide/Act → Verify.
-version: 2.0.0
-tags: [DARED, DARE, ADR, proposal, decision, architecture, OODA, governance, framework, set-theory]
-tier: frontier
-complexity: 8
-applies_to:
-  - "architecture decision"
-  - "proposal"
-  - "OODA state change"
-  - "governance"
-  - "first-order logic"
-output_types: [.tomllmd, .rs]
-depends_on: ["ufo-types-crate-511"]
-unlocks:
-  - "all architecture proposals"
-metadata:
-  ufo_stereotype: Relator
-  acronym: "Decision Alternative Risk ExecutiveDecision"
-  predecessor: "DARE v1 (Endurant) → DARED v2 (ExecutiveDecision)"
-  ooda_phase: "Act"
-  rust_module: "crates/ufo-types/src/dare.rs"
-  test_count: 28
----
+# b00t DARED datum
+# 🤓 converted from stray YAML-frontmatter .tomllmd (task #115 datum-errors cleanup):
+#    original content preserved, reformatted as valid TOML frontmatter + comment-prose body
+
+[b00t]
+name = "DARED"
+type = "specification"
+hint = "DARED::DecisionAlternativeRiskExecutiveDecision — codified OODA state-change proposal framework for b00t architecture governance. Each section maps to UFO stereotypes in Rust generics (crates/ufo-types/src/dare.rs). A DARED is an OODA Act-phase transition from Observe/Orient → Decide/Act → Verify."
+version = "2.0.0"
+tags = ["DARED", "DARE", "ADR", "proposal", "decision", "architecture", "OODA", "governance", "framework", "set-theory"]
+tier = "frontier"
+complexity = 8
+applies_to = ["architecture decision", "proposal", "OODA state change", "governance", "first-order logic"]
+output_types = [".tomllmd", ".rs"]
+depends_on = ["ufo-types-crate-511"]
+unlocks = ["all architecture proposals"]
+
+[b00t.metadata]
+ufo_stereotype = "Relator"
+acronym = "Decision Alternative Risk ExecutiveDecision"
+predecessor = "DARE v1 (Endurant) → DARED v2 (ExecutiveDecision)"
+ooda_phase = "Act"
+rust_module = "crates/ufo-types/src/dare.rs"
+test_count = 28
+
 ## DARED::DecisionAlternativeRiskExecutiveDecision
 
-<|🤓|>define DARED as the OODA Act-phase governor that classifies every
-architecture proposal into b00t's first-order logic via set/category
-theoretic grounding. Each section is a Rust generic implementing
-Stereotyped + Serialize + Deserialize, yielding ontology-triple
-evidence through NS-9 (record_is_a) and NS-10 (record_audited_by).
-The ExecutiveDecision's summary field is the semantic sugar — a
-⊆-separated category chain that enables querying "all decisions of
-type ArchitectureDecision" without walking the AST.</🤓|>
+# <|🤓|>define DARED as the OODA Act-phase governor that classifies every
+# architecture proposal into b00t's first-order logic via set/category
+# theoretic grounding. Each section is a Rust generic implementing
+# Stereotyped + Serialize + Deserialize, yielding ontology-triple
+# evidence through NS-9 (record_is_a) and NS-10 (record_audited_by).
+# The ExecutiveDecision's summary field is the semantic sugar — a
+# ⊆-separated category chain that enables querying "all decisions of
+# type ArchitectureDecision" without walking the AST.</🤓|>
 
 ### Set-Theoretic Grounding
 
-```
-DARED ⊆ ADR ∪ {ExecutiveDecision, summary, Rust types, FOL}
-Decision    ∈ Perdurant  — committed process unfolding in time
-Alternative ∈ Kind       — counterfactual entity, never instantiated
-Risk        ∈ Mode       — potential quality inhering in the decision
-ExecDec     ∈ Relator    — mediates Decision → Artifacts, captain's sign-off
+# ```
+# DARED ⊆ ADR ∪ {ExecutiveDecision, summary, Rust types, FOL}
+# Decision    ∈ Perdurant  — committed process unfolding in time
+# Alternative ∈ Kind       — counterfactual entity, never instantiated
+# Risk        ∈ Mode       — potential quality inhering in the decision
+# ExecDec     ∈ Relator    — mediates Decision → Artifacts, captain's sign-off
 
-ExecutiveDecision.summary ⊂ b00t_Ontology_Categories
-  where summary = "LeafCategory ⊆ ParentCategory ⊆ RootCategory"
-  and   RootCategory ∈ {ArchitectureDecision, ProcessChange, ToolAdoption, …}
-```
+# ExecutiveDecision.summary ⊂ b00t_Ontology_Categories
+#   where summary = "LeafCategory ⊆ ParentCategory ⊆ RootCategory"
+#   and   RootCategory ∈ {ArchitectureDecision, ProcessChange, ToolAdoption, …}
+# ```
 
 ### Category-Theoretic Relationship
 
-```
-                        Captain (operator)
-                            │
-                       sign_off
-                            │
-                            ▼
-Decision ──┬── produces ──→ ExecutiveDecision ── contains ──→ Artifacts
-           │                      │
-           │                 summary : Category
-           │                      │
-           ▼                      ▼
-     Alternative              AcceptanceCriteria
-     (rejected)               (iso 31000 auditable)
-           │
-           ▼
-         Risk
-     (mitigation)
-```
+# ```
+#                         Captain (operator)
+#                             │
+#                        sign_off
+#                             │
+#                             ▼
+# Decision ──┬── produces ──→ ExecutiveDecision ── contains ──→ Artifacts
+#            │                      │
+#            │                 summary : Category
+#            │                      │
+#            ▼                      ▼
+#      Alternative              AcceptanceCriteria
+#      (rejected)               (iso 31000 auditable)
+#            │
+#            ▼
+#          Risk
+#      (mitigation)
+# ```
 
-The ExecutiveDecision is the **natural transformation** between the
-Decision functor (what to do) and the Artifacts functor (what persists).
-The summary field is the **object classifier** in the subobject
-classifier Ω of b00t's governance topos.
+# The ExecutiveDecision is the **natural transformation** between the
+# Decision functor (what to do) and the Artifacts functor (what persists).
+# The summary field is the **object classifier** in the subobject
+# classifier Ω of b00t's governance topos.
 
 ### OODA State Machine (Rust enum)
 
-```rust
-pub enum OodaPhase { Observe, Orient, Decide, Act, Verify }
-// PartialOrd: Observe < Orient < Decide < Act < Verify
-// Stereotyped: each phase → UfoStereotype::Role("OodaPhase:{name}")
-```
+# ```rust
+# pub enum OodaPhase { Observe, Orient, Decide, Act, Verify }
+# // PartialOrd: Observe < Orient < Decide < Act < Verify
+# // Stereotyped: each phase → UfoStereotype::Role("OodaPhase:{name}")
+# ```
 
 ### DARED acceptance gate (Satisfies<DaredAcceptanceCriteria>)
 
-A DARED satisfies acceptance iff:
-1. |alternatives| ≥ min_alternatives
-2. ∀ r ∈ risks: r.mitigation ≠ ∅
-3. ExecutiveDecision.summary ≠ ""  (⊆ chain present)
-4. artifacts ∪ removed ≠ ∅
-5. ∀ c ∈ acceptance_criteria: c ≠ ""
-6. phase ≥ Decide
+# A DARED satisfies acceptance iff:
+# 1. |alternatives| ≥ min_alternatives
+# 2. ∀ r ∈ risks: r.mitigation ≠ ∅
+# 3. ExecutiveDecision.summary ≠ ""  (⊆ chain present)
+# 4. artifacts ∪ removed ≠ ∅
+# 5. ∀ c ∈ acceptance_criteria: c ≠ ""
+# 6. phase ≥ Decide
 
-Scored as confidence = checks_passed / 5.0. Passes at confidence = 1.0.
+# Scored as confidence = checks_passed / 5.0. Passes at confidence = 1.0.
 
 ### DARED Document Template
 
-```toml
-[decision]
-what = "<committed action>"
-who = "<owner>"
-when = "<timeline>"
-scope = ["<in-scope>", …]
-explicitly_out_of_scope = ["<excluded>", …]
+# ```toml
+# [decision]
+# what = "<committed action>"
+# who = "<owner>"
+# when = "<timeline>"
+# scope = ["<in-scope>", …]
+# explicitly_out_of_scope = ["<excluded>", …]
 
-[[alternatives]]
-name = "<name>"
-viable = "<why viable>"
-rejected_because = "<why rejected>"
+# [[alternatives]]
+# name = "<name>"
+# viable = "<why viable>"
+# rejected_because = "<why rejected>"
 
-[[risks]]
-name = "<risk name>"
-severity = "LOW|MEDIUM|HIGH|CRITICAL"
-description = "<what could go wrong>"
-mitigation = "<how mitigated>"
+# [[risks]]
+# name = "<risk name>"
+# severity = "LOW|MEDIUM|HIGH|CRITICAL"
+# description = "<what could go wrong>"
+# mitigation = "<how mitigated>"
 
-[executive_decision]
-summary = "LeafCategory ⊆ ParentCategory ⊆ RootCategory"
-artifacts = ["<persistent file/recipe/gate>", …]
-removed = ["<file/pattern to delete>", …]
-acceptance_criteria = ["<verifiable condition>", …]
-```
+# [executive_decision]
+# summary = "LeafCategory ⊆ ParentCategory ⊆ RootCategory"
+# artifacts = ["<persistent file/recipe/gate>", …]
+# removed = ["<file/pattern to delete>", …]
+# acceptance_criteria = ["<verifiable condition>", …]
+# ```
 
 ### DARED vs DARE v1
 
-| Aspect | DARE v1 | DARED v2 |
-|--------|---------|----------|
-| Fourth section | Endurant (Kind) | ExecutiveDecision (Relator) |
-| Category label | Implicit | `summary` field (⊆ chain) |
-| UFO grounding | Sections → stereotypes | Sections + Rust generics |
-| FOL queryable | No | Yes (summary ∈ categories) |
-| Rust types | N/A | `dare.rs` module, 28 tests |
-| Captain binding | Text reference | `ExecutiveDecision` struct |
+# | Aspect | DARE v1 | DARED v2 |
+# |--------|---------|----------|
+# | Fourth section | Endurant (Kind) | ExecutiveDecision (Relator) |
+# | Category label | Implicit | `summary` field (⊆ chain) |
+# | UFO grounding | Sections → stereotypes | Sections + Rust generics |
+# | FOL queryable | No | Yes (summary ∈ categories) |
+# | Rust types | N/A | `dare.rs` module, 28 tests |
+# | Captain binding | Text reference | `ExecutiveDecision` struct |
 
 
 

--- a/_b00t_/datums/DARED.tomllmd
+++ b/_b00t_/datums/DARED.tomllmd
@@ -12,7 +12,7 @@ tier = "frontier"
 complexity = 8
 applies_to = ["architecture decision", "proposal", "OODA state change", "governance", "first-order logic"]
 output_types = [".tomllmd", ".rs"]
-depends_on = ["ufo-types-crate-511"]
+depends_on = ["ufo-types-crate-511.skill"]
 unlocks = ["all architecture proposals"]
 
 [b00t.metadata]
@@ -141,3 +141,4 @@ test_count = 28
 # tier: frontier
 # cmds: just ufo-test, cargo test -p ufo-types dare
 # complexity: 8
+

--- a/_b00t_/datums/DATUM-PLANS.tomllmd
+++ b/_b00t_/datums/DATUM-PLANS.tomllmd
@@ -28,521 +28,521 @@ content = "draft"
 
 ## ── What is a Datum Plan? ─────────────────────────────────────────────────────
 
-A **datum plan** is a bridge between a concept datum (the _what_) and an
-execution plan (the _how and when_). In the b00t specification-driven development
-(SDD) pattern, work flows through three layers:
+# A **datum plan** is a bridge between a concept datum (the _what_) and an
+# execution plan (the _how and when_). In the b00t specification-driven development
+# (SDD) pattern, work flows through three layers:
 
-```
-  _b00t_/datums/       →  _b00t_/sdd/        →  _b00t_/plans/
-  (concept/spec)          (specification)        (execution plan)
-       │                        │                       │
-       │ defines the            │ defines the           │ schedules steps,
-       │ concept, terms,        │ interface,            │ assigns agents,
-       │ and semantics          │ architecture,         │ tracks progress,
-       │                        │ and invariants        │ produces artifacts
-       ▼                        ▼                       ▼
-  "WHAT are we            "HOW does it            "WHEN do we build
-   building?"              work?"                  it, and who does it?"
-```
+# ```
+#   _b00t_/datums/       →  _b00t_/sdd/        →  _b00t_/plans/
+#   (concept/spec)          (specification)        (execution plan)
+#        │                        │                       │
+#        │ defines the            │ defines the           │ schedules steps,
+#        │ concept, terms,        │ interface,            │ assigns agents,
+#        │ and semantics          │ architecture,         │ tracks progress,
+#        │                        │ and invariants        │ produces artifacts
+#        ▼                        ▼                       ▼
+#   "WHAT are we            "HOW does it            "WHEN do we build
+#    building?"              work?"                  it, and who does it?"
+# ```
 
-A datum plan resolves an issue into actionable work by:
-1. Defining the datum (concept/specification/schema/research)
-2. Optionally producing an SDD for detailed specification
-3. Creating a dated plan in _b00t_/plans/ for execution
-4. Mapping to b00t tasks for tracking
+# A datum plan resolves an issue into actionable work by:
+# 1. Defining the datum (concept/specification/schema/research)
+# 2. Optionally producing an SDD for detailed specification
+# 3. Creating a dated plan in _b00t_/plans/ for execution
+# 4. Mapping to b00t tasks for tracking
 
 ### Key principles
 
-| principle | description |
-|-----------|-------------|
-| **Spec-first** | Every plan begins with a datum definition, not implementation |
-| **Three layers** | Datums (what), SDDs (how), Plans (when) — each has its own directory |
-| **Dated plans** | Plans are organized by date for audit trail and rollback |
-| **Issue-driven** | Each plan traces back to an issue (issue-#) for provenance |
-| **Executable** | Plans contain concrete steps that map to b00t tasks |
-| **Self-documenting** | The plan IS the documentation — no separate project management tool |
+# | principle | description |
+# |-----------|-------------|
+# | **Spec-first** | Every plan begins with a datum definition, not implementation |
+# | **Three layers** | Datums (what), SDDs (how), Plans (when) — each has its own directory |
+# | **Dated plans** | Plans are organized by date for audit trail and rollback |
+# | **Issue-driven** | Each plan traces back to an issue (issue-#) for provenance |
+# | **Executable** | Plans contain concrete steps that map to b00t tasks |
+# | **Self-documenting** | The plan IS the documentation — no separate project management tool |
 
 ## ── How datums relate to plans ───────────────────────────────────────────────
 
 ### Datums as plan sources
 
-Every plan in _b00t_/plans/ originates from a datum in _b00t_/datums/. The datum
-provides the conceptual foundation; the plan provides the execution blueprint.
+# Every plan in _b00t_/plans/ originates from a datum in _b00t_/datums/. The datum
+# provides the conceptual foundation; the plan provides the execution blueprint.
 
-| datum type | plan purpose | example |
-|------------|-------------|---------|
-| `specification` | Define architecture, interfaces, and invariants | PAIR-CONCEPT → plan to implement pair management |
-| `schema` | Define data structures and validation rules | MCP-SERVER-SCHEMA → plan to add new transport type |
-| `datum` | Define research findings or experimental results | STOP-SEQUENCES → plan to run experiment protocol |
-| `concept` | Define a new b00t concept or pattern | DATUM-PLANS (this file) → plan to implement plan system |
+# | datum type | plan purpose | example |
+# |------------|-------------|---------|
+# | `specification` | Define architecture, interfaces, and invariants | PAIR-CONCEPT → plan to implement pair management |
+# | `schema` | Define data structures and validation rules | MCP-SERVER-SCHEMA → plan to add new transport type |
+# | `datum` | Define research findings or experimental results | STOP-SEQUENCES → plan to run experiment protocol |
+# | `concept` | Define a new b00t concept or pattern | DATUM-PLANS (this file) → plan to implement plan system |
 
 ### Datum-to-plan mapping
 
-A single datum can produce multiple plans (e.g., phase 1, phase 2), and a single
-plan can reference multiple datums. The mapping is many-to-many but always
-explicit:
+# A single datum can produce multiple plans (e.g., phase 1, phase 2), and a single
+# plan can reference multiple datums. The mapping is many-to-many but always
+# explicit:
 
-| relationship | direction | how it's recorded |
-|-------------|-----------|-------------------|
-| Plan references datum | plan → datum | `🔗参` link in plan header |
-| Datum references plan | datum → plan | `plans:` field or `🔗参` in datum footer |
-| SDD references both | sdd → datum + plan | SDD header includes `Datum:` and `Plan:` fields |
-| Issue references all | issue → datum + sdd + plan | Issue body or issue file links |
+# | relationship | direction | how it's recorded |
+# |-------------|-----------|-------------------|
+# | Plan references datum | plan → datum | `🔗参` link in plan header |
+# | Datum references plan | datum → plan | `plans:` field or `🔗参` in datum footer |
+# | SDD references both | sdd → datum + plan | SDD header includes `Datum:` and `Plan:` fields |
+# | Issue references all | issue → datum + sdd + plan | Issue body or issue file links |
 
 ### Plan lifecycle stage in datum
 
-Each datum can declare its plan status in the `[b00t.version]` section:
+# Each datum can declare its plan status in the `[b00t.version]` section:
 
-```toml
-[b00t.version]
-schema = 1
-content = "draft"       # draft | stable | archived
+# ```toml
+# [b00t.version]
+# schema = 1
+# content = "draft"       # draft | stable | archived
 # Plan stage can be tracked in a separate field:
 # stage = "proposed"    # proposed | reviewing | executing | verifying | complete
-```
+# ```
 
-The `content` field tracks the datum's stability, while the plan stage is
-tracked in the plan file itself (see lifecycle below).
+# The `content` field tracks the datum's stability, while the plan stage is
+# tracked in the plan file itself (see lifecycle below).
 
 ## ── Plan lifecycle ───────────────────────────────────────────────────────────
 
-Every datum plan progresses through a four-phase lifecycle. The lifecycle is
-inspired by the specification-driven development (SDD) pattern seen in
-_b00t_/sdd/ documents, extended to cover the full plan.
+# Every datum plan progresses through a four-phase lifecycle. The lifecycle is
+# inspired by the specification-driven development (SDD) pattern seen in
+# _b00t_/sdd/ documents, extended to cover the full plan.
 
-```
-  ┌──────────────────────────────────────────────────────┐
-  │                                                       │
-  ▼                                                       │
-PROPOSE ──► REVIEW ──► EXECUTE ──► VERIFY ───────────────┘
-```
+# ```
+#   ┌──────────────────────────────────────────────────────┐
+#   │                                                       │
+#   ▼                                                       │
+# PROPOSE ──► REVIEW ──► EXECUTE ──► VERIFY ───────────────┘
+# ```
 
 ### Phase 1: PROPOSE
 
-**Trigger:** An issue is opened or a gap is identified in the b00t system.
+# **Trigger:** An issue is opened or a gap is identified in the b00t system.
 
-1. Author creates a datum in _b00t_/datums/ defining the concept, schema, or
-   specification
-2. Optionally creates an SDD in _b00t_/sdd/ for detailed architecture design
-3. Creates a dated plan file in _b00t_/plans/ with:
-   - Plan metadata (date, author, issue reference)
-   - Datum reference (which datum this plan implements)
-   - SDD reference (if applicable)
-   - Concrete steps with acceptance criteria
-   - Estimated effort (sm0l / ch0nky / thicc)
-4. Plan is marked as `status = "proposed"`
+# 1. Author creates a datum in _b00t_/datums/ defining the concept, schema, or
+#    specification
+# 2. Optionally creates an SDD in _b00t_/sdd/ for detailed architecture design
+# 3. Creates a dated plan file in _b00t_/plans/ with:
+#    - Plan metadata (date, author, issue reference)
+#    - Datum reference (which datum this plan implements)
+#    - SDD reference (if applicable)
+#    - Concrete steps with acceptance criteria
+#    - Estimated effort (sm0l / ch0nky / thicc)
+# 4. Plan is marked as `status = "proposed"`
 
-**Output:** `_b00t_/plans/YYYY-MM-DD-slug-plan.md` with `status = "proposed"`
+# **Output:** `_b00t_/plans/YYYY-MM-DD-slug-plan.md` with `status = "proposed"`
 
 ### Phase 2: REVIEW
 
-**Trigger:** Plan is submitted for review (usually by a pair or captain).
+# **Trigger:** Plan is submitted for review (usually by a pair or captain).
 
-1. Reviewer(s) examine the plan for:
-   - Completeness: Are all steps defined with clear acceptance criteria?
-   - Feasibility: Is the effort estimate realistic?
-   - Consistency: Does the plan align with the datum and SDD?
-   - Dependencies: Are prerequisite tasks identified?
-2. Reviewer approves, requests changes, or rejects
-3. On approval, plan status advances to `status = "approved"`
-4. Plan may be broken into b00t tasks via `b00t task add`
+# 1. Reviewer(s) examine the plan for:
+#    - Completeness: Are all steps defined with clear acceptance criteria?
+#    - Feasibility: Is the effort estimate realistic?
+#    - Consistency: Does the plan align with the datum and SDD?
+#    - Dependencies: Are prerequisite tasks identified?
+# 2. Reviewer approves, requests changes, or rejects
+# 3. On approval, plan status advances to `status = "approved"`
+# 4. Plan may be broken into b00t tasks via `b00t task add`
 
-**Output:** `status = "approved"` plan file, optionally with linked b00t tasks
+# **Output:** `status = "approved"` plan file, optionally with linked b00t tasks
 
 ### Phase 3: EXECUTE
 
-**Trigger:** Plan is approved and prioritized for execution.
+# **Trigger:** Plan is approved and prioritized for execution.
 
-1. Steps are assigned to agents (via pair assignment or direct assignment)
-2. Each step is tracked as a b00t task (or subtask)
-3. Progress is updated in the plan file: `progress = "30%"`
-4. Completed steps are marked with `[x]` and a date
-5. Blockers are documented with `[blocked: reason]` annotations
-6. Plan status is updated: `status = "executing"`
+# 1. Steps are assigned to agents (via pair assignment or direct assignment)
+# 2. Each step is tracked as a b00t task (or subtask)
+# 3. Progress is updated in the plan file: `progress = "30%"`
+# 4. Completed steps are marked with `[x]` and a date
+# 5. Blockers are documented with `[blocked: reason]` annotations
+# 6. Plan status is updated: `status = "executing"`
 
-**Execution modes:**
+# **Execution modes:**
 
-| mode | description | use case |
-|------|-------------|----------|
-| **Sequential** | Steps execute one after another | Dependent steps, infrastructure setup |
-| **Parallel** | Steps execute concurrently | Independent features, refactoring |
-| **Iterative** | Steps repeat with refinement | Research, experimentation |
-| **Delegated** | Steps farmed out to sub-agents | Large plans across subsystems |
+# | mode | description | use case |
+# |------|-------------|----------|
+# | **Sequential** | Steps execute one after another | Dependent steps, infrastructure setup |
+# | **Parallel** | Steps execute concurrently | Independent features, refactoring |
+# | **Iterative** | Steps repeat with refinement | Research, experimentation |
+# | **Delegated** | Steps farmed out to sub-agents | Large plans across subsystems |
 
 ### Phase 4: VERIFY
 
-**Trigger:** All plan steps are complete.
+# **Trigger:** All plan steps are complete.
 
-1. Verify acceptance criteria for each step
-2. Run tests, check output artifacts, validate against the datum spec
-3. Update the datum's `content` field if the specification has been validated
-   (e.g., `draft` → `stable`)
-4. Archive the plan with `status = "complete"` or `status = "archived"`
-5. Write a retrospective (optional but recommended for ch0nky+ plans)
-6. Close or update the originating issue
+# 1. Verify acceptance criteria for each step
+# 2. Run tests, check output artifacts, validate against the datum spec
+# 3. Update the datum's `content` field if the specification has been validated
+#    (e.g., `draft` → `stable`)
+# 4. Archive the plan with `status = "complete"` or `status = "archived"`
+# 5. Write a retrospective (optional but recommended for ch0nky+ plans)
+# 6. Close or update the originating issue
 
-**Output:** `status = "complete"` plan, potentially updated datum or SDD
+# **Output:** `status = "complete"` plan, potentially updated datum or SDD
 
 ### Plan status values
 
-| status | meaning | next status |
-|--------|---------|-------------|
-| `proposed` | Plan created, awaiting review | `approved` or `rejected` |
-| `approved` | Plan reviewed and accepted | `executing` |
-| `executing` | Work in progress | `complete` or `blocked` |
-| `blocked` | Execution stalled, needs resolution | `executing` or `cancelled` |
-| `complete` | All steps verified and done | (terminal) |
-| `cancelled` | Plan abandoned | (terminal) |
-| `archived` | Completed plan, preserved for audit | (terminal) |
-| `rejected` | Plan rejected during review | (terminal, may be revised) |
+# | status | meaning | next status |
+# |--------|---------|-------------|
+# | `proposed` | Plan created, awaiting review | `approved` or `rejected` |
+# | `approved` | Plan reviewed and accepted | `executing` |
+# | `executing` | Work in progress | `complete` or `blocked` |
+# | `blocked` | Execution stalled, needs resolution | `executing` or `cancelled` |
+# | `complete` | All steps verified and done | (terminal) |
+# | `cancelled` | Plan abandoned | (terminal) |
+# | `archived` | Completed plan, preserved for audit | (terminal) |
+# | `rejected` | Plan rejected during review | (terminal, may be revised) |
 
 ## ── Directory relationships ─────────────────────────────────────────────────
 
-The three directories form a pipeline from concept to execution:
+# The three directories form a pipeline from concept to execution:
 
-```
-_b00t_/
-  ├── datums/          ← Concept hub (what)
-  │   ├── PAIR-CONCEPT.tomllmd
-  │   ├── MCP-SERVER-SCHEMA.tomllmd
-  │   ├── STOP-SEQUENCES.tomllmd
-  │   ├── ANTHROPIC-DESKTOP-EXTENSIONS.tomllmd
-  │   └── DATUM-PLANS.tomllmd         ← this file
-  │
-  ├── sdd/             ← Specification hub (how)
-  │   ├── SDD-004-install-dual-method.md
-  │   ├── SDD-006-ledg3rr-grok-chain.md
-  │   └── (new SDDs created from datum plans)
-  │
-  ├── plans/           ← Execution hub (when)
-  │   ├── 2026-05-08-datum-plans-implementation.md
-  │   └── (dated plan files per issue)
-  │
-  ├── issues/          ← Origination (why)
-  │   └── issue-89.md
-  │
-  └── (other b00t system files)
-```
+# ```
+# _b00t_/
+#   ├── datums/          ← Concept hub (what)
+#   │   ├── PAIR-CONCEPT.tomllmd
+#   │   ├── MCP-SERVER-SCHEMA.tomllmd
+#   │   ├── STOP-SEQUENCES.tomllmd
+#   │   ├── ANTHROPIC-DESKTOP-EXTENSIONS.tomllmd
+#   │   └── DATUM-PLANS.tomllmd         ← this file
+#   │
+#   ├── sdd/             ← Specification hub (how)
+#   │   ├── SDD-004-install-dual-method.md
+#   │   ├── SDD-006-ledg3rr-grok-chain.md
+#   │   └── (new SDDs created from datum plans)
+#   │
+#   ├── plans/           ← Execution hub (when)
+#   │   ├── 2026-05-08-datum-plans-implementation.md
+#   │   └── (dated plan files per issue)
+#   │
+#   ├── issues/          ← Origination (why)
+#   │   └── issue-89.md
+#   │
+#   └── (other b00t system files)
+# ```
 
 ### _b00t_/datums/ — Concept definitions
 
-| aspect | description |
-|--------|-------------|
-| **Format** | `.tomllmd` (TOML + Markdown) or `.tomllm` for simpler datums |
-| **Purpose** | Define concepts, schemas, specifications, and research findings |
-| **Stability** | `[b00t.version.content]` = `draft` | `stable` | `archived` |
-| **Lifecycle** | Created independently of plans; updated by plans |
-| **Cross-refs** | `🔗参` links to related datums, SDDs, plans, code |
-| **Footer** | `# b00t:map v1` with summary, tags, tier, cmds, complexity |
+# | aspect | description |
+# |--------|-------------|
+# | **Format** | `.tomllmd` (TOML + Markdown) or `.tomllm` for simpler datums |
+# | **Purpose** | Define concepts, schemas, specifications, and research findings |
+# | **Stability** | `[b00t.version.content]` = `draft` | `stable` | `archived` |
+# | **Lifecycle** | Created independently of plans; updated by plans |
+# | **Cross-refs** | `🔗参` links to related datums, SDDs, plans, code |
+# | **Footer** | `# b00t:map v1` with summary, tags, tier, cmds, complexity |
 
-Datums are the **source of truth** for what b00t knows. They are written in
-`.tomllmd` format — TOML frontmatter for structured metadata, Markdown body for
-human-readable specification.
+# Datums are the **source of truth** for what b00t knows. They are written in
+# `.tomllmd` format — TOML frontmatter for structured metadata, Markdown body for
+# human-readable specification.
 
 ### _b00t_/sdd/ — Specification-driven development documents
 
-| aspect | description |
-|--------|-------------|
-| **Format** | `.md` (Markdown) |
-| **Naming** | `SDD-NNN-slug.md` (sequentially numbered) |
-| **Purpose** | Deep architectural specifications with interface contracts, invariants, and implementation guidance |
-| **Status** | Embedded in document header: RESEARCH COMPLETE | IMPLEMENTED | DRAFT |
-| **Structure** | Problem → Questions (resolved/unresolved) → Specification (interface contract, pseudo-code, integration points) → Stage Gates → Retrospective |
-| **Stage gates** | Each SDD has gates (e.g., SDD written, types implemented, tests passing, integration verified) that must pass to advance confidence |
+# | aspect | description |
+# |--------|-------------|
+# | **Format** | `.md` (Markdown) |
+# | **Naming** | `SDD-NNN-slug.md` (sequentially numbered) |
+# | **Purpose** | Deep architectural specifications with interface contracts, invariants, and implementation guidance |
+# | **Status** | Embedded in document header: RESEARCH COMPLETE | IMPLEMENTED | DRAFT |
+# | **Structure** | Problem → Questions (resolved/unresolved) → Specification (interface contract, pseudo-code, integration points) → Stage Gates → Retrospective |
+# | **Stage gates** | Each SDD has gates (e.g., SDD written, types implemented, tests passing, integration verified) that must pass to advance confidence |
 
-SDDs are created when a datum plan requires detailed architecture design beyond
-what fits in the datum or plan file. The SDD pattern (seen in SDD-004 and
-SDD-006) includes:
+# SDDs are created when a datum plan requires detailed architecture design beyond
+# what fits in the datum or plan file. The SDD pattern (seen in SDD-004 and
+# SDD-006) includes:
 
-1. **Problem statement** — What problem is being solved
-2. **Questions** — Resolved (increases confidence) and unresolved
-3. **Specification** — Interface contract, Rust pseudo-code, integration points
-4. **Stage gates** — Checkpoints that must pass (documented with [x] or [ ])
-5. **Confidence tracker** — Iteration-by-iteration confidence score
-6. **Retrospective** — What was attempted, result, root cause if failure
+# 1. **Problem statement** — What problem is being solved
+# 2. **Questions** — Resolved (increases confidence) and unresolved
+# 3. **Specification** — Interface contract, Rust pseudo-code, integration points
+# 4. **Stage gates** — Checkpoints that must pass (documented with [x] or [ ])
+# 5. **Confidence tracker** — Iteration-by-iteration confidence score
+# 6. **Retrospective** — What was attempted, result, root cause if failure
 
 ### _b00t_/plans/ — Execution plans
 
-| aspect | description |
-|--------|-------------|
-| **Format** | `.md` (Markdown) |
-| **Naming** | `YYYY-MM-DD-slug-plan.md` (dated for chronological ordering) |
-| **Purpose** | Concrete execution plans with steps, assignments, and progress tracking |
-| **Status** | Embedded in plan header (see lifecycle above) |
-| **Structure** | Header (dates, references, status) → Goals → Steps (with acceptance criteria) → Progress → Retrospective |
+# | aspect | description |
+# |--------|-------------|
+# | **Format** | `.md` (Markdown) |
+# | **Naming** | `YYYY-MM-DD-slug-plan.md` (dated for chronological ordering) |
+# | **Purpose** | Concrete execution plans with steps, assignments, and progress tracking |
+# | **Status** | Embedded in plan header (see lifecycle above) |
+# | **Structure** | Header (dates, references, status) → Goals → Steps (with acceptance criteria) → Progress → Retrospective |
 
-The `_b00t_/plans/` directory is populated by the plan creation process. Each
-plan file captures:
+# The `_b00t_/plans/` directory is populated by the plan creation process. Each
+# plan file captures:
 
-```
+# ```
 ## Plan: [slug]
-- **Created:** YYYY-MM-DD
-- **Status:** proposed | approved | executing | complete | ...
-- **Datum:** _b00t_/datums/DATUM-NAME.tomllmd
-- **SDD:** _b00t_/sdd/SDD-NNN-slug.md (optional)
-- **Issue:** #89
-- **Author:** agent-name
+# - **Created:** YYYY-MM-DD
+# - **Status:** proposed | approved | executing | complete | ...
+# - **Datum:** _b00t_/datums/DATUM-NAME.tomllmd
+# - **SDD:** _b00t_/sdd/SDD-NNN-slug.md (optional)
+# - **Issue:** #89
+# - **Author:** agent-name
 
 ## Goals
-- Clear, measurable goals this plan achieves
+# - Clear, measurable goals this plan achieves
 
 ## Steps
-- [ ] Step 1: Description (acceptance criteria)
-- [ ] Step 2: Description (acceptance criteria)
+# - [ ] Step 1: Description (acceptance criteria)
+# - [ ] Step 2: Description (acceptance criteria)
 
 ## Progress: 0%
-```
+# ```
 
 ### Data flow between directories
 
-```
-Issue (#89) ─────┐
-                  ▼
-         ┌───────────────┐
-         │  _b00t_/datums │  ← Concept datum created
-         │  /DATUM-PLANS  │
-         └───────┬───────┘
-                  │  references
-                  ▼
-         ┌───────────────┐
-         │  _b00t_/sdd/   │  ← Optional: SDD for complex specs
-         │  SDD-NNN-*     │
-         └───────┬───────┘
-                  │  implements
-                  ▼
-         ┌───────────────┐
-         │  _b00t_/plans/ │  ← Execution plan created
-         │  YYYY-MM-DD-*  │
-         └───────┬───────┘
-                  │  mapped to
-                  ▼
-         ┌───────────────┐
-         │  b00t tasks    │  ← Steps tracked via b00t task system
-         │  (task add)    │
-         └───────────────┘
-```
+# ```
+# Issue (#89) ─────┐
+#                   ▼
+#          ┌───────────────┐
+#          │  _b00t_/datums │  ← Concept datum created
+#          │  /DATUM-PLANS  │
+#          └───────┬───────┘
+#                   │  references
+#                   ▼
+#          ┌───────────────┐
+#          │  _b00t_/sdd/   │  ← Optional: SDD for complex specs
+#          │  SDD-NNN-*     │
+#          └───────┬───────┘
+#                   │  implements
+#                   ▼
+#          ┌───────────────┐
+#          │  _b00t_/plans/ │  ← Execution plan created
+#          │  YYYY-MM-DD-*  │
+#          └───────┬───────┘
+#                   │  mapped to
+#                   ▼
+#          ┌───────────────┐
+#          │  b00t tasks    │  ← Steps tracked via b00t task system
+#          │  (task add)    │
+#          └───────────────┘
+# ```
 
 ### When each directory is used
 
-| scenario | datum | sdd | plan |
-|----------|-------|-----|------|
-| Simple concept (fits in a datum) | Required | Optional | Optional |
-| Complex feature (needs architecture) | Required | Required | Required |
-| Research / experiment | Required | Optional | Optional |
-| Schema definition | Required | Optional | Optional |
-| Multi-step implementation | Required | Optional | Required |
-| Cross-cutting change | Required | Required | Required |
+# | scenario | datum | sdd | plan |
+# |----------|-------|-----|------|
+# | Simple concept (fits in a datum) | Required | Optional | Optional |
+# | Complex feature (needs architecture) | Required | Required | Required |
+# | Research / experiment | Required | Optional | Optional |
+# | Schema definition | Required | Optional | Optional |
+# | Multi-step implementation | Required | Optional | Required |
+# | Cross-cutting change | Required | Required | Required |
 
 ## ── Plan file naming convention ──────────────────────────────────────────────
 
-Plan files in _b00t_/plans/ follow a strict naming convention for sortability:
+# Plan files in _b00t_/plans/ follow a strict naming convention for sortability:
 
-```
-YYYY-MM-DD-slug-plan.md
-```
+# ```
+# YYYY-MM-DD-slug-plan.md
+# ```
 
-| component | format | example |
-|-----------|--------|---------|
-| Date | `YYYY-MM-DD` | `2026-05-08` |
-| Slug | kebab-case | `datum-plans-implementation` |
-| Suffix | `-plan.md` | `-plan.md` |
+# | component | format | example |
+# |-----------|--------|---------|
+# | Date | `YYYY-MM-DD` | `2026-05-08` |
+# | Slug | kebab-case | `datum-plans-implementation` |
+# | Suffix | `-plan.md` | `-plan.md` |
 
-Examples:
-- `2026-05-08-datum-plans-implementation.md` — implementing the datum plans system
-- `2026-05-08-pair-concept-phase-1.md` — phase 1 of pair concept implementation
-- `2026-05-09-mcp-schema-extension.md` — extending MCP server schema
+# Examples:
+# - `2026-05-08-datum-plans-implementation.md` — implementing the datum plans system
+# - `2026-05-08-pair-concept-phase-1.md` — phase 1 of pair concept implementation
+# - `2026-05-09-mcp-schema-extension.md` — extending MCP server schema
 
-Multiple plans can exist for the same date; use a distinct slug.
+# Multiple plans can exist for the same date; use a distinct slug.
 
 ## ── SDD integration pattern ─────────────────────────────────────────────────
 
-When a datum plan requires an SDD, the integration follows this pattern:
+# When a datum plan requires an SDD, the integration follows this pattern:
 
-1. **Datum** defines the concept (e.g., "Datum Plans" — what the pattern is)
-2. **SDD** defines the implementation architecture (e.g., plan file schema, plan
-   lifecycle state machine, b00t task integration)
-3. **Plan** schedules the work (e.g., "create datum, write SDD, implement
-   parser, wire to task system, test")
+# 1. **Datum** defines the concept (e.g., "Datum Plans" — what the pattern is)
+# 2. **SDD** defines the implementation architecture (e.g., plan file schema, plan
+#    lifecycle state machine, b00t task integration)
+# 3. **Plan** schedules the work (e.g., "create datum, write SDD, implement
+#    parser, wire to task system, test")
 
-The SDD's stage gates map naturally to plan steps:
+# The SDD's stage gates map naturally to plan steps:
 
-| SDD gate | plan step |
-|----------|-----------|
-| Gate 1: SDD Written | Step 1: Write SDD document |
-| Gate 2: Types implemented | Step 2: Implement core types |
-| Gate 3: Tests passing | Step 3: Write and run tests |
-| Gate 4: Integration | Step 4: Wire to CLI/task system |
-| Gate 5: Verification | Step 5: Verify end-to-end |
+# | SDD gate | plan step |
+# |----------|-----------|
+# | Gate 1: SDD Written | Step 1: Write SDD document |
+# | Gate 2: Types implemented | Step 2: Implement core types |
+# | Gate 3: Tests passing | Step 3: Write and run tests |
+# | Gate 4: Integration | Step 4: Wire to CLI/task system |
+# | Gate 5: Verification | Step 5: Verify end-to-end |
 
-This creates a traceable chain:
-```
-Issue → Datum → SDD (gates) → Plan (steps) → Tasks → Done
-```
+# This creates a traceable chain:
+# ```
+# Issue → Datum → SDD (gates) → Plan (steps) → Tasks → Done
+# ```
 
 ## ── Plan templates ───────────────────────────────────────────────────────────
 
 ### Minimal plan template (sm0l)
 
-```markdown
+# ```markdown
 # Plan: [Slug]
-- **Created:** YYYY-MM-DD
-- **Status:** proposed
-- **Datum:** _b00t_/datums/DATUM-NAME.tomllmd
-- **Issue:** #NN
-- **Author:** agent-name
+# - **Created:** YYYY-MM-DD
+# - **Status:** proposed
+# - **Datum:** _b00t_/datums/DATUM-NAME.tomllmd
+# - **Issue:** #NN
+# - **Author:** agent-name
 
 ## Goals
-- [goal 1]
+# - [goal 1]
 
 ## Steps
-- [ ] Step 1
-- [ ] Step 2
+# - [ ] Step 1
+# - [ ] Step 2
 
 ## Progress: 0%
-```
+# ```
 
 ### Full plan template (ch0nky+)
 
-```markdown
+# ```markdown
 # Plan: [Slug]
-- **Created:** YYYY-MM-DD
-- **Updated:** YYYY-MM-DD
-- **Status:** proposed
-- **Datum:** _b00t_/datums/DATUM-NAME.tomllmd
-- **SDD:** _b00t_/sdd/SDD-NNN-slug.md
-- **Issue:** #NN
-- **Author:** agent-name
-- **Assignee:** agent-name
-- **Tier:** sm0l | ch0nky | thicc
-- **Estimated:** N hours
+# - **Created:** YYYY-MM-DD
+# - **Updated:** YYYY-MM-DD
+# - **Status:** proposed
+# - **Datum:** _b00t_/datums/DATUM-NAME.tomllmd
+# - **SDD:** _b00t_/sdd/SDD-NNN-slug.md
+# - **Issue:** #NN
+# - **Author:** agent-name
+# - **Assignee:** agent-name
+# - **Tier:** sm0l | ch0nky | thicc
+# - **Estimated:** N hours
 
 ## Goals
-- [goal 1]
-- [goal 2]
+# - [goal 1]
+# - [goal 2]
 
 ## Dependencies
-- [prerequisite plan or task]
+# - [prerequisite plan or task]
 
 ## Steps
-- [ ] Step 1: Description
-  - Acceptance criteria: [criteria]
-  - Assigned to: agent-name
-- [ ] Step 2: Description
-  - Acceptance criteria: [criteria]
-  - Assigned to: agent-name
+# - [ ] Step 1: Description
+#   - Acceptance criteria: [criteria]
+#   - Assigned to: agent-name
+# - [ ] Step 2: Description
+#   - Acceptance criteria: [criteria]
+#   - Assigned to: agent-name
 
 ## Progress: 0%
 ## Notes
-- [freeform notes, blockers, decisions]
-```
+# - [freeform notes, blockers, decisions]
+# ```
 
 ## ── Integration with b00t task system ───────────────────────────────────────
 
-Plan steps can be converted to b00t tasks for tracking:
+# Plan steps can be converted to b00t tasks for tracking:
 
-```bash
+# ```bash
 # Create a task for a plan step
-b00t task add \
-  --title "Implement datum plan lifecycle" \
-  --description "Implement the propose/review/execute/verify lifecycle from DATUM-PLANS" \
-  --priority 2 \
-  --tags "datum-plans,lifecycle"
+# b00t task add \
+#   --title "Implement datum plan lifecycle" \
+#   --description "Implement the propose/review/execute/verify lifecycle from DATUM-PLANS" \
+#   --priority 2 \
+#   --tags "datum-plans,lifecycle"
 
 # Link plan to task (in plan notes section)
 # Task #NN: b00t task show <id>
-```
+# ```
 
-Plan status and task status should be kept in sync. When all tasks for a plan
-are done, the plan moves to `complete`.
+# Plan status and task status should be kept in sync. When all tasks for a plan
+# are done, the plan moves to `complete`.
 
 ## ── Plan lifecycle state machine ─────────────────────────────────────────────
 
-```
-                  ┌─────────┐
-                  │ proposed │
-                  └────┬────┘
-                       │ review
-                       ▼
-                  ┌─────────┐
-           ┌─────│ approved │──────┐
-           │     └────┬────┘      │
-           │          │ execute    │ reject
-           │          ▼           │
-           │     ┌───────────┐    │
-           │     │ executing │    │
-           │     └───┬───┬───┘    │
-           │         │   │        │
-           │     block│   │done   │
-           │         │   │        │
-           │         ▼   ▼        │
-           │  ┌────────┐          │
-           │  │ blocked│          │
-           │  └───┬────┘          │
-           │      │ unblock       │
-           │      └──────────────┘
-           │
-           │ (from approved or executing)
-           ▼
-     ┌───────────┐     ┌───────────┐
-     │ cancelled │     │ rejected  │
-     └───────────┘     └───────────┘
+# ```
+#                   ┌─────────┐
+#                   │ proposed │
+#                   └────┬────┘
+#                        │ review
+#                        ▼
+#                   ┌─────────┐
+#            ┌─────│ approved │──────┐
+#            │     └────┬────┘      │
+#            │          │ execute    │ reject
+#            │          ▼           │
+#            │     ┌───────────┐    │
+#            │     │ executing │    │
+#            │     └───┬───┬───┘    │
+#            │         │   │        │
+#            │     block│   │done   │
+#            │         │   │        │
+#            │         ▼   ▼        │
+#            │  ┌────────┐          │
+#            │  │ blocked│          │
+#            │  └───┬────┘          │
+#            │      │ unblock       │
+#            │      └──────────────┘
+#            │
+#            │ (from approved or executing)
+#            ▼
+#      ┌───────────┐     ┌───────────┐
+#      │ cancelled │     │ rejected  │
+#      └───────────┘     └───────────┘
 
-     (from executing → verify)
-           │
-           ▼
-     ┌──────────┐     ┌──────────┐
-     │ complete │────►│ archived │
-     └──────────┘     └──────────┘
-```
+#      (from executing → verify)
+#            │
+#            ▼
+#      ┌──────────┐     ┌──────────┐
+#      │ complete │────►│ archived │
+#      └──────────┘     └──────────┘
+# ```
 
 ## ── Example: Creating a datum plan flow ───────────────────────────────────────
 
-Here is the complete flow for creating a datum plan, using this datum as an
-example:
+# Here is the complete flow for creating a datum plan, using this datum as an
+# example:
 
-1. **Issue #89** is opened: "Create Datum Plans concept datum"
-2. **Datum created:** `_b00t_/datums/DATUM-PLANS.tomllmd` (this file)
-   - Defines the Datum Plans concept, lifecycle, and directory relationships
-3. **SDD (optional):** If the implementation is complex, an SDD would be written
-   at `_b00t_/sdd/SDD-XXX-datum-plans.md`
-   - Specifies plan file schema, state machine, CLI integration
-4. **Plan created:** `_b00t_/plans/2026-05-08-datum-plans-implementation.md`
-   - Steps: create datum, write SDD, implement parser, wire CLI, test
-5. **Tasks created** via `b00t task add` for each plan step
-6. **Execution:** Agents work through plan steps, updating progress
-7. **Verification:** Acceptance criteria checked, datum updated to `stable`
-8. **Issue #89** updated to reflect completion
+# 1. **Issue #89** is opened: "Create Datum Plans concept datum"
+# 2. **Datum created:** `_b00t_/datums/DATUM-PLANS.tomllmd` (this file)
+#    - Defines the Datum Plans concept, lifecycle, and directory relationships
+# 3. **SDD (optional):** If the implementation is complex, an SDD would be written
+#    at `_b00t_/sdd/SDD-XXX-datum-plans.md`
+#    - Specifies plan file schema, state machine, CLI integration
+# 4. **Plan created:** `_b00t_/plans/2026-05-08-datum-plans-implementation.md`
+#    - Steps: create datum, write SDD, implement parser, wire CLI, test
+# 5. **Tasks created** via `b00t task add` for each plan step
+# 6. **Execution:** Agents work through plan steps, updating progress
+# 7. **Verification:** Acceptance criteria checked, datum updated to `stable`
+# 8. **Issue #89** updated to reflect completion
 
-Flow diagram:
+# Flow diagram:
 
-```
-Issue #89
-  │
-  ├──→ _b00t_/datums/DATUM-PLANS.tomllmd       (this datum)
-  │         ↑ defines the concept
-  │
-  ├──→ _b00t_/sdd/SDD-XXX-datum-plans.md        (optional SDD)
-  │         ↑ specifies the architecture
-  │
-  ├──→ _b00t_/plans/2026-05-08-*.md             (execution plan)
-  │         ↑ schedules the work
-  │
-  └──→ b00t tasks                                (tracking)
-            ↑ tracks progress
-```
+# ```
+# Issue #89
+#   │
+#   ├──→ _b00t_/datums/DATUM-PLANS.tomllmd       (this datum)
+#   │         ↑ defines the concept
+#   │
+#   ├──→ _b00t_/sdd/SDD-XXX-datum-plans.md        (optional SDD)
+#   │         ↑ specifies the architecture
+#   │
+#   ├──→ _b00t_/plans/2026-05-08-*.md             (execution plan)
+#   │         ↑ schedules the work
+#   │
+#   └──→ b00t tasks                                (tracking)
+#             ↑ tracks progress
+# ```
 
 ## ── Future considerations ────────────────────────────────────────────────────
 
-| area | description |
-|------|-------------|
-| **Automatic plan generation** | Agent generates plan from datum + issue automatically |
-| **Plan → task mapping CLI** | `b00t plan convert <plan-file>` auto-creates tasks from steps |
-| **Plan dependency graphs** | Visualize plan dependencies across multiple plans |
-| **Plan expiration** | Auto-archive plans with no activity for N days |
-| **Plan health metrics** | Track plan completion rate, cycle time, block frequency |
-| **Multi-agent plan assignment** | Distribute plan steps across pair members |
-| **SDD gate automation** | Auto-check SDD gates against plan step completion |
-| **Plan template registry** | Shareable plan templates for common patterns |
+# | area | description |
+# |------|-------------|
+# | **Automatic plan generation** | Agent generates plan from datum + issue automatically |
+# | **Plan → task mapping CLI** | `b00t plan convert <plan-file>` auto-creates tasks from steps |
+# | **Plan dependency graphs** | Visualize plan dependencies across multiple plans |
+# | **Plan expiration** | Auto-archive plans with no activity for N days |
+# | **Plan health metrics** | Track plan completion rate, cycle time, block frequency |
+# | **Multi-agent plan assignment** | Distribute plan steps across pair members |
+# | **SDD gate automation** | Auto-check SDD gates against plan step completion |
+# | **Plan template registry** | Shareable plan templates for common patterns |
 
 # b00t:map v1
 # summary: Datum Plans concept — specification-driven development pattern: how datums relate to plans, plan lifecycle (propose → review → execute → verify), directory relationships between _b00t_/datums/ (what), _b00t_/sdd/ (how), and _b00t_/plans/ (when), plan file templates, SDD integration, and state machine

--- a/_b00t_/datums/MCP-SERVER-SCHEMA.tomllmd
+++ b/_b00t_/datums/MCP-SERVER-SCHEMA.tomllmd
@@ -23,139 +23,139 @@ content = "stable"
 
 ## ── Datum-level fields ───────────────────────────────────────────────────────
 
-| field | type | required | default | description |
-|-------|------|----------|---------|-------------|
-| name | string | yes | — | Unique server name (lowercase, kebab-case) |
-| type | string | yes | "mcp" | MUST be "mcp" for MCP server datums |
-| hint | string | yes | — | One-line human description |
-| lfmf_category | string | no | — | Tool category for b00t lfmf lessons |
-| transport | table | yes | — | Transport definition (see Transport mdtable) |
-| env | table | no | — | Environment variables the server reads |
-| requires | string[] | no | [] | System commands required (e.g. ["node","python3"]) |
-| guards | array | no | [] | Hive guards for this server's commands |
-| discover | table | no | — | Tool discovery configuration (for \`b00t mcp registry\`) |
+# | field | type | required | default | description |
+# |-------|------|----------|---------|-------------|
+# | name | string | yes | — | Unique server name (lowercase, kebab-case) |
+# | type | string | yes | "mcp" | MUST be "mcp" for MCP server datums |
+# | hint | string | yes | — | One-line human description |
+# | lfmf_category | string | no | — | Tool category for b00t lfmf lessons |
+# | transport | table | yes | — | Transport definition (see Transport mdtable) |
+# | env | table | no | — | Environment variables the server reads |
+# | requires | string[] | no | [] | System commands required (e.g. ["node","python3"]) |
+# | guards | array | no | [] | Hive guards for this server's commands |
+# | discover | table | no | — | Tool discovery configuration (for \`b00t mcp registry\`) |
 
 ## ── Transport types ──────────────────────────────────────────────────────────
 
 ### stdio transport (default)
-| field | type | required | default | description |
-|-------|------|----------|---------|-------------|
-| command | string | yes | — | Executable path or name |
-| args | string[] | no | [] | CLI arguments |
-| transport | string | yes | "stdio" | MUST be "stdio" |
-| priority | u8 | no | 0 | Selection priority for multi-source MCPs (0=off, 1=fallback, 10=preferred) |
-| env | table | no | — | Extra env vars for this transport only |
-| working_dir | string | no | — | Working directory |
+# | field | type | required | default | description |
+# |-------|------|----------|---------|-------------|
+# | command | string | yes | — | Executable path or name |
+# | args | string[] | no | [] | CLI arguments |
+# | transport | string | yes | "stdio" | MUST be "stdio" |
+# | priority | u8 | no | 0 | Selection priority for multi-source MCPs (0=off, 1=fallback, 10=preferred) |
+# | env | table | no | — | Extra env vars for this transport only |
+# | working_dir | string | no | — | Working directory |
 
 ### http / sse transport
-| field | type | required | default | description |
-|-------|------|----------|---------|-------------|
-| url | string | yes | — | Server endpoint URL |
-| transport | string | yes | "http" | "http" or "sse" |
-| headers | table | no | — | Extra HTTP headers |
-| auth_token_env | string | no | — | Env var name for auth bearer token |
-| timeout_sec | u32 | no | 30 | Connection timeout |
+# | field | type | required | default | description |
+# |-------|------|----------|---------|-------------|
+# | url | string | yes | — | Server endpoint URL |
+# | transport | string | yes | "http" | "http" or "sse" |
+# | headers | table | no | — | Extra HTTP headers |
+# | auth_token_env | string | no | — | Env var name for auth bearer token |
+# | timeout_sec | u32 | no | 30 | Connection timeout |
 
 ## ── Install targets ──────────────────────────────────────────────────────────
 
-A single MCP datum can install to multiple targets. Each target maps to a
-different config file/directory.
+# A single MCP datum can install to multiple targets. Each target maps to a
+# different config file/directory.
 
-| target | config file | command |
-|--------|------------|---------|
-| hermes | ~/.hermes/config.yaml | \`b00t mcp install <name> hermes\` (auto with b00t install hermes) |
-| claudecode | ~/.claude/claude_desktop_config.json | \`b00t mcp install <name> claudecode\` |
-| vscode | ~/.config/Code/User/globalStorage/.../claude_mcp.json | \`b00t mcp install <name> vscode\` |
-| geminicli (repo) | .mcp.json in repo root | \`b00t mcp install <name> geminicli --repo\`\ |
-| geminicli (user) | ~/.gemini/mcp.json | \`b00t mcp install <name> geminicli --user\` |
-| dotmcpjson | .mcp.json in repo root | \`b00t mcp install <name> dotmcpjson [--stdio-command <cmd>\|--httpstream]\` |
+# | target | config file | command |
+# |--------|------------|---------|
+# | hermes | ~/.hermes/config.yaml | \`b00t mcp install <name> hermes\` (auto with b00t install hermes) |
+# | claudecode | ~/.claude/claude_desktop_config.json | \`b00t mcp install <name> claudecode\` |
+# | vscode | ~/.config/Code/User/globalStorage/.../claude_mcp.json | \`b00t mcp install <name> vscode\` |
+# | geminicli (repo) | .mcp.json in repo root | \`b00t mcp install <name> geminicli --repo\`\ |
+# | geminicli (user) | ~/.gemini/mcp.json | \`b00t mcp install <name> geminicli --user\` |
+# | dotmcpjson | .mcp.json in repo root | \`b00t mcp install <name> dotmcpjson [--stdio-command <cmd>\|--httpstream]\` |
 
 ## ── Guard integration ────────────────────────────────────────────────────────
 
-MCP server datums can embed guards that fire when the server's binary is invoked
-via \`b00t hive run\` or when Hermes calls the server's binary:
+# MCP server datums can embed guards that fire when the server's binary is invoked
+# via \`b00t hive run\` or when Hermes calls the server's binary:
 
-```toml
-[[b00t.guards]]
-pattern = { rhai = "pip_guard" }
-action = "warn"
-message = "🦨 use uv pip install"
-redirect = "uv pip install"
-repeat_threshold = 1
-```
+# ```toml
+# [[b00t.guards]]
+# pattern = { rhai = "pip_guard" }
+# action = "warn"
+# message = "🦨 use uv pip install"
+# redirect = "uv pip install"
+# repeat_threshold = 1
+# ```
 
-See hive-guards.hive.toml for the full guard reference.
-Guards defined in MCP datums are profile-specific (not universal like hive-guards).
-They load when \`b00t hive activate <profile>\` activates the MCP's hive profile.
+# See hive-guards.hive.toml for the full guard reference.
+# Guards defined in MCP datums are profile-specific (not universal like hive-guards).
+# They load when \`b00t hive activate <profile>\` activates the MCP's hive profile.
 
 ## ── Discovery configuration ──────────────────────────────────────────────────
 
-For \`b00t mcp registry list\` and \`b00t mcp install <name>\`:
+# For \`b00t mcp registry list\` and \`b00t mcp install <name>\`:
 
-```toml
-[b00t.discover]
+# ```toml
+# [b00t.discover]
 # npm package name (install via npx)
-npm_package = "@modelcontextprotocol/server-filesystem"
+# npm_package = "@modelcontextprotocol/server-filesystem"
 # pip package (install via uv pip)
-pip_package = "mcp-server-filesystem"
+# pip_package = "mcp-server-filesystem"
 # cargo install
-cargo_crate = "mcp-server-filesystem"
+# cargo_crate = "mcp-server-filesystem"
 # binary download URL patterns
-download_urls = ["https://github.com/org/server/releases/latest/download/mcp-server-{os}-{arch}"]
+# download_urls = ["https://github.com/org/server/releases/latest/download/mcp-server-{os}-{arch}"]
 # Tags for registry search
-tags = ["filesystem", "fs", "storage"]
-```
+# tags = ["filesystem", "fs", "storage"]
+# ```
 
 ## ── Example: stdio server ────────────────────────────────────────────────────
 
-```toml
-[b00t]
-name = "filesystem"
-type = "mcp"
-hint = "Filesystem MCP server — read/write/search files"
-lfmf_category = "filesystem"
-requires = ["node"]
+# ```toml
+# [b00t]
+# name = "filesystem"
+# type = "mcp"
+# hint = "Filesystem MCP server — read/write/search files"
+# lfmf_category = "filesystem"
+# requires = ["node"]
 
- [[b00t.mcp.stdio]]
-command = "npx"
-args = ["-y", "@modelcontextprotocol/server-filesystem"]
-transport = "stdio"
-priority = 10
+#  [[b00t.mcp.stdio]]
+# command = "npx"
+# args = ["-y", "@modelcontextprotocol/server-filesystem"]
+# transport = "stdio"
+# priority = 10
 
-[b00t.discover]
-npm_package = "@modelcontextprotocol/server-filesystem"
-tags = ["filesystem", "fs", "storage"]
-```
+# [b00t.discover]
+# npm_package = "@modelcontextprotocol/server-filesystem"
+# tags = ["filesystem", "fs", "storage"]
+# ```
 
 ## ── Example: HTTP server ─────────────────────────────────────────────────────
 
-```toml
-[b00t]
-name = "grok-raglight"
-type = "mcp"
-hint = "Grok RAG service — HTTP SSE MCP server"
+# ```toml
+# [b00t]
+# name = "grok-raglight"
+# type = "mcp"
+# hint = "Grok RAG service — HTTP SSE MCP server"
 
-[[b00t.mcp.http]]
-url = "http://localhost:45205/sse"
-transport = "sse"
-timeout_sec = 60
-auth_token_env = "GROK_API_KEY"
-```
+# [[b00t.mcp.http]]
+# url = "http://localhost:45205/sse"
+# transport = "sse"
+# timeout_sec = 60
+# auth_token_env = "GROK_API_KEY"
+# ```
 
 ## ── Field reference ──────────────────────────────────────────────────────────
 
 ### b00t.mcp.stdio fields (serde deserialization target)
 
-These map directly to Rust struct HiveTomlMcpStdio in b00t-cli/src/hive.rs:
+# These map directly to Rust struct HiveTomlMcpStdio in b00t-cli/src/hive.rs:
 
-| Rust field | TOML path | type | description |
-|-----------|-----------|------|-------------|
-| command | b00t.mcp.stdio[].command | String | Binary/script to execute |
-| args | b00t.mcp.stdio[].args | Vec<String> | CLI arguments |
-| transport | b00t.mcp.stdio[].transport | String | "stdio" |
-| priority | b00t.mcp.stdio[].priority | u32 | Selection ordering |
-| env | b00t.mcp.stdio[].env | Option<HashMap<String,String>> | Extra env vars |
-| working_dir | b00t.mcp.stdio[].working_dir | Option<String> | Working directory |
+# | Rust field | TOML path | type | description |
+# |-----------|-----------|------|-------------|
+# | command | b00t.mcp.stdio[].command | String | Binary/script to execute |
+# | args | b00t.mcp.stdio[].args | Vec<String> | CLI arguments |
+# | transport | b00t.mcp.stdio[].transport | String | "stdio" |
+# | priority | b00t.mcp.stdio[].priority | u32 | Selection ordering |
+# | env | b00t.mcp.stdio[].env | Option<HashMap<String,String>> | Extra env vars |
+# | working_dir | b00t.mcp.stdio[].working_dir | Option<String> | Working directory |
 
 # b00t:map v1
 # summary: Canonical MCP server schema datum — transport definitions (stdio/http/sse), install targets (hermes/claudecode/vscode/geminicli), guard integration, discovery config

--- a/_b00t_/datums/NON-HERMETIC-CODEGEN.tomllmd
+++ b/_b00t_/datums/NON-HERMETIC-CODEGEN.tomllmd
@@ -36,145 +36,145 @@ content = "stable"
 
 ## ── Method ───────────────────────────────────────────────────────────────────
 
-Audit performed 2026-08-06 in an isolated worktree
-(`~/.cache/b00t-worktrees/fix-882-codegen-catalog`, branch
-`task/882-non-hermetic-codegen-catalog`, real ext4 disk) against `origin/main`
-at commit `d3240ff4`.
+# Audit performed 2026-08-06 in an isolated worktree
+# (`~/.cache/b00t-worktrees/fix-882-codegen-catalog`, branch
+# `task/882-non-hermetic-codegen-catalog`, real ext4 disk) against `origin/main`
+# at commit `d3240ff4`.
 
-1. `find . -name build.rs -not -path "*/target/*" -not -path "*/.claude/worktrees/*"`
-   across the full workspace, with the Rust-plausible `vendor/*` submodules
-   initialized non-recursively (`git submodule update --init <path>`) so their
-   `build.rs` files were actually on disk to read — not assumed absent.
-2. `grep -rn 'env!(' --include=*.rs .` and `grep -rn 'include_str!\|include!('`
-   across the same tree, filtered to exclude standard Cargo-provided vars
-   (`CARGO_PKG_*`, `CARGO_MANIFEST_DIR`, `OUT_DIR`) which ARE declared,
-   hermetic build inputs.
-3. `grep -rln "proc-macro = true"` — zero hits; this workspace has no
-   proc-macro crates, so that candidate category is empty.
-4. `grep -rn "GENERATED\|DO NOT EDIT\|@generated"` — all hits were runtime
-   file-writing code paths (`b00t schema import`, `b00t model train`, moltis
-   startup-time config regeneration), not `cargo build`-time codegen. Out of
-   scope: they don't affect compiler-invocation caching.
-5. Every `std::env::var("HOME"/"USER"/...)` / `hostname::get()` hit found was
-   a **runtime** read (executed when the compiled binary runs), not a
-   compile-time embed — explicitly excluded per the issue's own definition
-   ("build steps generate source code non-hermetically"), confirmed by
-   reading each call site's enclosing function.
-6. For every `build.rs` found: read the full file, then classified as
-   confirmed-non-hermetic only if it embeds a value that varies independent
-   of Cargo.toml/source content (timestamp, git state, ambient env var not
-   gated by a Cargo feature) into a `.rs` file consumed by the crate. Two
-   sites were additionally confirmed by an actual `cargo build`, `touch`,
-   rebuild, diff cycle — see entries below.
+# 1. `find . -name build.rs -not -path "*/target/*" -not -path "*/.claude/worktrees/*"`
+#    across the full workspace, with the Rust-plausible `vendor/*` submodules
+#    initialized non-recursively (`git submodule update --init <path>`) so their
+#    `build.rs` files were actually on disk to read — not assumed absent.
+# 2. `grep -rn 'env!(' --include=*.rs .` and `grep -rn 'include_str!\|include!('`
+#    across the same tree, filtered to exclude standard Cargo-provided vars
+#    (`CARGO_PKG_*`, `CARGO_MANIFEST_DIR`, `OUT_DIR`) which ARE declared,
+#    hermetic build inputs.
+# 3. `grep -rln "proc-macro = true"` — zero hits; this workspace has no
+#    proc-macro crates, so that candidate category is empty.
+# 4. `grep -rn "GENERATED\|DO NOT EDIT\|@generated"` — all hits were runtime
+#    file-writing code paths (`b00t schema import`, `b00t model train`, moltis
+#    startup-time config regeneration), not `cargo build`-time codegen. Out of
+#    scope: they don't affect compiler-invocation caching.
+# 5. Every `std::env::var("HOME"/"USER"/...)` / `hostname::get()` hit found was
+#    a **runtime** read (executed when the compiled binary runs), not a
+#    compile-time embed — explicitly excluded per the issue's own definition
+#    ("build steps generate source code non-hermetically"), confirmed by
+#    reading each call site's enclosing function.
+# 6. For every `build.rs` found: read the full file, then classified as
+#    confirmed-non-hermetic only if it embeds a value that varies independent
+#    of Cargo.toml/source content (timestamp, git state, ambient env var not
+#    gated by a Cargo feature) into a `.rs` file consumed by the crate. Two
+#    sites were additionally confirmed by an actual `cargo build`, `touch`,
+#    rebuild, diff cycle — see entries below.
 
 ## ── Confirmed non-hermetic sites ───────────────────────────────────────────────
 
-[[site]]
-crate = "b00t-admin"
-build_step = "b00t-admin/build.rs:4-32 (fn chrono(), fn git_short_hash()) → target/.../out/build_info.rs, included at b00t-admin/src/main.rs:36, read at main.rs:1125-1126"
-why_non_hermetic = "Shells out to `date -u +%Y-%m-%dT%H:%M:%SZ` and `git rev-parse --short HEAD` and writes BUILD_TIMESTAMP + GIT_HASH consts to $OUT_DIR/build_info.rs. Emits ZERO `cargo:rerun-if-changed`/`cargo:rerun-if-env-changed` directives, so Cargo falls back to its default fingerprint (rerun the build script whenever any file in the b00t-admin package changes) — every such rebuild re-embeds the *current* wall clock, not a value derived from any declared Cargo input."
-verification_method = "Empirical: built b00t-admin twice with an intervening `touch b00t-admin/src/main.rs` (no content change, no git HEAD change). BUILD_TIMESTAMP changed from 2026-08-06T01:44:15Z to 2026-08-06T01:46:12Z across the two builds; GIT_HASH stayed d3240ff4 (HEAD unchanged) — proving the embedded output is a function of build wall-clock time, not of any declared build input."
-verified_date = "2026-08-06"
+# [[site]]
+# crate = "b00t-admin"
+# build_step = "b00t-admin/build.rs:4-32 (fn chrono(), fn git_short_hash()) → target/.../out/build_info.rs, included at b00t-admin/src/main.rs:36, read at main.rs:1125-1126"
+# why_non_hermetic = "Shells out to `date -u +%Y-%m-%dT%H:%M:%SZ` and `git rev-parse --short HEAD` and writes BUILD_TIMESTAMP + GIT_HASH consts to $OUT_DIR/build_info.rs. Emits ZERO `cargo:rerun-if-changed`/`cargo:rerun-if-env-changed` directives, so Cargo falls back to its default fingerprint (rerun the build script whenever any file in the b00t-admin package changes) — every such rebuild re-embeds the *current* wall clock, not a value derived from any declared Cargo input."
+# verification_method = "Empirical: built b00t-admin twice with an intervening `touch b00t-admin/src/main.rs` (no content change, no git HEAD change). BUILD_TIMESTAMP changed from 2026-08-06T01:44:15Z to 2026-08-06T01:46:12Z across the two builds; GIT_HASH stayed d3240ff4 (HEAD unchanged) — proving the embedded output is a function of build wall-clock time, not of any declared build input."
+# verified_date = "2026-08-06"
 
-[[site]]
-crate = "b00t-cli"
-build_step = "b00t-cli/build.rs:9-26 → cargo:rustc-env=GIT_HASH / cargo:rustc-env=BUILD_TIMESTAMP, read via env!(\"GIT_HASH\")/env!(\"BUILD_TIMESTAMP\") at b00t-cli/src/commands/version.rs:256-257"
-why_non_hermetic = "Same shell-out pattern as b00t-admin (`git rev-parse --short=7 HEAD`, `date -u ...`), embedded via rustc-env instead of a generated file. Partially mitigated vs. b00t-admin — it DOES emit `cargo:rerun-if-changed=.git/HEAD` and `cargo:rerun-if-changed=.git/refs/heads`, so it doesn't rerun on unrelated source edits — but `.git/HEAD` / `.git/refs/heads` are not declared Cargo build inputs (not part of Cargo.toml, not part of the crate's source tree hash), and BUILD_TIMESTAMP is still wall-clock-derived rather than derived from any declared input, so the value embedded on the *first* build after a given HEAD lands is whatever the local clock read at that moment — not reproducible from source + Cargo.toml + declared env alone. A checkout without a `.git` directory (source tarball, some shallow-clone CI modes) silently degrades GIT_HASH to \"unknown\", another ambient-state dependency."
-verification_method = "Code inspection (confirmed via `find . -name build.rs` + full read of b00t-cli/build.rs) plus cross-reference of the two rustc-env consumers via `grep -rn 'env!(\"GIT_HASH\"\\|env!(\"BUILD_TIMESTAMP\"'`. Not independently rebuilt+diffed in this pass (b00t-cli is a large crate); the mechanism is unambiguous from source and directly parallels the empirically-confirmed b00t-admin case."
-verified_date = "2026-08-06"
+# [[site]]
+# crate = "b00t-cli"
+# build_step = "b00t-cli/build.rs:9-26 → cargo:rustc-env=GIT_HASH / cargo:rustc-env=BUILD_TIMESTAMP, read via env!(\"GIT_HASH\")/env!(\"BUILD_TIMESTAMP\") at b00t-cli/src/commands/version.rs:256-257"
+# why_non_hermetic = "Same shell-out pattern as b00t-admin (`git rev-parse --short=7 HEAD`, `date -u ...`), embedded via rustc-env instead of a generated file. Partially mitigated vs. b00t-admin — it DOES emit `cargo:rerun-if-changed=.git/HEAD` and `cargo:rerun-if-changed=.git/refs/heads`, so it doesn't rerun on unrelated source edits — but `.git/HEAD` / `.git/refs/heads` are not declared Cargo build inputs (not part of Cargo.toml, not part of the crate's source tree hash), and BUILD_TIMESTAMP is still wall-clock-derived rather than derived from any declared input, so the value embedded on the *first* build after a given HEAD lands is whatever the local clock read at that moment — not reproducible from source + Cargo.toml + declared env alone. A checkout without a `.git` directory (source tarball, some shallow-clone CI modes) silently degrades GIT_HASH to \"unknown\", another ambient-state dependency."
+# verification_method = "Code inspection (confirmed via `find . -name build.rs` + full read of b00t-cli/build.rs) plus cross-reference of the two rustc-env consumers via `grep -rn 'env!(\"GIT_HASH\"\\|env!(\"BUILD_TIMESTAMP\"'`. Not independently rebuilt+diffed in this pass (b00t-cli is a large crate); the mechanism is unambiguous from source and directly parallels the empirically-confirmed b00t-admin case."
+# verified_date = "2026-08-06"
 
-[[site]]
-crate = "vendor/moltis-b00t"
-build_step = "vendor/moltis-b00t/crates/config/src/version.rs:7-14 (VERSION, IS_DEV_BUILD consts via option_env!(\"MOLTIS_VERSION\")); same pattern at vendor/moltis-b00t/crates/common/src/http_client.rs:23"
-why_non_hermetic = "MOLTIS_VERSION is an ambient shell environment variable, not a Cargo.toml field and not set by any build.rs in this crate — it is injected only by moltis-b00t's own GitHub Actions release workflow (vendor/moltis-b00t/.github/workflows/release.yml, multiple `MOLTIS_VERSION: ${{ steps.release_version.outputs.version }}` env blocks). A build invoked with MOLTIS_VERSION set embeds that string as VERSION and sets IS_DEV_BUILD=false; the identical source tree built without it embeds CARGO_PKG_VERSION and IS_DEV_BUILD=true. Two builds of byte-identical source + Cargo.toml produce different compiled constants purely as a function of the invoking shell's environment — the textbook non-hermetic case."
-verification_method = "Code inspection: read version.rs and http_client.rs in full, then `grep -rn MOLTIS_VERSION` across vendor/moltis-b00t/ to confirm no build.rs sets it (only justfile release-packaging steps and the GitHub Actions release workflow reference it as an ambient CI-injected var)."
-verified_date = "2026-08-06"
+# [[site]]
+# crate = "vendor/moltis-b00t"
+# build_step = "vendor/moltis-b00t/crates/config/src/version.rs:7-14 (VERSION, IS_DEV_BUILD consts via option_env!(\"MOLTIS_VERSION\")); same pattern at vendor/moltis-b00t/crates/common/src/http_client.rs:23"
+# why_non_hermetic = "MOLTIS_VERSION is an ambient shell environment variable, not a Cargo.toml field and not set by any build.rs in this crate — it is injected only by moltis-b00t's own GitHub Actions release workflow (vendor/moltis-b00t/.github/workflows/release.yml, multiple `MOLTIS_VERSION: ${{ steps.release_version.outputs.version }}` env blocks). A build invoked with MOLTIS_VERSION set embeds that string as VERSION and sets IS_DEV_BUILD=false; the identical source tree built without it embeds CARGO_PKG_VERSION and IS_DEV_BUILD=true. Two builds of byte-identical source + Cargo.toml produce different compiled constants purely as a function of the invoking shell's environment — the textbook non-hermetic case."
+# verification_method = "Code inspection: read version.rs and http_client.rs in full, then `grep -rn MOLTIS_VERSION` across vendor/moltis-b00t/ to confirm no build.rs sets it (only justfile release-packaging steps and the GitHub Actions release workflow reference it as an ambient CI-injected var)."
+# verified_date = "2026-08-06"
 
 ## ── Investigated and ruled out (hermetic or not codegen) ───────────────────────
 
-Documented so this audit doesn't need to be re-litigated from scratch. All
-`build.rs` files found in the workspace (core + Rust-plausible `vendor/*`
-submodules initialized for this audit) are listed; sites not in the confirmed
-table above were read in full and judged hermetic or out-of-scope for the
-reason given.
+# Documented so this audit doesn't need to be re-litigated from scratch. All
+# `build.rs` files found in the workspace (core + Rust-plausible `vendor/*`
+# submodules initialized for this audit) are listed; sites not in the confirmed
+# table above were read in full and judged hermetic or out-of-scope for the
+# reason given.
 
-| crate | build.rs / site | ruling | reason |
-|-------|-----------------|--------|--------|
-| `blessed` | `blessed/build.rs` (copies `_b00t_/blessed/rust.toml` → `blessed/rust.toml`, read via `include_str!` in `blessed/src/lib.rs:4`) | **dead code, not non-hermetic** | Build-script CWD is the package root (`blessed/`), so the hardcoded relative path `_b00t_/blessed/rust.toml` resolves to the nonexistent `blessed/_b00t_/blessed/rust.toml`; `src.exists()` is false and the copy silently no-ops. Empirically confirmed: `sha256sum`/mtime of `blessed/rust.toml` were identical before and after a real `cargo build -p blessed`. The committed `blessed/rust.toml` is what actually ships — deterministic. 🚩 worth a follow-up bugfix (dead/misleading code), tracked separately, not a hermeticity issue since it never executes. |
-| `b00t-grok` | `b00t-grok/build.rs` | hermetic | Reads `CONDA_PREFIX`/`VIRTUAL_ENV`/`CARGO_FEATURE_PYO3`/`B00T_GROK_FIRST_BUILD` only to emit `cargo:warning=`/`cargo:note=` build messages — no generated source, no embedded value. |
-| `b00t-lib-chat` | `b00t-lib-chat/build.rs` | hermetic | `CARGO_FEATURE_PYTHON`/`CARGO_FEATURE_WASM` gate `cargo:rustc-cfg` flags — these are Cargo feature flags, i.e. declared build inputs, not ambient state. |
-| `vendor/irontology-mcp` | `crates/dsl/build.rs` (`lalrpop::process_root()`) | hermetic | Grammar-to-parser codegen is a pure function of the `.lalrpop` source files (declared inputs); no ambient env/timestamp involved. |
-| `vendor/ledgrrr` | `crates/ledger-core/build.rs` | hermetic | Only emits a `cargo:warning=` when the `legal-z3` feature is enabled and libz3 isn't found on the system — no source is generated or embedded; affects developer messaging only. |
-| `vendor/ledgrrr` | `crates/ledgerr-tauri/build.rs` (`tauri_build::build()`) | hermetic (not deep-audited beyond standard tauri codegen from `tauri.conf.json` — a declared input) | Standard Tauri build-script entry point; not independently re-audited past confirming it takes no ambient-env branch in this repo's usage. |
-| `vendor/moltis-b00t` | `crates/providers/build.rs` (NCCL header detection) | **not a codegen site** (noted for completeness) | Machine-local-path dependent (`/usr/include/nccl.h` presence) — matches the issue's "machine-local paths" symptom category — but it only conditionally emits `cargo:rustc-link-lib=nccl`, a linker flag, not embedded source/generated code. Out of this catalog's scope (source codegen only) but flagged here since it's the same underlying class of problem for anyone extending this audit to link-time caching. |
-| `vendor/moltis-b00t` | `crates/schema-export/build.rs` | hermetic | Builds the GraphQL SDL schema string from the crate's own Rust type definitions (`moltis_graphql::build_schema(...).sdl()`) and writes it to `$OUT_DIR/schema.graphqls` — a pure function of declared source. |
-| `vendor/moltis-b00t` | `crates/web/build.rs` | hermetic | Only checks for the presence of pre-built web asset files and fails/warns accordingly — does not generate or embed a varying value. |
+# | crate | build.rs / site | ruling | reason |
+# |-------|-----------------|--------|--------|
+# | `blessed` | `blessed/build.rs` (copies `_b00t_/blessed/rust.toml` → `blessed/rust.toml`, read via `include_str!` in `blessed/src/lib.rs:4`) | **dead code, not non-hermetic** | Build-script CWD is the package root (`blessed/`), so the hardcoded relative path `_b00t_/blessed/rust.toml` resolves to the nonexistent `blessed/_b00t_/blessed/rust.toml`; `src.exists()` is false and the copy silently no-ops. Empirically confirmed: `sha256sum`/mtime of `blessed/rust.toml` were identical before and after a real `cargo build -p blessed`. The committed `blessed/rust.toml` is what actually ships — deterministic. 🚩 worth a follow-up bugfix (dead/misleading code), tracked separately, not a hermeticity issue since it never executes. |
+# | `b00t-grok` | `b00t-grok/build.rs` | hermetic | Reads `CONDA_PREFIX`/`VIRTUAL_ENV`/`CARGO_FEATURE_PYO3`/`B00T_GROK_FIRST_BUILD` only to emit `cargo:warning=`/`cargo:note=` build messages — no generated source, no embedded value. |
+# | `b00t-lib-chat` | `b00t-lib-chat/build.rs` | hermetic | `CARGO_FEATURE_PYTHON`/`CARGO_FEATURE_WASM` gate `cargo:rustc-cfg` flags — these are Cargo feature flags, i.e. declared build inputs, not ambient state. |
+# | `vendor/irontology-mcp` | `crates/dsl/build.rs` (`lalrpop::process_root()`) | hermetic | Grammar-to-parser codegen is a pure function of the `.lalrpop` source files (declared inputs); no ambient env/timestamp involved. |
+# | `vendor/ledgrrr` | `crates/ledger-core/build.rs` | hermetic | Only emits a `cargo:warning=` when the `legal-z3` feature is enabled and libz3 isn't found on the system — no source is generated or embedded; affects developer messaging only. |
+# | `vendor/ledgrrr` | `crates/ledgerr-tauri/build.rs` (`tauri_build::build()`) | hermetic (not deep-audited beyond standard tauri codegen from `tauri.conf.json` — a declared input) | Standard Tauri build-script entry point; not independently re-audited past confirming it takes no ambient-env branch in this repo's usage. |
+# | `vendor/moltis-b00t` | `crates/providers/build.rs` (NCCL header detection) | **not a codegen site** (noted for completeness) | Machine-local-path dependent (`/usr/include/nccl.h` presence) — matches the issue's "machine-local paths" symptom category — but it only conditionally emits `cargo:rustc-link-lib=nccl`, a linker flag, not embedded source/generated code. Out of this catalog's scope (source codegen only) but flagged here since it's the same underlying class of problem for anyone extending this audit to link-time caching. |
+# | `vendor/moltis-b00t` | `crates/schema-export/build.rs` | hermetic | Builds the GraphQL SDL schema string from the crate's own Rust type definitions (`moltis_graphql::build_schema(...).sdl()`) and writes it to `$OUT_DIR/schema.graphqls` — a pure function of declared source. |
+# | `vendor/moltis-b00t` | `crates/web/build.rs` | hermetic | Only checks for the presence of pre-built web asset files and fails/warns accordingly — does not generate or embed a varying value. |
 
-No proc-macro crates exist in this workspace (`grep -rln "proc-macro = true" --include=Cargo.toml .` — zero hits), so that candidate category from the issue text is empty.
+# No proc-macro crates exist in this workspace (`grep -rln "proc-macro = true" --include=Cargo.toml .` — zero hits), so that candidate category from the issue text is empty.
 
 ## ── Vendor submodules not initialized for this pass ────────────────────────────
 
-The following `vendor/*` submodules were judged non-Rust (or Rust with no
-`Cargo.toml` reachable from this workspace) from directory/README naming and
-were not initialized for this audit: `agentsea-skillpacks`,
-`android-emulator-container-scripts`, `opencode-goal-plugin`, `aohp`,
-`pyinfra`, `runpod-sdk`* (Python/JS/infra tooling), `serena`, `linkml-b00t`
-(Python). `gemm-common` failed to clone in this environment (submodule init
-error) and was not investigated — flag for a follow-up pass if it turns out
-to be a real Rust dependency of any workspace member.
+# The following `vendor/*` submodules were judged non-Rust (or Rust with no
+# `Cargo.toml` reachable from this workspace) from directory/README naming and
+# were not initialized for this audit: `agentsea-skillpacks`,
+# `android-emulator-container-scripts`, `opencode-goal-plugin`, `aohp`,
+# `pyinfra`, `runpod-sdk`* (Python/JS/infra tooling), `serena`, `linkml-b00t`
+# (Python). `gemm-common` failed to clone in this environment (submodule init
+# error) and was not investigated — flag for a follow-up pass if it turns out
+# to be a real Rust dependency of any workspace member.
 
-\* `runpod-sdk` was subsequently initialized anyway (mid-audit) because
-`cargo build -p blessed` failed to resolve the workspace graph without it —
-it is a `path`/`git` dependency of something in the graph despite being in
-`[workspace] exclude`. Its `build.rs` presence was checked (`find` above,
-post-init) — none found.
+# \* `runpod-sdk` was subsequently initialized anyway (mid-audit) because
+# `cargo build -p blessed` failed to resolve the workspace graph without it —
+# it is a `path`/`git` dependency of something in the graph despite being in
+# `[workspace] exclude`. Its `build.rs` presence was checked (`find` above,
+# post-init) — none found.
 
 ## ── Referenced files (verification manifest) ────────────────────────────────────
 
-Ground-truth list of repo-relative paths this datum cites as *existing,
-real* evidence (crate build.rs files + the source files that consume their
-output). This is the list the verification script below checks — NOT a
-blind text-regex over the prose above, because the "Investigated and ruled
-out" table intentionally also describes one path that does NOT exist
-(`blessed/_b00t_/blessed/rust.toml`, the resolved-but-missing path that
-proves `blessed/build.rs`'s copy step is dead code) — asserting that path's
-existence would be a false-negative test.
+# Ground-truth list of repo-relative paths this datum cites as *existing,
+# real* evidence (crate build.rs files + the source files that consume their
+# output). This is the list the verification script below checks — NOT a
+# blind text-regex over the prose above, because the "Investigated and ruled
+# out" table intentionally also describes one path that does NOT exist
+# (`blessed/_b00t_/blessed/rust.toml`, the resolved-but-missing path that
+# proves `blessed/build.rs`'s copy step is dead code) — asserting that path's
+# existence would be a false-negative test.
 
-```paths
-b00t-admin/build.rs
-b00t-admin/src/main.rs
-b00t-cli/build.rs
-b00t-cli/src/commands/version.rs
-vendor/moltis-b00t/crates/config/src/version.rs
-vendor/moltis-b00t/crates/common/src/http_client.rs
-blessed/build.rs
-blessed/src/lib.rs
-blessed/rust.toml
-_b00t_/blessed/rust.toml
-b00t-grok/build.rs
-b00t-lib-chat/build.rs
-vendor/irontology-mcp/crates/dsl/build.rs
-vendor/ledgrrr/crates/ledger-core/build.rs
-vendor/ledgrrr/crates/ledgerr-tauri/build.rs
-vendor/moltis-b00t/crates/providers/build.rs
-vendor/moltis-b00t/crates/schema-export/build.rs
-vendor/moltis-b00t/crates/web/build.rs
-vendor/moltis-b00t/.github/workflows/release.yml
-```
+# ```paths
+# b00t-admin/build.rs
+# b00t-admin/src/main.rs
+# b00t-cli/build.rs
+# b00t-cli/src/commands/version.rs
+# vendor/moltis-b00t/crates/config/src/version.rs
+# vendor/moltis-b00t/crates/common/src/http_client.rs
+# blessed/build.rs
+# blessed/src/lib.rs
+# blessed/rust.toml
+# _b00t_/blessed/rust.toml
+# b00t-grok/build.rs
+# b00t-lib-chat/build.rs
+# vendor/irontology-mcp/crates/dsl/build.rs
+# vendor/ledgrrr/crates/ledger-core/build.rs
+# vendor/ledgrrr/crates/ledgerr-tauri/build.rs
+# vendor/moltis-b00t/crates/providers/build.rs
+# vendor/moltis-b00t/crates/schema-export/build.rs
+# vendor/moltis-b00t/crates/web/build.rs
+# vendor/moltis-b00t/.github/workflows/release.yml
+# ```
 
 ## ── Verification (file-path existence check) ───────────────────────────────────
 
-Run from repo root. Extracts the fenced ` ```paths ` manifest above (the
-curated ground truth, not a blind regex over prose) and checks every entry
-resolves to a real file:
+# Run from repo root. Extracts the fenced ` ```paths ` manifest above (the
+# curated ground truth, not a blind regex over prose) and checks every entry
+# resolves to a real file:
 
-```bash
-awk '/^```paths$/{f=1;next} /^```$/{f=0} f' _b00t_/datums/NON-HERMETIC-CODEGEN.tomllmd \
-  | while read -r f; do
-      [ -f "$f" ] || { echo "MISSING: $f"; exit 1; }
-    done \
-  && echo "PASS: all referenced file paths exist"
-```
+# ```bash
+# awk '/^```paths$/{f=1;next} /^```$/{f=0} f' _b00t_/datums/NON-HERMETIC-CODEGEN.tomllmd \
+#   | while read -r f; do
+#       [ -f "$f" ] || { echo "MISSING: $f"; exit 1; }
+#     done \
+#   && echo "PASS: all referenced file paths exist"
+# ```
 
 # b00t:map v1
 # summary: Catalog of b00t build steps confirmed non-hermetic (embedded build timestamps/git hashes in b00t-admin and b00t-cli build.rs, ambient MOLTIS_VERSION env var in vendor/moltis-b00t) vs. sites investigated and ruled out (blessed/build.rs dead code, lalrpop/tauri/graphql-schema codegen judged hermetic) — issue #882, sccache-adoption prerequisite

--- a/_b00t_/datums/PAIR-CONCEPT.tomllmd
+++ b/_b00t_/datums/PAIR-CONCEPT.tomllmd
@@ -30,375 +30,375 @@ content = "draft"
 
 ## ── What is a b00t pair? ───────────────────────────────────────────────────────
 
-A **b00t pair** is an autonomous agent (or pair of agents) assigned as
-maintainer and subject matter domain expert (SME) of a specific subsystem.
-Subsystems can be:
+# A **b00t pair** is an autonomous agent (or pair of agents) assigned as
+# maintainer and subject matter domain expert (SME) of a specific subsystem.
+# Subsystems can be:
 
-- A Git repository (e.g., `b00t-cli`, `b00t-c0re-lib`)
-- A subdirectory tree (e.g., `b00t-cli/src/commands/`)
-- A service or daemon (e.g., `b00t-mcp`, `plantuml-server`)
-- A bounded code domain (e.g., tool integrations, ontology, datums)
+# - A Git repository (e.g., `b00t-cli`, `b00t-c0re-lib`)
+# - A subdirectory tree (e.g., `b00t-cli/src/commands/`)
+# - A service or daemon (e.g., `b00t-mcp`, `plantuml-server`)
+# - A bounded code domain (e.g., tool integrations, ontology, datums)
 
-The pair concept is inspired by extreme programming (XP) pair programming,
-applied at the subsystem-ownership level rather than per-commit.
+# The pair concept is inspired by extreme programming (XP) pair programming,
+# applied at the subsystem-ownership level rather than per-commit.
 
 ### Key principles
 
-| principle | description |
-|-----------|-------------|
-| **Subsystem ownership** | Each pair owns one subsystem end-to-end |
-| **Two heads** | Maintainer + Reviewer; never a single point of context failure |
-| **Rotating pairs** | Pairs shuffle periodically to spread domain knowledge |
-| **Autonomous but accountable** | Pairs drive changes independently; review is mandatory |
-| **Discovery-driven** | Pairs find their subsystem via `b00t idiomap scan`, not manual assignment |
+# | principle | description |
+# |-----------|-------------|
+# | **Subsystem ownership** | Each pair owns one subsystem end-to-end |
+# | **Two heads** | Maintainer + Reviewer; never a single point of context failure |
+# | **Rotating pairs** | Pairs shuffle periodically to spread domain knowledge |
+# | **Autonomous but accountable** | Pairs drive changes independently; review is mandatory |
+# | **Discovery-driven** | Pairs find their subsystem via `b00t idiomap scan`, not manual assignment |
 
 ## ── Pair roles ─────────────────────────────────────────────────────────────────
 
-Each pair has two complementary roles:
+# Each pair has two complementary roles:
 
 ### Maintainer
 
-| responsibility | description |
-|----------------|-------------|
-| **Drive changes** | Implements features, fixes bugs, refactors code |
-| **Subsystem health** | Monitors CI, dependency updates, security advisories |
-| **Context building** | Maintains deep understanding of the subsystem's architecture |
-| **Documentation** | Keeps subsystem docs, datums, and ADRs current |
-| **First responder** | Triages issues and PRs tagged for the subsystem |
+# | responsibility | description |
+# |----------------|-------------|
+# | **Drive changes** | Implements features, fixes bugs, refactors code |
+# | **Subsystem health** | Monitors CI, dependency updates, security advisories |
+# | **Context building** | Maintains deep understanding of the subsystem's architecture |
+# | **Documentation** | Keeps subsystem docs, datums, and ADRs current |
+# | **First responder** | Triages issues and PRs tagged for the subsystem |
 
 ### Reviewer
 
-| responsibility | description |
-|----------------|-------------|
-| **Code review** | Reviews all changes before merge |
-| **Quality gate** | Ensures tests pass, style conforms, no regressions |
-| **Knowledge shadow** | Maintains enough context to take over if maintainer rotates |
-| **Challenge assumptions** | Questions design decisions, suggests alternatives |
-| **Cross-pollination** | Brings patterns and lessons from other subsystems |
+# | responsibility | description |
+# |----------------|-------------|
+# | **Code review** | Reviews all changes before merge |
+# | **Quality gate** | Ensures tests pass, style conforms, no regressions |
+# | **Knowledge shadow** | Maintains enough context to take over if maintainer rotates |
+# | **Challenge assumptions** | Questions design decisions, suggests alternatives |
+# | **Cross-pollination** | Brings patterns and lessons from other subsystems |
 
 ### Role switching
 
-Roles are NOT permanent. The pair swaps maintainer/reviewer on a regular
-cadence (see lifecycle below) to ensure both members build deep context.
+# Roles are NOT permanent. The pair swaps maintainer/reviewer on a regular
+# cadence (see lifecycle below) to ensure both members build deep context.
 
 ## ── Pair lifecycle ─────────────────────────────────────────────────────────────
 
-The pair lifecycle follows a four-phase loop:
+# The pair lifecycle follows a four-phase loop:
 
-```
-  ┌──────────────────────────────────────────────────┐
-  │                                                   │
-  ▼                                                   │
-ASSIGN ──► PAIR ──► REVIEW ──► ROTATE ───────────────┘
-```
+# ```
+#   ┌──────────────────────────────────────────────────┐
+#   │                                                   │
+#   ▼                                                   │
+# ASSIGN ──► PAIR ──► REVIEW ──► ROTATE ───────────────┘
+# ```
 
 ### Phase 1: ASSIGN
 
-Triggered by `b00t idiomap scan` (see discovery section below). When a
-subsystem is identified (new directory, new repo, new service), the system:
+# Triggered by `b00t idiomap scan` (see discovery section below). When a
+# subsystem is identified (new directory, new repo, new service), the system:
 
-1. Detects the subsystem boundary (by `t.b00t` file, idiomatic structure, etc.)
-2. Selects candidate agents from the pool based on capability match
-3. Assigns a maintainer and a reviewer
-4. Creates the pair binding in the agent registry
-5. Notifies both agents of their assignment
+# 1. Detects the subsystem boundary (by `t.b00t` file, idiomatic structure, etc.)
+# 2. Selects candidate agents from the pool based on capability match
+# 3. Assigns a maintainer and a reviewer
+# 4. Creates the pair binding in the agent registry
+# 5. Notifies both agents of their assignment
 
 ### Phase 2: PAIR
 
-The active pairing phase. The maintainer works on the subsystem while the
-reviewer shadows. During this phase:
+# The active pairing phase. The maintainer works on the subsystem while the
+# reviewer shadows. During this phase:
 
-- Maintainer drives all changes to the subsystem
-- Reviewer stays informed (reads diffs, reviews architecture decisions)
-- Both agents maintain a shared context document (stored as a datum or note)
-- Handoffs occur when the maintainer needs assist (see Pair Protocol)
+# - Maintainer drives all changes to the subsystem
+# - Reviewer stays informed (reads diffs, reviews architecture decisions)
+# - Both agents maintain a shared context document (stored as a datum or note)
+# - Handoffs occur when the maintainer needs assist (see Pair Protocol)
 
 ### Phase 3: REVIEW
 
-Before any change reaches the subsystem:
+# Before any change reaches the subsystem:
 
-1. Maintainer submits the proposed change for review
-2. Reviewer examines for correctness, style, test coverage, regressions
-3. Reviewer approves, requests changes, or escalates (see Escalation)
-4. On approval, the change is merged
+# 1. Maintainer submits the proposed change for review
+# 2. Reviewer examines for correctness, style, test coverage, regressions
+# 3. Reviewer approves, requests changes, or escalates (see Escalation)
+# 4. On approval, the change is merged
 
 ### Phase 4: ROTATE
 
-On a defined cadence (configurable per subsystem via `t.b00t`, default every
-sprint or N commits):
+# On a defined cadence (configurable per subsystem via `t.b00t`, default every
+# sprint or N commits):
 
-1. Maintainer and reviewer swap roles
-2. If the rotation is permanent, a new partner may be assigned
-3. Handoff document is updated with current state
-4. New maintainer picks up where the previous left off
+# 1. Maintainer and reviewer swap roles
+# 2. If the rotation is permanent, a new partner may be assigned
+# 3. Handoff document is updated with current state
+# 4. New maintainer picks up where the previous left off
 
 ### Rotation cadence options
 
-| cadence | trigger | use case |
-|---------|---------|----------|
-| Time-based | Every N days/weeks | Stable subsystems with steady flow |
-| Commit-based | Every N commits | Active development sprints |
-| Event-based | On milestone/release | Release-bound work |
-| On-demand | Manual trigger | Context handoff when maintainer is blocked or pulled away |
+# | cadence | trigger | use case |
+# |---------|---------|----------|
+# | Time-based | Every N days/weeks | Stable subsystems with steady flow |
+# | Commit-based | Every N commits | Active development sprints |
+# | Event-based | On milestone/release | Release-bound work |
+# | On-demand | Manual trigger | Context handoff when maintainer is blocked or pulled away |
 
 ## ── Pair protocol ──────────────────────────────────────────────────────────────
 
 ### Handoff
 
-When transferring work between pair members:
+# When transferring work between pair members:
 
-1. Maintainer writes a concise handoff note covering:
-   - Current state of the work
-   - Decisions made and rationale
-   - Open questions or blockers
-   - Next steps for the incoming maintainer
-2. Handoff note is stored as a subsystem datum or attached to the pair record
-3. Incoming maintainer acknowledges receipt and reviews the context
-4. The pair record is updated to reflect the active maintainer
+# 1. Maintainer writes a concise handoff note covering:
+#    - Current state of the work
+#    - Decisions made and rationale
+#    - Open questions or blockers
+#    - Next steps for the incoming maintainer
+# 2. Handoff note is stored as a subsystem datum or attached to the pair record
+# 3. Incoming maintainer acknowledges receipt and reviews the context
+# 4. The pair record is updated to reflect the active maintainer
 
 ### Escalation
 
-When a pair cannot resolve a disagreement internally:
+# When a pair cannot resolve a disagreement internally:
 
-| escalation level | who | what happens |
-|------------------|-----|--------------|
-| Level 1 | Peer discussion | Maintainer and reviewer discuss; reviewer's concerns addressed or overridden with rationale |
-| Level 2 | SME review | A third agent with deeper subsystem knowledge is consulted |
-| Level 3 | Captain resolution | The crew captain makes a binding decision |
-| Level 4 | Human operator | The human operator is notified and decides |
+# | escalation level | who | what happens |
+# |------------------|-----|--------------|
+# | Level 1 | Peer discussion | Maintainer and reviewer discuss; reviewer's concerns addressed or overridden with rationale |
+# | Level 2 | SME review | A third agent with deeper subsystem knowledge is consulted |
+# | Level 3 | Captain resolution | The crew captain makes a binding decision |
+# | Level 4 | Human operator | The human operator is notified and decides |
 
-Escalation is tracked in the pair record and reviewed during rotation
-retrospectives.
+# Escalation is tracked in the pair record and reviewed during rotation
+# retrospectives.
 
 ### Conflict resolution
 
-| conflict type | resolution strategy |
-|---------------|--------------------|
-| Design disagreement | Both parties write a short ADR; captain selects |
-| Priority conflict | Referenced against subsystem goals and crew priorities |
-| Code quality dispute | Run automated linters/metrics; review against subsystem standards |
-| Role boundary dispute | Escalate to captain who may redefine subsystem boundaries |
-| Schedule conflict | Rotation calendar is adjusted; backup pair members activated |
+# | conflict type | resolution strategy |
+# |---------------|--------------------|
+# | Design disagreement | Both parties write a short ADR; captain selects |
+# | Priority conflict | Referenced against subsystem goals and crew priorities |
+# | Code quality dispute | Run automated linters/metrics; review against subsystem standards |
+# | Role boundary dispute | Escalate to captain who may redefine subsystem boundaries |
+# | Schedule conflict | Rotation calendar is adjusted; backup pair members activated |
 
 ### Conflict resolution rules
 
-1. **Data over opinion** — automated metrics, test results, and benchmarks
-   win subjective preferences
-2. **Subsystem goals over individual preference** — the subsystem's
-   documented purpose and constraints take priority
-3. **Escalate quickly** — if a disagreement persists past 2 exchanges,
-   escalate rather than stall
-4. **Log the resolution** — every resolution is recorded in the pair record
-   for future reference
+# 1. **Data over opinion** — automated metrics, test results, and benchmarks
+#    win subjective preferences
+# 2. **Subsystem goals over individual preference** — the subsystem's
+#    documented purpose and constraints take priority
+# 3. **Escalate quickly** — if a disagreement persists past 2 exchanges,
+#    escalate rather than stall
+# 4. **Log the resolution** — every resolution is recorded in the pair record
+#    for future reference
 
 ## ── Subsystem discovery (b00t idiomap) ──────────────────────────────────────────
 
-Pairs discover their subsystem through `b00t idiomap scan`. This is the
-mechanism by which b00t identifies code boundaries and proposes pair
-assignments.
+# Pairs discover their subsystem through `b00t idiomap scan`. This is the
+# mechanism by which b00t identifies code boundaries and proposes pair
+# assignments.
 
 ### What idiomap scan detects
 
-| signal | detection method |
-|--------|------------------|
-| `t.b00t` file | Reads `.b00t/config` or `t.b00t` at a directory root |
-| Repository root | Detects `.git` directory |
-| Subdirectory structure | Recognizes idiomatic project layouts (src/, lib/, cmd/) |
-| Datum presence | Finds `_b00t_/datums/*.tomllmd` files |
-| Service definition | Detects `Dockerfile`, `docker-compose.yml`, `service.yaml` |
-| Package manifest | Reads `Cargo.toml`, `package.json`, `pyproject.toml`, etc. |
+# | signal | detection method |
+# |--------|------------------|
+# | `t.b00t` file | Reads `.b00t/config` or `t.b00t` at a directory root |
+# | Repository root | Detects `.git` directory |
+# | Subdirectory structure | Recognizes idiomatic project layouts (src/, lib/, cmd/) |
+# | Datum presence | Finds `_b00t_/datums/*.tomllmd` files |
+# | Service definition | Detects `Dockerfile`, `docker-compose.yml`, `service.yaml` |
+# | Package manifest | Reads `Cargo.toml`, `package.json`, `pyproject.toml`, etc. |
 
 ### Discovery flow
 
-```
-b00t idiomap scan --recursive
-  │
-  ├── /home/user/projects/b00t-cli/        (t.b00t found)
-  │     └── ASSIGN pair: agent-alpha (M) + agent-beta (R)
-  │
-  ├── /home/user/projects/b00t-c0re-lib/   (t.b00t found)
-  │     └── ASSIGN pair: agent-gamma (M) + agent-delta (R)
-  │
-  └── /home/user/projects/website/src/     (no t.b00t, idiomatic dir)
-        └── PROMPT: create t.b00t for this subsystem?
-```
+# ```
+# b00t idiomap scan --recursive
+#   │
+#   ├── /home/user/projects/b00t-cli/        (t.b00t found)
+#   │     └── ASSIGN pair: agent-alpha (M) + agent-beta (R)
+#   │
+#   ├── /home/user/projects/b00t-c0re-lib/   (t.b00t found)
+#   │     └── ASSIGN pair: agent-gamma (M) + agent-delta (R)
+#   │
+#   └── /home/user/projects/website/src/     (no t.b00t, idiomatic dir)
+#         └── PROMPT: create t.b00t for this subsystem?
+# ```
 
 ### Output
 
-`b00t idiomap scan` produces a subsystem map that feeds the pair assignment
-engine:
+# `b00t idiomap scan` produces a subsystem map that feeds the pair assignment
+# engine:
 
-```json
-{
-  "subsystems": [
-    {
-      "path": "/home/user/projects/b00t-cli",
-      "type": "repository",
-      "t_b00t": true,
-      "pair": "b00t-cli-pair",
-      "maintainer": "agent-alpha",
-      "reviewer": "agent-beta"
-    }
-  ]
-}
-```
+# ```json
+# {
+#   "subsystems": [
+#     {
+#       "path": "/home/user/projects/b00t-cli",
+#       "type": "repository",
+#       "t_b00t": true,
+#       "pair": "b00t-cli-pair",
+#       "maintainer": "agent-alpha",
+#       "reviewer": "agent-beta"
+#     }
+#   ]
+# }
+# ```
 
 ## ── t.b00t file pattern ────────────────────────────────────────────────────────
 
-The `t.b00t` file (pronounced "t-dot-b00t" or "t b00t") is the configuration
-marker that assigns a pair to a subdirectory or subsystem. It is placed at
-the root of the subsystem it governs.
+# The `t.b00t` file (pronounced "t-dot-b00t" or "t b00t") is the configuration
+# marker that assigns a pair to a subdirectory or subsystem. It is placed at
+# the root of the subsystem it governs.
 
 ### Purpose
 
-- Marks a directory as an owned subsystem
-- Configures pair assignments, rotation cadence, and subsystem metadata
-- Provides the primary discovery signal for `b00t idiomap scan`
-- Stores subsystem-level configuration overrides
+# - Marks a directory as an owned subsystem
+# - Configures pair assignments, rotation cadence, and subsystem metadata
+# - Provides the primary discovery signal for `b00t idiomap scan`
+# - Stores subsystem-level configuration overrides
 
 ### Location
 
-```
-<subsystem-root>/
-  ├── t.b00t              # Pair assignment and subsystem config
-  ├── src/
-  ├── tests/
-  └── ...
-```
+# ```
+# <subsystem-root>/
+#   ├── t.b00t              # Pair assignment and subsystem config
+#   ├── src/
+#   ├── tests/
+#   └── ...
+# ```
 
 ### Schema
 
-```toml
-[b00t.pair]
+# ```toml
+# [b00t.pair]
 # Agent IDs assigned to this subsystem
-maintainer = "agent-name"
-reviewer = "agent-name"
+# maintainer = "agent-name"
+# reviewer = "agent-name"
 
 # Rotation configuration
-[b00t.pair.rotation]
-cadence = "time"           # time | commits | event | on-demand
-interval_days = 14         # For time-based cadence
-commit_threshold = 50      # For commit-based cadence
+# [b00t.pair.rotation]
+# cadence = "time"           # time | commits | event | on-demand
+# interval_days = 14         # For time-based cadence
+# commit_threshold = 50      # For commit-based cadence
 
 # Subsystem metadata
-[b00t.pair.subsystem]
-name = "b00t-cli"
-type = "repository"        # repository | directory | service | domain
-description = "b00t CLI tool — commands and REPL"
-tags = ["cli", "rust", "commands"]
+# [b00t.pair.subsystem]
+# name = "b00t-cli"
+# type = "repository"        # repository | directory | service | domain
+# description = "b00t CLI tool — commands and REPL"
+# tags = ["cli", "rust", "commands"]
 
 # Escalation path
-[b00t.pair.escalation]
-captain = "captain-agent-name"
-backup_reviewer = "backup-agent-name"
-auto_escalate_after_days = 3
-```
+# [b00t.pair.escalation]
+# captain = "captain-agent-name"
+# backup_reviewer = "backup-agent-name"
+# auto_escalate_after_days = 3
+# ```
 
 ### Field reference
 
-| field | type | required | default | description |
-|-------|------|----------|---------|-------------|
-| `b00t.pair.maintainer` | string | yes | — | Agent ID of the current maintainer |
-| `b00t.pair.reviewer` | string | yes | — | Agent ID of the current reviewer |
-| `b00t.pair.rotation.cadence` | string | no | `"time"` | Rotation trigger: `time`, `commits`, `event`, `on-demand` |
-| `b00t.pair.rotation.interval_days` | integer | no | 14 | Days between rotations (time cadence) |
-| `b00t.pair.rotation.commit_threshold` | integer | no | 50 | Commits between rotations (commit cadence) |
-| `b00t.pair.subsystem.name` | string | yes | — | Human-readable subsystem name |
-| `b00t.pair.subsystem.type` | string | yes | `"directory"` | Subsystem classification |
-| `b00t.pair.subsystem.description` | string | no | — | One-line subsystem description |
-| `b00t.pair.subsystem.tags` | string[] | no | [] | Tags for discovery and filtering |
-| `b00t.pair.escalation.captain` | string | no | — | Default escalation target |
-| `b00t.pair.escalation.backup_reviewer` | string | no | — | Fallback reviewer |
-| `b00t.pair.escalation.auto_escalate_after_days` | integer | no | 3 | Auto-escalate unresolved issues |
+# | field | type | required | default | description |
+# |-------|------|----------|---------|-------------|
+# | `b00t.pair.maintainer` | string | yes | — | Agent ID of the current maintainer |
+# | `b00t.pair.reviewer` | string | yes | — | Agent ID of the current reviewer |
+# | `b00t.pair.rotation.cadence` | string | no | `"time"` | Rotation trigger: `time`, `commits`, `event`, `on-demand` |
+# | `b00t.pair.rotation.interval_days` | integer | no | 14 | Days between rotations (time cadence) |
+# | `b00t.pair.rotation.commit_threshold` | integer | no | 50 | Commits between rotations (commit cadence) |
+# | `b00t.pair.subsystem.name` | string | yes | — | Human-readable subsystem name |
+# | `b00t.pair.subsystem.type` | string | yes | `"directory"` | Subsystem classification |
+# | `b00t.pair.subsystem.description` | string | no | — | One-line subsystem description |
+# | `b00t.pair.subsystem.tags` | string[] | no | [] | Tags for discovery and filtering |
+# | `b00t.pair.escalation.captain` | string | no | — | Default escalation target |
+# | `b00t.pair.escalation.backup_reviewer` | string | no | — | Fallback reviewer |
+# | `b00t.pair.escalation.auto_escalate_after_days` | integer | no | 3 | Auto-escalate unresolved issues |
 
 ### Example: Single-repo setup
 
-```toml
+# ```toml
 # /home/user/projects/b00t-cli/t.b00t
-[b00t.pair]
-maintainer = "ralph"
-reviewer = "zed"
+# [b00t.pair]
+# maintainer = "ralph"
+# reviewer = "zed"
 
-[b00t.pair.rotation]
-cadence = "commits"
-commit_threshold = 25
+# [b00t.pair.rotation]
+# cadence = "commits"
+# commit_threshold = 25
 
-[b00t.pair.subsystem]
-name = "b00t-cli"
-type = "repository"
-description = "b00t CLI — commands, REPL, and tool dispatch"
-tags = ["cli", "rust", "core"]
+# [b00t.pair.subsystem]
+# name = "b00t-cli"
+# type = "repository"
+# description = "b00t CLI — commands, REPL, and tool dispatch"
+# tags = ["cli", "rust", "core"]
 
-[b00t.pair.escalation]
-captain = "b00t-captain"
-backup_reviewer = "alice"
-```
+# [b00t.pair.escalation]
+# captain = "b00t-captain"
+# backup_reviewer = "alice"
+# ```
 
 ### Example: Subdirectory subsystem
 
-```toml
+# ```toml
 # /home/user/projects/b00t/b00t-c0re-lib/t.b00t
-[b00t.pair]
-maintainer = "bob"
-reviewer = "carol"
+# [b00t.pair]
+# maintainer = "bob"
+# reviewer = "carol"
 
-[b00t.pair.rotation]
-cadence = "time"
-interval_days = 21
+# [b00t.pair.rotation]
+# cadence = "time"
+# interval_days = 21
 
-[b00t.pair.subsystem]
-name = "b00t-c0re-lib"
-type = "directory"
-description = "Core b00t agent library — agent manager, MCP bridge, Redis, IR ontology"
-tags = ["library", "rust", "core", "agents"]
+# [b00t.pair.subsystem]
+# name = "b00t-c0re-lib"
+# type = "directory"
+# description = "Core b00t agent library — agent manager, MCP bridge, Redis, IR ontology"
+# tags = ["library", "rust", "core", "agents"]
 
-[b00t.pair.escalation]
-captain = "b00t-captain"
-auto_escalate_after_days = 5
-```
+# [b00t.pair.escalation]
+# captain = "b00t-captain"
+# auto_escalate_after_days = 5
+# ```
 
 ## ── Pair registry ──────────────────────────────────────────────────────────────
 
-Pair assignments are tracked in the b00t agent registry
-(`b00t-c0re-lib/src/agent_manager.rs`). Each pair record contains:
+# Pair assignments are tracked in the b00t agent registry
+# (`b00t-c0re-lib/src/agent_manager.rs`). Each pair record contains:
 
-| field | type | description |
-|-------|------|-------------|
-| pair_id | string | Unique pair identifier |
-| subsystem_id | string | FK to the subsystem |
-| maintainer | string | Agent ID |
-| reviewer | string | Agent ID |
-| status | string | `active`, `rotating`, `on-break`, `disbanded` |
-| created_at | timestamp | When the pair was formed |
-| last_rotation | timestamp | When roles last swapped |
-| rotation_count | integer | Total rotations performed |
-| escalation_log | json[] | History of escalations |
-| handoff_log | json[] | History of handoffs |
-| captain | string | Default escalation target agent ID |
+# | field | type | description |
+# |-------|------|-------------|
+# | pair_id | string | Unique pair identifier |
+# | subsystem_id | string | FK to the subsystem |
+# | maintainer | string | Agent ID |
+# | reviewer | string | Agent ID |
+# | status | string | `active`, `rotating`, `on-break`, `disbanded` |
+# | created_at | timestamp | When the pair was formed |
+# | last_rotation | timestamp | When roles last swapped |
+# | rotation_count | integer | Total rotations performed |
+# | escalation_log | json[] | History of escalations |
+# | handoff_log | json[] | History of handoffs |
+# | captain | string | Default escalation target agent ID |
 
 ## ── Pair in the b00t ecosystem ─────────────────────────────────────────────────
 
-The pair concept integrates with existing b00t subsystems:
+# The pair concept integrates with existing b00t subsystems:
 
-| subsystem | integration |
-|-----------|-------------|
-| **agent_manager.rs** | Pair lifecycle, role assignments, registry |
-| **idiomap scan** | Subsystem discovery, t.b00t detection |
-| **Ontology / datums** | Subsystem metadata stored as datums |
-| **Crew coordination** | Pairs are the atomic unit of a crew |
-| **Hive guards** | Pair-based access control for subsystem commands |
-| **Task system** | Tasks can be scoped to a pair's subsystem |
-| **grok RAG** | Pair context documents indexed for retrieval |
+# | subsystem | integration |
+# |-----------|-------------|
+# | **agent_manager.rs** | Pair lifecycle, role assignments, registry |
+# | **idiomap scan** | Subsystem discovery, t.b00t detection |
+# | **Ontology / datums** | Subsystem metadata stored as datums |
+# | **Crew coordination** | Pairs are the atomic unit of a crew |
+# | **Hive guards** | Pair-based access control for subsystem commands |
+# | **Task system** | Tasks can be scoped to a pair's subsystem |
+# | **grok RAG** | Pair context documents indexed for retrieval |
 
 ## ── Future considerations ──────────────────────────────────────────────────────
 
-| area | description |
-|------|-------------|
-| **Multi-pair subsystems** | Large subsystems may warrant multiple pairs (e.g., frontend + backend pair for a web service) |
-| **Pair health metrics** | Track review latency, rotation frequency, escalation rate |
-| **Automatic pair assignment** | ML-based capability matching from agent profiles to subsystem requirements |
-| **Cross-pair review** | Pairs can request external review from other pairs for sensitive changes |
-| **Pair affinity** | Track which pairs work well together across rotations |
+# | area | description |
+# |------|-------------|
+# | **Multi-pair subsystems** | Large subsystems may warrant multiple pairs (e.g., frontend + backend pair for a web service) |
+# | **Pair health metrics** | Track review latency, rotation frequency, escalation rate |
+# | **Automatic pair assignment** | ML-based capability matching from agent profiles to subsystem requirements |
+# | **Cross-pair review** | Pairs can request external review from other pairs for sensitive changes |
+# | **Pair affinity** | Track which pairs work well together across rotations |
 
 # b00t:map v1
 # summary: b00t Pair concept — autonomous agent maintainer + SME for subsystems: pair roles (maintainer + reviewer), lifecycle (assign → pair → review → rotate), protocol (handoff, escalation, conflict resolution), subsystem discovery via b00t idiomap scan, and t.b00t configuration file schema

--- a/_b00t_/datums/PRD-ARCH-015-HIVE-CONTROLLER-PYINFRA.tomllmd
+++ b/_b00t_/datums/PRD-ARCH-015-HIVE-CONTROLLER-PYINFRA.tomllmd
@@ -10,7 +10,7 @@ id     = "PRD-ARCH-015-HIVE-CONTROLLER-PYINFRA"
 title  = "Persistent hive controller daemon + pyinfra ouroboros operations"
 status = "proposed"
 tier   = "frontier"
-closes_task = null
+closes_task = 0
 
 # ─── Executive Summary ────────────────────────────────────────────────────────
 # b00t currently has agent coordination over Redis but no persistent daemon.

--- a/_b00t_/datums/PRD-F0UNDRY-AGENT-ONTOLOGY.tomllmd
+++ b/_b00t_/datums/PRD-F0UNDRY-AGENT-ONTOLOGY.tomllmd
@@ -384,7 +384,7 @@ what = "Triple-graph walk of the datum type system."
 output_key = "All 22 DatumType variants with BFO/UFO grounding."
 
 [discovery_protocol.step5_skill_discovery]
-cmd  = "fdfind '\.skill\.toml' _b00t_/ | xargs grep 'unlocks\\|depends_on'"
+cmd  = "fdfind '\\.skill\\.toml' _b00t_/ | xargs grep 'unlocks\\|depends_on'"
 what = "Find skill graph: what each skill unlocks (AuthZ) and what it depends on."
 output_key = "Skill → unlocks → MCP tools chain."
 

--- a/_b00t_/datums/PRD-PRIORITIZABLE-TASK.tomllmd
+++ b/_b00t_/datums/PRD-PRIORITIZABLE-TASK.tomllmd
@@ -59,54 +59,7 @@ operator_triage    = "b00t task list only — no filtering, grouping, or scoring
 ## Schema Extension
 [task_schema]
 # New fields appended to existing task JSON schema
-new_fields = {
-    "checklist": {
-        "type": "array",
-        "description": "Sub-items when task is decomposed into checklist",
-        "items": {
-            "id": "string (slug)",
-            "label": "string",
-            "status": "pending|done|blocked|skipped",
-            "verification": "string (how to verify this item is done)",
-            "output_ref": "string (path to output artifact)"
-        }
-    },
-    "graph_links": {
-        "type": "array",
-        "description": "Knowledge graph node references for traceability",
-        "items": {
-            "node_type": "Function|File|PR|Issue|Datum|Agent",
-            "qualified_name": "string",
-            "relationship": "produces|modifies|depends_on|reviews|validates",
-            "project": "string (codebase-memory project name)"
-        }
-    },
-    "risk_score": {
-        "type": "float",
-        "description": "0.0-1.0 risk that this task produces hallucinated output",
-        "factors": ["author_experience", "complexity", "dependency_depth", "novelty"]
-    },
-    "review_policy": {
-        "type": "string",
-        "description": "How this task's output should be reviewed",
-        "enum": ["auto-approve", "checklist", "single-reviewer", "multi-framework", "adversarial-bounce"]
-    },
-    "blocked_by": {
-        "type": "array",
-        "description": "Task IDs that block this task (auto-computed from dep graph)",
-        "items": "uint"
-    },
-    "unblock_conditions": {
-        "type": "object",
-        "description": "Conditions that auto-unblock when met",
-        "pattern": {
-            "all_deps_done": "bool",
-            "review_passed": "bool", 
-            "tests_green": "bool",
-            "operator_approval": "bool"
-        }
-    }
-}
+new_fields = { checklist = { type = "array", description = "Sub-items when task is decomposed into checklist", items = { id = "string (slug)", label = "string", status = "pending|done|blocked|skipped", verification = "string (how to verify this item is done)", output_ref = "string (path to output artifact)" } }, graph_links = { type = "array", description = "Knowledge graph node references for traceability", items = { node_type = "Function|File|PR|Issue|Datum|Agent", qualified_name = "string", relationship = "produces|modifies|depends_on|reviews|validates", project = "string (codebase-memory project name)" } }, risk_score = { type = "float", description = "0.0-1.0 risk that this task produces hallucinated output", factors = ["author_experience", "complexity", "dependency_depth", "novelty"] }, review_policy = { type = "string", description = "How this task's output should be reviewed", enum = ["auto-approve", "checklist", "single-reviewer", "multi-framework", "adversarial-bounce"] }, blocked_by = { type = "array", description = "Task IDs that block this task (auto-computed from dep graph)", items = "uint" }, unblock_conditions = { type = "object", description = "Conditions that auto-unblock when met", pattern = { all_deps_done = "bool", review_passed = "bool", tests_green = "bool", operator_approval = "bool" } } }
 
 # ── Knowledge Graph Linkages ─────────────────────────────────────────────────
 
@@ -116,42 +69,12 @@ new_fields = {
 # Edge types connecting tasks to code artifacts:
 
 edges = [
-    {
-        "edge": "TASK_PRODUCES",
-        "from": "PrioritizableTask",
-        "to": "Function|File",
-        "meaning": "This task created this code"
-    },
-    {
-        "edge": "TASK_MODIFIES", 
-        "from": "PrioritizableTask",
-        "to": "Function|File",
-        "meaning": "This task changed this code"
-    },
-    {
-        "edge": "TASK_REVIEWS",
-        "from": "PrioritizableTask",
-        "to": "PR|Commit",
-        "meaning": "This task reviews this artifact"
-    },
-    {
-        "edge": "TASK_DEPENDS_ON",
-        "from": "PrioritizableTask",
-        "to": "PrioritizableTask",
-        "meaning": "Upstream dependency (blocked until done)"
-    },
-    {
-        "edge": "TASK_VALIDATES",
-        "from": "PrioritizableTask", 
-        "to": "PrioritizableTask",
-        "meaning": "This task validates the output of another task"
-    },
-    {
-        "edge": "TASK_REFERENCES",
-        "from": "PrioritizableTask",
-        "to": "Datum|Issue",
-        "meaning": "This task references this datum or issue"
-    }
+    { edge = "TASK_PRODUCES", from = "PrioritizableTask", to = "Function|File", meaning = "This task created this code" },
+    { edge = "TASK_MODIFIES", from = "PrioritizableTask", to = "Function|File", meaning = "This task changed this code" },
+    { edge = "TASK_REVIEWS", from = "PrioritizableTask", to = "PR|Commit", meaning = "This task reviews this artifact" },
+    { edge = "TASK_DEPENDS_ON", from = "PrioritizableTask", to = "PrioritizableTask", meaning = "Upstream dependency (blocked until done)" },
+    { edge = "TASK_VALIDATES", from = "PrioritizableTask", to = "PrioritizableTask", meaning = "This task validates the output of another task" },
+    { edge = "TASK_REFERENCES", from = "PrioritizableTask", to = "Datum|Issue", meaning = "This task references this datum or issue" }
 ]
 
 ## Query Power
@@ -172,41 +95,13 @@ graph_queries = [
 # Tools that make operators more effective at task organization and triage
 
 tools = [
-    {
-        "name": "b00t task graph [--format mermaid|json]",
-        "description": "Render task dependency graph. Shows blocked/unblocked, parallel-ready tasks.",
-        "example": "b00t task graph --format mermaid > .b00t/task-graph.md"
-    },
-    {
-        "name": "b00t task checklist <id>",
-        "description": "Toggle a task into checklist mode. Bulk-add sub-items from template or LLM decomposition.",
-        "example": "b00t task checklist 16 --decompose 'review all datum files for tail-map compliance'"
-    },
-    {
-        "name": "b00t task promote <id>",
-        "description": "Promote a checklist item or finding to its own task. Creates dependency link automatically.",
-        "example": "b00t task promote 16 --item 3  # promotes checklist item 3 to new task"
-    },
-    {
-        "name": "b00t task triage [--risk] [--stale] [--blocked]",
-        "description": "Operator triage view: sort by risk score, flag stale tasks, show blocked chain.",
-        "example": "b00t task triage --risk --blocked  # what needs attention now?"
-    },
-    {
-        "name": "b00t task link <id> --node <qualified_name> --rel produces",
-        "description": "Link task to knowledge graph node. Creates TASK_PRODUCES edge.",
-        "example": "b00t task link 16 --node 'b00t-cli/src/task.rs' --rel modifies"
-    },
-    {
-        "name": "b00t task verify <id> [--checklist]",
-        "description": "Verify task completion: run checklist verifications, check graph linkages, validate output.",
-        "example": "b00t task verify 16 --checklist"
-    },
-    {
-        "name": "b00t task batch <status> [--limit N]",
-        "description": "Batch operations: mark multiple tasks, bulk-link, bulk-triage.",
-        "example": "b00t task batch blocked --mark ready  # unblock all satisfied dependencies"
-    }
+    { name = "b00t task graph [--format mermaid|json]", description = "Render task dependency graph. Shows blocked/unblocked, parallel-ready tasks.", example = "b00t task graph --format mermaid > .b00t/task-graph.md" },
+    { name = "b00t task checklist <id>", description = "Toggle a task into checklist mode. Bulk-add sub-items from template or LLM decomposition.", example = "b00t task checklist 16 --decompose 'review all datum files for tail-map compliance'" },
+    { name = "b00t task promote <id>", description = "Promote a checklist item or finding to its own task. Creates dependency link automatically.", example = "b00t task promote 16 --item 3 # promotes checklist item 3 to new task" },
+    { name = "b00t task triage [--risk] [--stale] [--blocked]", description = "Operator triage view: sort by risk score, flag stale tasks, show blocked chain.", example = "b00t task triage --risk --blocked # what needs attention now?" },
+    { name = "b00t task link <id> --node <qualified_name> --rel produces", description = "Link task to knowledge graph node. Creates TASK_PRODUCES edge.", example = "b00t task link 16 --node 'b00t-cli/src/task.rs' --rel modifies" },
+    { name = "b00t task verify <id> [--checklist]", description = "Verify task completion: run checklist verifications, check graph linkages, validate output.", example = "b00t task verify 16 --checklist" },
+    { name = "b00t task batch <status> [--limit N]", description = "Batch operations: mark multiple tasks, bulk-link, bulk-triage.", example = "b00t task batch blocked --mark ready # unblock all satisfied dependencies" }
 ]
 
 ## Just Recipe Syntax Sugar
@@ -214,31 +109,11 @@ tools = [
 # Just recipes that make common operator workflows one-liners
 
 recipes = [
-    {
-        "recipe": "just task-graph",
-        "desc": "Render current task graph to terminal",
-        "impl": "b00t task graph --format mermaid | mermaid-cli",
-    },
-    {
-        "recipe": "just task-next-batch",
-        "desc": "Show next N parallel-ready tasks",
-        "impl": "b00t task triage --ready --limit 5",
-    },
-    {
-        "recipe": "just task-review-queue",
-        "desc": "Show all review tasks with risk scores",
-        "impl": "b00t task triage --tag reviewer --risk",
-    },
-    {
-        "recipe": "just task-blocked-chain <id>",
-        "desc": "Show what's blocking this task and what it blocks",
-        "impl": "b00t task graph --root <id> --direction both",
-    },
-    {
-        "recipe": "just task-checklist-all",
-        "desc": "Run verification on all active checklist tasks",
-        "impl": "b00t task triage --checklist --verify",
-    }
+    { recipe = "just task-graph", desc = "Render current task graph to terminal", impl = "b00t task graph --format mermaid | mermaid-cli" },
+    { recipe = "just task-next-batch", desc = "Show next N parallel-ready tasks", impl = "b00t task triage --ready --limit 5" },
+    { recipe = "just task-review-queue", desc = "Show all review tasks with risk scores", impl = "b00t task triage --tag reviewer --risk" },
+    { recipe = "just task-blocked-chain <id>", desc = "Show what's blocking this task and what it blocks", impl = "b00t task graph --root <id> --direction both" },
+    { recipe = "just task-checklist-all", desc = "Run verification on all active checklist tasks", impl = "b00t task triage --checklist --verify" }
 ]
 
 # ── Hallucination vs Eureka — The Reviewer's Triage Problem ───────────────────
@@ -278,48 +153,12 @@ eureka_indicators = [
 
 [implementation]
 phases = [
-    {
-        "phase": 1,
-        "name": "Checklist Support",
-        "description": "Add checklist array to task schema. b00t task checklist <id> creates/decomposes.",
-        "effort": "ch0nky",
-        "depends_on": []
-    },
-    {
-        "phase": 2,
-        "name": "Graph Linkages",
-        "description": "Add graph_links array. b00t task link creates edges. trace_path works on tasks.",
-        "effort": "ch0nky",
-        "depends_on": ["phase-1"]
-    },
-    {
-        "phase": 3,
-        "name": "Auto-Unblock",
-        "description": "unblock_conditions evaluated after task done. Auto-transitions blocked→pending.",
-        "effort": "sm0l",
-        "depends_on": ["phase-2"]
-    },
-    {
-        "phase": 4,
-        "name": "Risk Scoring",
-        "description": "risk_score computed from author/hotness/complexity/novelty. review_policy auto-assigned.",
-        "effort": "ch0nky",
-        "depends_on": ["phase-2"]
-    },
-    {
-        "phase": 5,
-        "name": "Operator Triage",
-        "description": "b00t task triage, graph, batch commands. just sugar recipes.",
-        "effort": "sm0l",
-        "depends_on": ["phase-3", "phase-4"]
-    },
-    {
-        "phase": 6,
-        "name": "Signal Detection",
-        "description": "Automated hallucination/eureka indicators. Links to codebase-memory for verification.",
-        "effort": "frontier",
-        "depends_on": ["phase-4"]
-    }
+    { phase = 1, name = "Checklist Support", description = "Add checklist array to task schema. b00t task checklist <id> creates/decomposes.", effort = "ch0nky", depends_on = [] },
+    { phase = 2, name = "Graph Linkages", description = "Add graph_links array. b00t task link creates edges. trace_path works on tasks.", effort = "ch0nky", depends_on = ["phase-1"] },
+    { phase = 3, name = "Auto-Unblock", description = "unblock_conditions evaluated after task done. Auto-transitions blocked→pending.", effort = "sm0l", depends_on = ["phase-2"] },
+    { phase = 4, name = "Risk Scoring", description = "risk_score computed from author/hotness/complexity/novelty. review_policy auto-assigned.", effort = "ch0nky", depends_on = ["phase-2"] },
+    { phase = 5, name = "Operator Triage", description = "b00t task triage, graph, batch commands. just sugar recipes.", effort = "sm0l", depends_on = ["phase-3", "phase-4"] },
+    { phase = 6, name = "Signal Detection", description = "Automated hallucination/eureka indicators. Links to codebase-memory for verification.", effort = "frontier", depends_on = ["phase-4"] }
 ]
 
 # ── Success Metrics ──────────────────────────────────────────────────────────

--- a/_b00t_/datums/PRD-REVIEWER-GOVERNANCE-ENGINE.tomllmd
+++ b/_b00t_/datums/PRD-REVIEWER-GOVERNANCE-ENGINE.tomllmd
@@ -94,35 +94,11 @@ diagram = """
 # Every type in the reviewer governance engine is grounded in a UFO stereotype.
 
 types = [
-    {
-        "type": "ReviewVerdict",
-        "ufo_stereotype": "Moment::Mode",
-        "description": "The verdict is an intrinsic moment — it exists only as a property of the review event. It is not an endurant (doesn't persist independently) nor a perdurant (isn't a process — the review process IS the perdurant).",
-        "citation": "Guizzardi 2005, §4.3: Mode = intrinsic moment dependent on a single individual"
-    },
-    {
-        "type": "VerdictConstraint",
-        "ufo_stereotype": "Abstract",
-        "description": "Constraints are abstract — they define rules that govern moments. They exist independently of any particular verdict instance.",
-        "citation": "UFO-B: Abstract category for purely formal entities"
-    },
-    {
-        "type": "ReviewEvent",
-        "ufo_stereotype": "Perdurant::Event",
-        "description": "The review itself is an event — a perdurant that unfolds in time, composed of temporal parts (setup → mece → triz → eureka → synthesize).",
-        "citation": "Guizzardi 2005, §5: Event = perdurant with proper temporal parts"
-    },
-    {
-        "type": "CommandEvidence",
-        "ufo_stereotype": "Endurant::SubKind",
-        "description": "Evidence is a subkind of document — it persists beyond the review event and can be referenced by multiple audit processes.",
-        "citation": "Guizzardi 2005, §3.2: SubKind = rigid specialization of a Kind"
-    },
-    {
-        "type": "CommandReceipt",
-        "ufo_stereotype": "Endurant::SubKind",
-        "description": "A receipt is evidence that a command was executed. It is a rigid specialization of the evidence endurant.",
-    }
+    { type = "ReviewVerdict", ufo_stereotype = "Moment::Mode", description = "The verdict is an intrinsic moment — it exists only as a property of the review event. It is not an endurant (doesn't persist independently) nor a perdurant (isn't a process — the review process IS the perdurant).", citation = "Guizzardi 2005, §4.3: Mode = intrinsic moment dependent on a single individual" },
+    { type = "VerdictConstraint", ufo_stereotype = "Abstract", description = "Constraints are abstract — they define rules that govern moments. They exist independently of any particular verdict instance.", citation = "UFO-B: Abstract category for purely formal entities" },
+    { type = "ReviewEvent", ufo_stereotype = "Perdurant::Event", description = "The review itself is an event — a perdurant that unfolds in time, composed of temporal parts (setup → mece → triz → eureka → synthesize).", citation = "Guizzardi 2005, §5: Event = perdurant with proper temporal parts" },
+    { type = "CommandEvidence", ufo_stereotype = "Endurant::SubKind", description = "Evidence is a subkind of document — it persists beyond the review event and can be referenced by multiple audit processes.", citation = "Guizzardi 2005, §3.2: SubKind = rigid specialization of a Kind" },
+    { type = "CommandReceipt", ufo_stereotype = "Endurant::SubKind", description = "A receipt is evidence that a command was executed. It is a rigid specialization of the evidence endurant." }
 ]
 
 # ── Rust Trait Extension ─────────────────────────────────────────────────────
@@ -283,88 +259,22 @@ hook_flow = """
 # Thin MCP wrappers (≤10 lines each) over Satisfies<Constraint> checks
 
 actions = [
-    {
-        "name": "reviewer_evidence_record",
-        "description": "Record a reviewer verdict command with evidence",
-        "input": {"verdict_hash": "Blake3Hash", "command": "ReviewerCommand"},
-        "output": "CommandReceipt",
-        "impl": "review_verdict.satisfies(&constraint) → if satisfied: tracker.record(evidence, command)"
-    },
-    {
-        "name": "reviewer_evidence_verify",
-        "description": "Verify a command has valid evidence (did it happen?)",
-        "input": {"command_id": "CommandId"},
-        "output": "bool",
-        "impl": "tracker.verify(&command_id)"
-    },
-    {
-        "name": "reviewer_evidence_rollback",
-        "description": "Rollback a command that lacks evidence",
-        "input": {"command_id": "CommandId"},
-        "output": "RollbackResult",
-        "impl": "tracker.rollback(&command_id)"
-    },
-    {
-        "name": "reviewer_audit_trail",
-        "description": "Get the full audit trail for a review session",
-        "input": {"review_event_id": "EventId"},
-        "output": "Vec<CommandReceipt>",
-        "impl": "tracker.query_by_review_event(&review_event_id)"
-    },
+    { name = "reviewer_evidence_record", description = "Record a reviewer verdict command with evidence", input = {verdict_hash = "Blake3Hash", command = "ReviewerCommand"}, output = "CommandReceipt", impl = "review_verdict.satisfies(&constraint) → if satisfied: tracker.record(evidence, command)" },
+    { name = "reviewer_evidence_verify", description = "Verify a command has valid evidence (did it happen?)", input = {command_id = "CommandId"}, output = "bool", impl = "tracker.verify(&command_id)" },
+    { name = "reviewer_evidence_rollback", description = "Rollback a command that lacks evidence", input = {command_id = "CommandId"}, output = "RollbackResult", impl = "tracker.rollback(&command_id)" },
+    { name = "reviewer_audit_trail", description = "Get the full audit trail for a review session", input = {review_event_id = "EventId"}, output = "Vec<CommandReceipt>", impl = "tracker.query_by_review_event(&review_event_id)" },
 ]
 
 # ── Implementation Phases ────────────────────────────────────────────────────
 
 [implementation]
 phases = [
-    {
-        "phase": 1,
-        "name": "Core Traits",
-        "description": "Define ReviewVerdict, CommandTracker, ReviewerCommand, VerdictDisposition, HarnessAction traits in b00t-c0re-lib. Ground in UFO stereotypes.",
-        "effort": "frontier",
-        "depends_on": [],
-        "deliverable": "b00t-c0re-lib/src/reviewer/governance.rs"
-    },
-    {
-        "phase": 2,
-        "name": "Evidence Node Production",
-        "description": "Implement evidence_node() using Blake3 hashing of diff + findings + disposition. Integrate with arc-kit-au for node ID generation.",
-        "effort": "ch0nky",
-        "depends_on": ["phase-1"],
-        "deliverable": "b00t-c0re-lib/src/reviewer/evidence.rs"
-    },
-    {
-        "phase": 3,
-        "name": "Ledgerr Command Tracker",
-        "description": "Implement CommandTracker trait backed by ledgerr. record/verify/rollback operations with audit trail.",
-        "effort": "ch0nky",
-        "depends_on": ["phase-2"],
-        "deliverable": "b00t-c0re-lib/src/reviewer/ledgerr_tracker.rs"
-    },
-    {
-        "phase": 4,
-        "name": "Ledgerr MCP Actions",
-        "description": "Create 4 thin MCP wrappers (reviewer_evidence_record, verify, rollback, audit_trail) as ≤10-line JSON-RPC handlers.",
-        "effort": "sm0l",
-        "depends_on": ["phase-3"],
-        "deliverable": "ledgerr-mcp/src/actions/reviewer_evidence.rs"
-    },
-    {
-        "phase": 5,
-        "name": "Agent Hooks Integration",
-        "description": "Create agent-hooks/events/review.verdict.sh and agent-hooks/roles/reviewer/agent.stop.sh. Hooks call ledgerr MCP to verify evidence before executing harness action.",
-        "effort": "sm0l",
-        "depends_on": ["phase-4"],
-        "deliverable": ["agent-hooks/events/review.verdict.sh", "agent-hooks/roles/reviewer/agent.stop.sh"]
-    },
-    {
-        "phase": 6,
-        "name": "OpenCode Adapter Update",
-        "description": "Update agent-hooks/adapters/opencode.sh with ReviewVerdict event mapping. Wire harness actions to opencode commands.",
-        "effort": "sm0l",
-        "depends_on": ["phase-5"],
-        "deliverable": "agent-hooks/adapters/opencode.sh (updated)"
-    },
+    { phase = 1, name = "Core Traits", description = "Define ReviewVerdict, CommandTracker, ReviewerCommand, VerdictDisposition, HarnessAction traits in b00t-c0re-lib. Ground in UFO stereotypes.", effort = "frontier", depends_on = [], deliverable = "b00t-c0re-lib/src/reviewer/governance.rs" },
+    { phase = 2, name = "Evidence Node Production", description = "Implement evidence_node() using Blake3 hashing of diff + findings + disposition. Integrate with arc-kit-au for node ID generation.", effort = "ch0nky", depends_on = ["phase-1"], deliverable = "b00t-c0re-lib/src/reviewer/evidence.rs" },
+    { phase = 3, name = "Ledgerr Command Tracker", description = "Implement CommandTracker trait backed by ledgerr. record/verify/rollback operations with audit trail.", effort = "ch0nky", depends_on = ["phase-2"], deliverable = "b00t-c0re-lib/src/reviewer/ledgerr_tracker.rs" },
+    { phase = 4, name = "Ledgerr MCP Actions", description = "Create 4 thin MCP wrappers (reviewer_evidence_record, verify, rollback, audit_trail) as ≤10-line JSON-RPC handlers.", effort = "sm0l", depends_on = ["phase-3"], deliverable = "ledgerr-mcp/src/actions/reviewer_evidence.rs" },
+    { phase = 5, name = "Agent Hooks Integration", description = "Create agent-hooks/events/review.verdict.sh and agent-hooks/roles/reviewer/agent.stop.sh. Hooks call ledgerr MCP to verify evidence before executing harness action.", effort = "sm0l", depends_on = ["phase-4"], deliverable = ["agent-hooks/events/review.verdict.sh", "agent-hooks/roles/reviewer/agent.stop.sh"] },
+    { phase = 6, name = "OpenCode Adapter Update", description = "Update agent-hooks/adapters/opencode.sh with ReviewVerdict event mapping. Wire harness actions to opencode commands.", effort = "sm0l", depends_on = ["phase-5"], deliverable = "agent-hooks/adapters/opencode.sh (updated)" },
 ]
 
 # ── Acceptance Criteria ──────────────────────────────────────────────────────

--- a/_b00t_/datums/PRD-SUDO-OPERATOR-GOVERNANCE.tomllmd
+++ b/_b00t_/datums/PRD-SUDO-OPERATOR-GOVERNANCE.tomllmd
@@ -98,35 +98,11 @@ diagram = """
 
 [ufo_grounding]
 types = [
-    {
-        "type": "SudoGrantVerdict",
-        "ufo_stereotype": "Moment::Mode",
-        "description": "The grant/deny/escalate decision is an intrinsic moment dependent on the review event — mirrors ReviewVerdict's grounding exactly.",
-        "citation": "Guizzardi 2005, §4.3: Mode = intrinsic moment dependent on a single individual"
-    },
-    {
-        "type": "SudoGrantConstraint",
-        "ufo_stereotype": "Abstract",
-        "description": "Constraints (does the justification + cited evidence support this specific command?) are abstract rules governing the moment, independent of any particular grant instance.",
-        "citation": "UFO-B: Abstract category for purely formal entities"
-    },
-    {
-        "type": "SudoReviewEvent",
-        "ufo_stereotype": "Perdurant::Event",
-        "description": "The adversarial review is an event unfolding in time: command received → justification parsed → cited commits inspected → model queried → verdict produced.",
-        "citation": "Guizzardi 2005, §5: Event = perdurant with proper temporal parts"
-    },
-    {
-        "type": "SudoGrantEvidence",
-        "ufo_stereotype": "Endurant::SubKind",
-        "description": "Evidence (the Blake3-hashed record of command+justification+cited-commits+verdict) persists beyond the review event, referenceable by future audits — same subkind as CommandEvidence in the reviewer PRD.",
-        "citation": "Guizzardi 2005, §3.2: SubKind = rigid specialization of a Kind"
-    },
-    {
-        "type": "SystemCheckpoint",
-        "ufo_stereotype": "Endurant::SubKind",
-        "description": "A checkpoint is evidence of pre-command state, sufficient for an operator to manually revert. Rigid specialization of the evidence endurant.",
-    }
+    { type = "SudoGrantVerdict", ufo_stereotype = "Moment::Mode", description = "The grant/deny/escalate decision is an intrinsic moment dependent on the review event — mirrors ReviewVerdict's grounding exactly.", citation = "Guizzardi 2005, §4.3: Mode = intrinsic moment dependent on a single individual" },
+    { type = "SudoGrantConstraint", ufo_stereotype = "Abstract", description = "Constraints (does the justification + cited evidence support this specific command?) are abstract rules governing the moment, independent of any particular grant instance.", citation = "UFO-B: Abstract category for purely formal entities" },
+    { type = "SudoReviewEvent", ufo_stereotype = "Perdurant::Event", description = "The adversarial review is an event unfolding in time: command received → justification parsed → cited commits inspected → model queried → verdict produced.", citation = "Guizzardi 2005, §5: Event = perdurant with proper temporal parts" },
+    { type = "SudoGrantEvidence", ufo_stereotype = "Endurant::SubKind", description = "Evidence (the Blake3-hashed record of command+justification+cited-commits+verdict) persists beyond the review event, referenceable by future audits — same subkind as CommandEvidence in the reviewer PRD.", citation = "Guizzardi 2005, §3.2: SubKind = rigid specialization of a Kind" },
+    { type = "SystemCheckpoint", ufo_stereotype = "Endurant::SubKind", description = "A checkpoint is evidence of pre-command state, sufficient for an operator to manually revert. Rigid specialization of the evidence endurant." }
 ]
 
 # ── Rust Trait Extension ─────────────────────────────────────────────────────
@@ -254,54 +230,12 @@ hook_flow = """
 
 [implementation]
 phases = [
-    {
-        "phase": 1,
-        "name": "Core Traits",
-        "description": "Define SudoGrantConstraint, SudoGrantVerdict, SudoDisposition, SudoCommandTracker in b00t-c0re-lib. Ground in UFO stereotypes. Sibling of the (also unbuilt) reviewer/governance.rs.",
-        "effort": "frontier",
-        "depends_on": [],
-        "deliverable": "b00t-c0re-lib/src/sudo_operator/governance.rs"
-    },
-    {
-        "phase": 2,
-        "name": "Checkpoint",
-        "description": "Generalize job_executor.rs::create_checkpoint's git-tag pattern into checkpoint_system_state(); add systemctl show / kubectl get -o yaml artifact dump for non-git state.",
-        "effort": "ch0nky",
-        "depends_on": ["phase-1"],
-        "deliverable": "b00t-c0re-lib/src/sudo_operator/checkpoint.rs"
-    },
-    {
-        "phase": 3,
-        "name": "Adversarial Verdict",
-        "description": "Build review prompt, call sm0l OpenAI-compat endpoint (:8000), parse structured Grant/Deny/Escalate verdict, shell `git show --stat` for cited commits to ground the review.",
-        "effort": "ch0nky",
-        "depends_on": ["phase-1"],
-        "deliverable": "b00t-c0re-lib/src/sudo_operator/verdict.rs"
-    },
-    {
-        "phase": 4,
-        "name": "exec.rs Integration",
-        "description": "Add --justification/--cites flags to handle_exec. Route Block-tier + justification-present through the new verdict flow; leave the existing 300s-TTL bypass unchanged for the no-flag case.",
-        "effort": "ch0nky",
-        "depends_on": ["phase-2", "phase-3"],
-        "deliverable": "b00t-cli/src/commands/exec.rs (updated)"
-    },
-    {
-        "phase": 5,
-        "name": "Escalation Channel",
-        "description": "Reuse budget_controller.rs::send_alert()'s n8n webhook client for a new SudoEscalation event type. Add notify-send desktop fallback.",
-        "effort": "sm0l",
-        "depends_on": ["phase-4"],
-        "deliverable": "b00t-cli/src/budget_controller.rs (updated)"
-    },
-    {
-        "phase": 6,
-        "name": "Ledgerr MCP Actions (follow-up)",
-        "description": "sudo_grant_record / verify / checkpoint_ref as thin MCP wrappers, mirroring reviewer_evidence_* actions in ledgerr-mcp. NOT in v1 scope.",
-        "effort": "sm0l",
-        "depends_on": ["phase-4"],
-        "deliverable": "ledgerr-mcp/src/actions/sudo_grant.rs"
-    },
+    { phase = 1, name = "Core Traits", description = "Define SudoGrantConstraint, SudoGrantVerdict, SudoDisposition, SudoCommandTracker in b00t-c0re-lib. Ground in UFO stereotypes. Sibling of the (also unbuilt) reviewer/governance.rs.", effort = "frontier", depends_on = [], deliverable = "b00t-c0re-lib/src/sudo_operator/governance.rs" },
+    { phase = 2, name = "Checkpoint", description = "Generalize job_executor.rs::create_checkpoint's git-tag pattern into checkpoint_system_state(); add systemctl show / kubectl get -o yaml artifact dump for non-git state.", effort = "ch0nky", depends_on = ["phase-1"], deliverable = "b00t-c0re-lib/src/sudo_operator/checkpoint.rs" },
+    { phase = 3, name = "Adversarial Verdict", description = "Build review prompt, call sm0l OpenAI-compat endpoint (:8000), parse structured Grant/Deny/Escalate verdict, shell `git show --stat` for cited commits to ground the review.", effort = "ch0nky", depends_on = ["phase-1"], deliverable = "b00t-c0re-lib/src/sudo_operator/verdict.rs" },
+    { phase = 4, name = "exec.rs Integration", description = "Add --justification/--cites flags to handle_exec. Route Block-tier + justification-present through the new verdict flow; leave the existing 300s-TTL bypass unchanged for the no-flag case.", effort = "ch0nky", depends_on = ["phase-2", "phase-3"], deliverable = "b00t-cli/src/commands/exec.rs (updated)" },
+    { phase = 5, name = "Escalation Channel", description = "Reuse budget_controller.rs::send_alert()'s n8n webhook client for a new SudoEscalation event type. Add notify-send desktop fallback.", effort = "sm0l", depends_on = ["phase-4"], deliverable = "b00t-cli/src/budget_controller.rs (updated)" },
+    { phase = 6, name = "Ledgerr MCP Actions (follow-up)", description = "sudo_grant_record / verify / checkpoint_ref as thin MCP wrappers, mirroring reviewer_evidence_* actions in ledgerr-mcp. NOT in v1 scope.", effort = "sm0l", depends_on = ["phase-4"], deliverable = "ledgerr-mcp/src/actions/sudo_grant.rs" },
 ]
 
 # ── Acceptance Criteria ──────────────────────────────────────────────────────

--- a/_b00t_/datums/PRD-TAX-LAWYER-UFO-SDD.tomllmd
+++ b/_b00t_/datums/PRD-TAX-LAWYER-UFO-SDD.tomllmd
@@ -233,9 +233,11 @@ iso      = "crates/ufo-types/src/iso.rs"
 cargo    = "crates/ufo-types/Cargo.toml"
 
 [issue.510.docs_to_update_on_ship]
-- "vendor/l3dg3rr/AGENTS.md: add section on ufo-types module"
-- "vendor/l3dg3rr/docs/architecture.md: add ufo-types layer to architecture diagram"
-- "vendor/l3dg3rr/book/src/theory.md: add UFO grounding section"
+items = [
+    "vendor/l3dg3rr/AGENTS.md: add section on ufo-types module",
+    "vendor/l3dg3rr/docs/architecture.md: add ufo-types layer to architecture diagram",
+    "vendor/l3dg3rr/book/src/theory.md: add UFO grounding section",
+]
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # ISSUE #511: AU R&D Tax Incentive — domain ontology + satisfies impls
@@ -359,12 +361,14 @@ DoD: Evidence chain with all 4 new node/edge types roundtrips through JSON.
 
 [issue.511.files_to_create]
 au_rd        = "crates/ledger-core/src/au_rd.rs"
-evidence_ext = "crates/arc-kit-au/src/node.rs"  // extended
+evidence_ext = "crates/arc-kit-au/src/node.rs"  # extended
 
 [issue.511.docs_to_update_on_ship]
-- "vendor/l3dg3rr/docs/mcp-capability-contract.md: add au_rd_* actions"
-- "vendor/l3dg3rr/AGENTS.md: add AU R&D section"
-- "vendor/l3dg3rr/rules/ONTOLOGY.md: add classify_au_rd_eligible.rhai"
+items = [
+    "vendor/l3dg3rr/docs/mcp-capability-contract.md: add au_rd_* actions",
+    "vendor/l3dg3rr/AGENTS.md: add AU R&D section",
+    "vendor/l3dg3rr/rules/ONTOLOGY.md: add classify_au_rd_eligible.rhai",
+]
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # ISSUE #512: US R&D Tax Credit — domain ontology + satisfies impls
@@ -424,8 +428,10 @@ DoD: Both methods produce correct values for known test cases.
 us_rdc = "crates/ledger-core/src/us_rdc.rs"
 
 [issue.512.docs_to_update_on_ship]
-- "vendor/l3dg3rr/book/src/tax.md: add US R&D Tax Credit chapter"
-- "vendor/l3dg3rr/docs/mcp-capability-contract.md: add us_rdc_* actions"
+items = [
+    "vendor/l3dg3rr/book/src/tax.md: add US R&D Tax Credit chapter",
+    "vendor/l3dg3rr/docs/mcp-capability-contract.md: add us_rdc_* actions",
+]
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # ISSUE #513: Crypto cost basis — cross-jurisdiction ontology + satisfies
@@ -502,8 +508,10 @@ crypto     = "crates/ledger-core/src/crypto.rs"
 rules_au   = "rules/classify_crypto_au.rhai"
 
 [issue.513.docs_to_update_on_ship]
-- "vendor/l3dg3rr/rules/ONTOLOGY.md: add crypto-au rule docs"
-- "vendor/l3dg3rr/docs/crypto.md: new crypto tax reference"
+items = [
+    "vendor/l3dg3rr/rules/ONTOLOGY.md: add crypto-au rule docs",
+    "vendor/l3dg3rr/docs/crypto.md: new crypto tax reference",
+]
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # ISSUE #514: MCP action layer — thin JSON-RPC wrappers over Satisfies
@@ -608,16 +616,18 @@ fn handle_au_rd_eligibility(service: &TurboLedgerService, args: &Value) -> Value
 '''
 
 [issue.514.files_to_modify]
-contract     = "crates/ledgerr-mcp/src/contract.rs"       // +TaxArgs variants +actions list
-mcp_adapter  = "crates/ledgerr-mcp/src/mcp_adapter.rs"    // +handler match arms
-au_rd_handler = "crates/ledgerr-mcp/src/au_rd.rs"         // NEW: thin handlers
-us_rdc_handler = "crates/ledgerr-mcp/src/us_rdc.rs"       // NEW: thin handlers
-crypto_handler = "crates/ledgerr-mcp/src/crypto.rs"       // NEW: thin handlers
+contract     = "crates/ledgerr-mcp/src/contract.rs"       # +TaxArgs variants +actions list
+mcp_adapter  = "crates/ledgerr-mcp/src/mcp_adapter.rs"    # +handler match arms
+au_rd_handler = "crates/ledgerr-mcp/src/au_rd.rs"         # NEW: thin handlers
+us_rdc_handler = "crates/ledgerr-mcp/src/us_rdc.rs"       # NEW: thin handlers
+crypto_handler = "crates/ledgerr-mcp/src/crypto.rs"       # NEW: thin handlers
 
 [issue.514.docs_to_update_on_ship]
-- "vendor/l3dg3rr/docs/mcp-capability-contract.md: regenerated"
-- "vendor/l3dg3rr/docs/agent-mcp-runbook.md: regenerated"
-- "scripts/mcp_cli_demo.sh: regenerated"
+items = [
+    "vendor/l3dg3rr/docs/mcp-capability-contract.md: regenerated",
+    "vendor/l3dg3rr/docs/agent-mcp-runbook.md: regenerated",
+    "scripts/mcp_cli_demo.sh: regenerated",
+]
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # ISSUE #515: Skill content — SKILL.md files for tax-lawyer concepts
@@ -704,8 +714,10 @@ agent_test  = "b00t doctor check --probe tax-lawyer passes (skills resolvable)"
 doctest     = "b00t skill search 'rd tax incentive' returns the au-rd-tax-incentive skill"
 
 [issue.515.docs_to_update_on_ship]
-- "AGENTS.md: add tax-lawyer skill registration"
-- "justfile: add skill-tax-lawyer-* just recipes for each skill"
+items = [
+    "AGENTS.md: add tax-lawyer skill registration",
+    "justfile: add skill-tax-lawyer-* just recipes for each skill",
+]
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # EPIC ISSUE #509

--- a/_b00t_/datums/STOP-SEQUENCES.tomllmd
+++ b/_b00t_/datums/STOP-SEQUENCES.tomllmd
@@ -62,21 +62,21 @@ content = "draft"
 ## This table documents the token, its ID (for common tokenizers), how it
 ## behaves in input vs output, and any known edge cases.
 
-| Model Family | Stop Token(s) | Token ID(s) | Input Behavior | Output Behavior | Edge Cases |
-|---|---|---|---|---|---|
-| GPT-2 / GPT-3 | `<|endoftext|>` | 50256 | Normal token; attends to all others | Inference halts on output | Single token; if embedded in file middle, context window contains it but model continues reading |
-| GPT-4 / ChatGPT | `<|im_start|>` `<|im_end|>` | 100264 / 100265 | Tokens in chat template wrapping only; raw text tokenized normally | `stop=["<|im_end|>"]` by default; output stops after assistant's turn | API strips special tokens from input; embedding raw `<|im_end|>` in user message may truncate context |
-| Llama 1/2 | `</s>` | 2 | Normal token; added as EOS during training | Generation stops when EOS token is sampled | If `</s>` appears mid-document in training data, it may be masked in loss (depends on pretraining impl) |
-| Llama 3 / 3.1 | `<|end_of_text|>` `<|eot_id|>` | 128001 / 128009 | `<|eot_id|>` signals end-of-turn in chat template; raw text tokenized as multi-byte tokens | Output stops on `<|end_of_text|>` or `<|eot_id|>` | `<|eot_id|>` in input conditions model to expect assistant turn next — subtle behavioral effect |
-| Mistral / Mixtral | `</s>` | 2 | Single token; part of instruction template `[INST][/INST]` | Generation stops on `</s>` | Instruction template tokens (`[INST]` `[/INST]`) are NOT the same as stop tokens — they are instruction markers, not generation halts |
-| Gemma (Google) | `<eos>` `<end_of_turn>` | 1 / 107 | Part of chat template; raw text tokenized as single tokens | Halts on `<eos>` or `<end_of_turn>` | `<end_of_turn>` in user input may cause the model to respond as if conversation ended |
-| Qwen / Qwen2.5 | `<|endoftext|>` `<|im_end|>` | 151643 / 151645 | Chat template wrapping; raw text tokenizes normally | Generation stops on either token | Qwen2.5 chat template enforces strict role alternation — embedded `<|im_end|>` in input may confuse role detection |
-| DeepSeek (V2/V3) | `<|end_of_sentence|>` | 100001 | Assistant-only suffix in chat template | Stops on EOS at inference | DeepSeek's tokenizer has separate Chinese/English tokens for "用户:" and "助理:" — these are format markers, not stop tokens |
-| Phi-3 (Microsoft) | `<|end|>` `<|user|>` `<|assistant|>` `<|system|>` | 32000-32003 | Chat template roles; raw text tokenized as single tokens | Stops on `<|end|>` | Embedding `<|assistant|>` in user text tricks the model into acting as if its turn just started |
-| Falcon (TII) | `<|endoftext|>` | 11 | Standard EOS token | Halts on EOS | Single token — trivial to embed, no special behavior |
-| Command-R (Cohere) | `<EOS_TOKEN>` | 255001 | Part of prompt template; tokenized as single token | Halts on EOS | API accepts `stop_sequences` list; raw `<EOS_TOKEN>` text in prompt is just content |
-| Starcoder2 / CodeLlama | `<|endoftext|>` + FIM tokens | Varies | FIM tokens (`<fim_prefix>`, `<fim_middle>`, `<fim_suffix>`) delimit infill regions | Halts on EOS; FIM tokens only active in fill-in-middle mode | FIM tokens in regular mode may cause unexpected infill behavior |
-| Anthropic Claude | `Human:` `Assistant:` | N/A (no special token IDs) | Format markers in prompt construction; raw text is just text | Claude checks for `\n\nHuman:` and `\n\nAssistant:` as conversation turn boundaries | These are NOT single tokens — they're multi-token strings. Claude API strips them from tool/function call turns internally |
+# | Model Family | Stop Token(s) | Token ID(s) | Input Behavior | Output Behavior | Edge Cases |
+# |---|---|---|---|---|---|
+# | GPT-2 / GPT-3 | `<|endoftext|>` | 50256 | Normal token; attends to all others | Inference halts on output | Single token; if embedded in file middle, context window contains it but model continues reading |
+# | GPT-4 / ChatGPT | `<|im_start|>` `<|im_end|>` | 100264 / 100265 | Tokens in chat template wrapping only; raw text tokenized normally | `stop=["<|im_end|>"]` by default; output stops after assistant's turn | API strips special tokens from input; embedding raw `<|im_end|>` in user message may truncate context |
+# | Llama 1/2 | `</s>` | 2 | Normal token; added as EOS during training | Generation stops when EOS token is sampled | If `</s>` appears mid-document in training data, it may be masked in loss (depends on pretraining impl) |
+# | Llama 3 / 3.1 | `<|end_of_text|>` `<|eot_id|>` | 128001 / 128009 | `<|eot_id|>` signals end-of-turn in chat template; raw text tokenized as multi-byte tokens | Output stops on `<|end_of_text|>` or `<|eot_id|>` | `<|eot_id|>` in input conditions model to expect assistant turn next — subtle behavioral effect |
+# | Mistral / Mixtral | `</s>` | 2 | Single token; part of instruction template `[INST][/INST]` | Generation stops on `</s>` | Instruction template tokens (`[INST]` `[/INST]`) are NOT the same as stop tokens — they are instruction markers, not generation halts |
+# | Gemma (Google) | `<eos>` `<end_of_turn>` | 1 / 107 | Part of chat template; raw text tokenized as single tokens | Halts on `<eos>` or `<end_of_turn>` | `<end_of_turn>` in user input may cause the model to respond as if conversation ended |
+# | Qwen / Qwen2.5 | `<|endoftext|>` `<|im_end|>` | 151643 / 151645 | Chat template wrapping; raw text tokenizes normally | Generation stops on either token | Qwen2.5 chat template enforces strict role alternation — embedded `<|im_end|>` in input may confuse role detection |
+# | DeepSeek (V2/V3) | `<|end_of_sentence|>` | 100001 | Assistant-only suffix in chat template | Stops on EOS at inference | DeepSeek's tokenizer has separate Chinese/English tokens for "用户:" and "助理:" — these are format markers, not stop tokens |
+# | Phi-3 (Microsoft) | `<|end|>` `<|user|>` `<|assistant|>` `<|system|>` | 32000-32003 | Chat template roles; raw text tokenized as single tokens | Stops on `<|end|>` | Embedding `<|assistant|>` in user text tricks the model into acting as if its turn just started |
+# | Falcon (TII) | `<|endoftext|>` | 11 | Standard EOS token | Halts on EOS | Single token — trivial to embed, no special behavior |
+# | Command-R (Cohere) | `<EOS_TOKEN>` | 255001 | Part of prompt template; tokenized as single token | Halts on EOS | API accepts `stop_sequences` list; raw `<EOS_TOKEN>` text in prompt is just content |
+# | Starcoder2 / CodeLlama | `<|endoftext|>` + FIM tokens | Varies | FIM tokens (`<fim_prefix>`, `<fim_middle>`, `<fim_suffix>`) delimit infill regions | Halts on EOS; FIM tokens only active in fill-in-middle mode | FIM tokens in regular mode may cause unexpected infill behavior |
+# | Anthropic Claude | `Human:` `Assistant:` | N/A (no special token IDs) | Format markers in prompt construction; raw text is just text | Claude checks for `\n\nHuman:` and `\n\nAssistant:` as conversation turn boundaries | These are NOT single tokens — they're multi-token strings. Claude API strips them from tool/function call turns internally |
 
 ## ── Tokenization analysis ────────────────────────────────────────────────────
 ##
@@ -87,19 +87,19 @@ content = "draft"
 ## are never "accidentally" generated, while single-token stop IDs are
 ## always exactly one token whether in input or output.
 ##
-| Tokenizer | Stop String | Is Single Token? | Tokens |
-|---|---|---|---|
-| GPT-2 (tiktoken p50k_base) | `<|endoftext|>` | YES | 1 token (id=50256) |
-| Llama 3 (tiktoken cl100k_base variant) | `<|end_of_text|>` | YES | 1 token (id=128001) |
-| Llama 3 (tiktoken variant) | `<|eot_id|>` | YES | 1 token (id=128009) |
-| Llama 2 (sentencepiece) | `</s>` | YES | 1 token (id=2) |
-| Mistral (sentencepiece) | `</s>` | YES | 1 token (id=2) |
-| Qwen2.5 (tiktoken variant) | `<|im_end|>` | YES | 1 token (id=151645) |
-| Gemma (sentencepiece) | `<end_of_turn>` | YES | 1 token (id=107) |
-| Phi-3 (tiktoken) | `<|end|>` | YES | 1 token (id=32000) |
-| Claude (Claude tokenizer) | `\n\nHuman:` | NO | ~5 tokens (no single ID) |
-| DeepSeek (tiktoken variant) | `<|end_of_sentence|>` | YES | 1 token (id=100001) |
-| Command-R (sentencepiece) | `<EOS_TOKEN>` | YES | 1 token (id=255001) |
+# | Tokenizer | Stop String | Is Single Token? | Tokens |
+# |---|---|---|---|
+# | GPT-2 (tiktoken p50k_base) | `<|endoftext|>` | YES | 1 token (id=50256) |
+# | Llama 3 (tiktoken cl100k_base variant) | `<|end_of_text|>` | YES | 1 token (id=128001) |
+# | Llama 3 (tiktoken variant) | `<|eot_id|>` | YES | 1 token (id=128009) |
+# | Llama 2 (sentencepiece) | `</s>` | YES | 1 token (id=2) |
+# | Mistral (sentencepiece) | `</s>` | YES | 1 token (id=2) |
+# | Qwen2.5 (tiktoken variant) | `<|im_end|>` | YES | 1 token (id=151645) |
+# | Gemma (sentencepiece) | `<end_of_turn>` | YES | 1 token (id=107) |
+# | Phi-3 (tiktoken) | `<|end|>` | YES | 1 token (id=32000) |
+# | Claude (Claude tokenizer) | `\n\nHuman:` | NO | ~5 tokens (no single ID) |
+# | DeepSeek (tiktoken variant) | `<|end_of_sentence|>` | YES | 1 token (id=100001) |
+# | Command-R (sentencepiece) | `<EOS_TOKEN>` | YES | 1 token (id=255001) |
 
 ## ── Experiment protocol (Issue #96) ──────────────────────────────────────────
 ##
@@ -127,12 +127,12 @@ content = "draft"
 ## to misinterpret the conversation structure. This is NOT the model
 ## "stopping" — it's the model being confused about whose turn it is.
 ##
-| Variation | Embedded Token | Expected Effect |
-|---|---|---|
-| Role confusion | `<|assistant|>` | Model may act as if assistant turn started |
-| Turn skip | `<|eot_id|>` | Model may skip user turn, start new assistant response |
-| EOS early | `<|end_of_text|>` | No effect on input; only matters if model outputs it |
-| Raw FIM token | `<fim_middle>` | Code models may enter infill mode unexpectedly |
+# | Variation | Embedded Token | Expected Effect |
+# |---|---|---|
+# | Role confusion | `<|assistant|>` | Model may act as if assistant turn started |
+# | Turn skip | `<|eot_id|>` | Model may skip user turn, start new assistant response |
+# | EOS early | `<|end_of_text|>` | No effect on input; only matters if model outputs it |
+# | Raw FIM token | `<fim_middle>` | Code models may enter infill mode unexpectedly |
 
 ## ── Practical implications ───────────────────────────────────────────────────
 ##
@@ -158,13 +158,13 @@ content = "draft"
 ## If you want to prevent models from reading past a boundary in a file,
 ## do NOT rely on stop sequences. Use one of these strategies instead:
 ##
-| Strategy | Mechanism | Works? |
-|---|---|---|
-| Stop sequence embedding | Token-level stop only checked on output | NO |
-| Truncate file before sending | Pre-processing | YES |
-| Instruction: "stop reading at <marker>" | Model instruction-following | Usually |
-| Segmented file with delimiter | Split into chunks + instruct | YES |
-| Token budget / sliding window | Slice prompt tokens | YES |
+# | Strategy | Mechanism | Works? |
+# |---|---|---|
+# | Stop sequence embedding | Token-level stop only checked on output | NO |
+# | Truncate file before sending | Pre-processing | YES |
+# | Instruction: "stop reading at <marker>" | Model instruction-following | Usually |
+# | Segmented file with delimiter | Split into chunks + instruct | YES |
+# | Token budget / sliding window | Slice prompt tokens | YES |
 
 ## ── Experimental log ─────────────────────────────────────────────────────────
 ##

--- a/_b00t_/datums/SYNC-INTEGRATION.tomllmd
+++ b/_b00t_/datums/SYNC-INTEGRATION.tomllmd
@@ -26,178 +26,178 @@ content = "draft"
 
 ## ── Problem statement ──────────────────────────────────────────────────────────
 
-Upstream b00t (this repository) evolves continuously — new datums, changed
-agent hooks, updated gate scripts, modified job definitions. Downstream
-__b00t__ directories (external projects that embed b00t as an AI agent
-framework) depend on these changes functioning correctly. Currently:
+# Upstream b00t (this repository) evolves continuously — new datums, changed
+# agent hooks, updated gate scripts, modified job definitions. Downstream
+# __b00t__ directories (external projects that embed b00t as an AI agent
+# framework) depend on these changes functioning correctly. Currently:
 
-| Risk | Impact |
-|------|--------|
-| No test gating before dispatch | Broken upstream changes propagate silently to downstream __b00t__ dirs |
-| No notification channel | Downstream __b00t__ has no way to know upstream changed |
-| No validation contract | Downstream doesn't know which tests must pass before accepting |
-| Manual propagation | Operators must manually copy changes and run validation |
+# | Risk | Impact |
+# |------|--------|
+# | No test gating before dispatch | Broken upstream changes propagate silently to downstream __b00t__ dirs |
+# | No notification channel | Downstream __b00t__ has no way to know upstream changed |
+# | No validation contract | Downstream doesn't know which tests must pass before accepting |
+# | Manual propagation | Operators must manually copy changes and run validation |
 
-The sync integration solves these with a test-gated dispatch notification
-pipeline that runs BATS tests BEFORE any downstream notification is sent.
+# The sync integration solves these with a test-gated dispatch notification
+# pipeline that runs BATS tests BEFORE any downstream notification is sent.
 
 ## ── Existing test structure (discovery findings) ───────────────────────────────
 
 ### BATS test framework
 
-The existing test suite lives at `_b00t_/test/` and uses BATS (Bash Automated
-Testing System) with the following structure:
+# The existing test suite lives at `_b00t_/test/` and uses BATS (Bash Automated
+# Testing System) with the following structure:
 
-```
-_b00t_/test/
-  moltls_soul_integration.bats     # HTTP K/V soul serve integration tests
-  test_helper/
-    bats-support/                   # Support library (output, error, lang)
-      load.bash
-      src/output.bash
-      src/error.bash
-      src/lang.bash
-      test/                        # Inner tests for bats-support itself
-    bats-assert/                    # Assertion library
-      load.bash
-      src/assert.bash
-      src/refute.bash
-      src/assert_output.bash
-      src/assert_success.bash
-      src/assert_failure.bash
-      src/assert_line.bash
-      src/refute_output.bash
-      src/refute_line.bash
-      src/assert_equal.bash
-      test/                        # Inner tests for bats-assert itself
-  bats/                             # Bats project test fixtures
-    test/junit-formatter.bats      # JUnit formatter tests
-```
+# ```
+# _b00t_/test/
+#   moltls_soul_integration.bats     # HTTP K/V soul serve integration tests
+#   test_helper/
+#     bats-support/                   # Support library (output, error, lang)
+#       load.bash
+#       src/output.bash
+#       src/error.bash
+#       src/lang.bash
+#       test/                        # Inner tests for bats-support itself
+#     bats-assert/                    # Assertion library
+#       load.bash
+#       src/assert.bash
+#       src/refute.bash
+#       src/assert_output.bash
+#       src/assert_success.bash
+#       src/assert_failure.bash
+#       src/assert_line.bash
+#       src/refute_output.bash
+#       src/refute_line.bash
+#       src/assert_equal.bash
+#       test/                        # Inner tests for bats-assert itself
+#   bats/                             # Bats project test fixtures
+#     test/junit-formatter.bats      # JUnit formatter tests
+# ```
 
 ### Test pattern reference (moltis_soul_integration.bats)
 
-The existing integration test follows this pattern:
+# The existing integration test follows this pattern:
 
-```bash
+# ```bash
 #!/usr/bin/env bats
-load 'test_helper/bats-support/load'
-load 'test_helper/bats-assert/load'
+# load 'test_helper/bats-support/load'
+# load 'test_helper/bats-assert/load'
 
-setup() {
+# setup() {
   # Start service under test, capture PID
-  b00t soul serve &
-  echo $! > /tmp/bats-soul-serve.pid
-  sleep 2   # Wait for service readiness
-}
+#   b00t soul serve &
+#   echo $! > /tmp/bats-soul-serve.pid
+#   sleep 2   # Wait for service readiness
+# }
 
-teardown() {
+# teardown() {
   # Kill service, clean up PID file
-  kill "$(cat /tmp/bats-soul-serve.pid)" 2>/dev/null
-  wait "$(cat /tmp/bats-soul-serve.pid)" 2>/dev/null
-  rm -f /tmp/bats-soul-serve.pid
-}
+#   kill "$(cat /tmp/bats-soul-serve.pid)" 2>/dev/null
+#   wait "$(cat /tmp/bats-soul-serve.pid)" 2>/dev/null
+#   rm -f /tmp/bats-soul-serve.pid
+# }
 
-@test "set key" {
-  run curl -s -o /dev/null -w "%{http_code}" -X POST ...
-  assert_output "200"
-}
+# @test "set key" {
+#   run curl -s -o /dev/null -w "%{http_code}" -X POST ...
+#   assert_output "200"
+# }
 
-@test "get key returns ok" {
-  run curl -s http://127.0.0.1:7700/v1/kv/...
-  assert_output --partial "ok"
-}
-```
+# @test "get key returns ok" {
+#   run curl -s http://127.0.0.1:7700/v1/kv/...
+#   assert_output --partial "ok"
+# }
+# ```
 
-Key observations about the BATS pattern:
-- `setup/teardown` lifecycle for service management and cleanup
-- `run` captures command output and exit code
-- `assert_output` checks stdout against expected value
-- `assert_output --partial` for substring matching
-- PID file pattern for clean shutdown
-- No BATS test currently exists for sync/dispatch/notification
+# Key observations about the BATS pattern:
+# - `setup/teardown` lifecycle for service management and cleanup
+# - `run` captures command output and exit code
+# - `assert_output` checks stdout against expected value
+# - `assert_output --partial` for substring matching
+# - PID file pattern for clean shutdown
+# - No BATS test currently exists for sync/dispatch/notification
 
 ## ── Existing dispatch mechanisms ───────────────────────────────────────────────
 
 ### Agent event hooks (`agent-hooks/`)
 
-```
-agent-hooks/
-  dispatch.sh              # Central event router — routes tool-agnostic events
-  install-claude-hooks.sh  # Hook registration helper
-  adapters/
-    claude-code.sh          # Normalizes Claude Code events to b00t canonical
-    opencode.sh             # Normalizes OpenCode events to b00t canonical
-  events/
-    session.start.sh        # Fires on session start — injects role context
-    agent.start.sh          # Fires on subagent spawn — logs/injects tier context
-    agent.stop.sh           # Fires on subagent stop — result gating
-    tool.pre.sh             # Fires before tool use — security gates (exit 2 = block)
-    tool.post.sh            # Fires after tool use — result inspection
-    prompt.pre.sh           # Fires before prompt — context injection
-  roles/
-    executive/
-      agent.start.sh        # Executive-tier agent start (tier routing, output contracts)
-      agent.stop.sh         # Executive-tier agent stop
-```
+# ```
+# agent-hooks/
+#   dispatch.sh              # Central event router — routes tool-agnostic events
+#   install-claude-hooks.sh  # Hook registration helper
+#   adapters/
+#     claude-code.sh          # Normalizes Claude Code events to b00t canonical
+#     opencode.sh             # Normalizes OpenCode events to b00t canonical
+#   events/
+#     session.start.sh        # Fires on session start — injects role context
+#     agent.start.sh          # Fires on subagent spawn — logs/injects tier context
+#     agent.stop.sh           # Fires on subagent stop — result gating
+#     tool.pre.sh             # Fires before tool use — security gates (exit 2 = block)
+#     tool.post.sh            # Fires after tool use — result inspection
+#     prompt.pre.sh           # Fires before prompt — context injection
+#   roles/
+#     executive/
+#       agent.start.sh        # Executive-tier agent start (tier routing, output contracts)
+#       agent.stop.sh         # Executive-tier agent stop
+# ```
 
-The dispatch.sh router operates via:
-1. Tool detection (CLAUDE_PROJECT_DIR, OPENCODE_PROJECT_DIR, or unknown)
-2. Event normalization (PascalCase vs snake_case via adapter)
-3. Role-specific hooks first (`roles/<role>/<event>.sh`)
-4. Generic event hooks fallback (`events/<event>.sh`)
-5. Exit codes: 0=allow, 2=block, 1=warn
+# The dispatch.sh router operates via:
+# 1. Tool detection (CLAUDE_PROJECT_DIR, OPENCODE_PROJECT_DIR, or unknown)
+# 2. Event normalization (PascalCase vs snake_case via adapter)
+# 3. Role-specific hooks first (`roles/<role>/<event>.sh`)
+# 4. Generic event hooks fallback (`events/<event>.sh`)
+# 5. Exit codes: 0=allow, 2=block, 1=warn
 
 ### Rhai gate evaluation (`scripts/gates.rhai`)
 
-The gates.rhai script provides reusable gate evaluation for datum hooks:
-- `derive_gates(content)` — Parses datum TOML to extract gates from `requires`, `[b00t.env]`, `[[b00t.gate]]`
-- `evaluate_gates(name, datum_content)` — Runs all derived gates, returns false if any fail
-- Gate types: command (binary exists), file (path exists), env (variable set), rhai (custom expression)
+# The gates.rhai script provides reusable gate evaluation for datum hooks:
+# - `derive_gates(content)` — Parses datum TOML to extract gates from `requires`, `[b00t.env]`, `[[b00t.gate]]`
+# - `evaluate_gates(name, datum_content)` — Runs all derived gates, returns false if any fail
+# - Gate types: command (binary exists), file (path exists), env (variable set), rhai (custom expression)
 
 ## ── No existing sync/dispatch notification infrastructure ─────────────────────
 
-Key finding: There is NO existing infrastructure for:
+# Key finding: There is NO existing infrastructure for:
 
-| Missing Component | Evidence |
-|-------------------|----------|
-| Sync notification channel | No files matching `*sync*` or `*notif*` in `_b00t_/` |
-| Test-gated dispatch | No BATS tests reference dispatch or sync |
-| Downstream notification protocol | No webhook, pub/sub, or callback mechanism exists |
-| Upstream change detection | No git hooks, file watchers, or CI integration for sync |
-| Dispatch config/enablement | No job definition or datum for sync dispatch |
+# | Missing Component | Evidence |
+# |-------------------|----------|
+# | Sync notification channel | No files matching `*sync*` or `*notif*` in `_b00t_/` |
+# | Test-gated dispatch | No BATS tests reference dispatch or sync |
+# | Downstream notification protocol | No webhook, pub/sub, or callback mechanism exists |
+# | Upstream change detection | No git hooks, file watchers, or CI integration for sync |
+# | Dispatch config/enablement | No job definition or datum for sync dispatch |
 
-This is exactly what Issue #167 needs to build.
+# This is exactly what Issue #167 needs to build.
 
 ## ── Plan: test-gated dispatch notifications ────────────────────────────────────
 
 ### Phase 1: Create sync BATS test suite
 
-Create `_b00t_/test/sync_dispatch.bats` with test gates for the dispatch
-pipeline. These tests validate that sync events are correctly formed,
-filtered, and delivered.
+# Create `_b00t_/test/sync_dispatch.bats` with test gates for the dispatch
+# pipeline. These tests validate that sync events are correctly formed,
+# filtered, and delivered.
 
-| Test case | Description | Priority |
-|-----------|-------------|----------|
-| `dispatch event is well-formed` | Verify sync event JSON has required fields (type, source, payload, timestamp) | P0 |
-| `dispatch only fired on changed files` | Verify unchanged files don't trigger dispatch | P0 |
-| `dispatch respects test gate` | Verify dispatch is blocked when BATS tests fail | P0 |
-| `dispatch passes when tests pass` | Verify dispatch fires when all BATS tests pass | P0 |
-| `dispatch payload contains diff` | Verify sync event includes the change diff | P1 |
-| `dispatch targets configured downstreams` | Verify destinations from config are notified | P1 |
-| `dispatch retries on failure` | Verify delivery retry logic after transient failure | P2 |
-| `dispatch idempotency` | Verify duplicate events are deduplicated | P2 |
+# | Test case | Description | Priority |
+# |-----------|-------------|----------|
+# | `dispatch event is well-formed` | Verify sync event JSON has required fields (type, source, payload, timestamp) | P0 |
+# | `dispatch only fired on changed files` | Verify unchanged files don't trigger dispatch | P0 |
+# | `dispatch respects test gate` | Verify dispatch is blocked when BATS tests fail | P0 |
+# | `dispatch passes when tests pass` | Verify dispatch fires when all BATS tests pass | P0 |
+# | `dispatch payload contains diff` | Verify sync event includes the change diff | P1 |
+# | `dispatch targets configured downstreams` | Verify destinations from config are notified | P1 |
+# | `dispatch retries on failure` | Verify delivery retry logic after transient failure | P2 |
+# | `dispatch idempotency` | Verify duplicate events are deduplicated | P2 |
 
 ### Phase 2: Create sync dispatch script
 
-Create `_b00t_/agent-hooks/events/sync.dispatch.sh` — the core dispatch
-engine that:
+# Create `_b00t_/agent-hooks/events/sync.dispatch.sh` — the core dispatch
+# engine that:
 
-1. Accepts a change event on stdin (JSON with {source, type, files, diff})
-2. Runs the BATS sync test suite (`bats _b00t_/test/sync_dispatch*.bats`)
-3. If tests pass — fire notification to downstream __b00t__ directories
-4. If tests fail — block dispatch, log failure, notify operator
+# 1. Accepts a change event on stdin (JSON with {source, type, files, diff})
+# 2. Runs the BATS sync test suite (`bats _b00t_/test/sync_dispatch*.bats`)
+# 3. If tests pass — fire notification to downstream __b00t__ directories
+# 4. If tests fail — block dispatch, log failure, notify operator
 
-```bash
+# ```bash
 # Pseudocode for sync.dispatch.sh:
 # 1. Parse input: jq -r '.source, .type, .files[], .diff'
 # 2. Validate input structure (check required fields)
@@ -205,256 +205,256 @@ engine that:
 # 4. If BATS exit != 0 → exit 2 (block), stderr shows test failures
 # 5. If BATS passes → construct notification, deliver to downstreams
 # 6. Log the dispatch event with timestamp and result
-```
+# ```
 
-Exit protocol follows existing agent-hook conventions:
-- exit 0 + JSON to stdout = dispatch succeeded
-- exit 2 = dispatch blocked (test failure), stderr sent as reason
-- exit 1 = non-blocking warning (e.g., downstream unreachable)
+# Exit protocol follows existing agent-hook conventions:
+# - exit 0 + JSON to stdout = dispatch succeeded
+# - exit 2 = dispatch blocked (test failure), stderr sent as reason
+# - exit 1 = non-blocking warning (e.g., downstream unreachable)
 
 ### Phase 3: Define dispatch notification protocol
 
-Define the protocol for how downstream __b00t__ directories receive and
-acknowledge sync notifications.
+# Define the protocol for how downstream __b00t__ directories receive and
+# acknowledge sync notifications.
 
 #### Notification payload schema
 
-```json
-{
-  "sync_notification": {
-    "schema_version": "1.0",
-    "source": "<upstream-identifier>",
-    "timestamp": "2026-05-08T12:00:00Z",
-    "event_type": "update | create | delete",
-    "changes": [
-      {
-        "path": "_b00t_/datums/NEW-DATUM.tomllmd",
-        "change_type": "create",
-        "hash": "sha256:abc123..."
-      }
-    ],
-    "test_results": {
-      "passed": 5,
-      "failed": 0,
-      "skipped": 1,
-      "total": 6
-    },
-    "metadata": {
-      "commit": "abc123def",
-      "branch": "main",
-      "operator": "agent-ralph"
-    }
-  }
-}
-```
+# ```json
+# {
+#   "sync_notification": {
+#     "schema_version": "1.0",
+#     "source": "<upstream-identifier>",
+#     "timestamp": "2026-05-08T12:00:00Z",
+#     "event_type": "update | create | delete",
+#     "changes": [
+#       {
+#         "path": "_b00t_/datums/NEW-DATUM.tomllmd",
+#         "change_type": "create",
+#         "hash": "sha256:abc123..."
+#       }
+#     ],
+#     "test_results": {
+#       "passed": 5,
+#       "failed": 0,
+#       "skipped": 1,
+#       "total": 6
+#     },
+#     "metadata": {
+#       "commit": "abc123def",
+#       "branch": "main",
+#       "operator": "agent-ralph"
+#     }
+#   }
+# }
+# ```
 
 #### Delivery methods (ordered by preference)
 
-| Method | Mechanism | Required infrastructure |
-|--------|-----------|------------------------|
-| File touch | Write `.sync-ready` marker in downstream __b00t__/.sync/ | None — filesystem only |
-| Agent hook | Fire `sync.notification` event via downstream agent-hooks | Downstream has dispatch.sh installed |
-| MCP notification | Call downstream MCP tool `sync_ingest` | Downstream runs MCP server |
-| Webhook | POST to configured URL | Network access + URL config |
+# | Method | Mechanism | Required infrastructure |
+# |--------|-----------|------------------------|
+# | File touch | Write `.sync-ready` marker in downstream __b00t__/.sync/ | None — filesystem only |
+# | Agent hook | Fire `sync.notification` event via downstream agent-hooks | Downstream has dispatch.sh installed |
+# | MCP notification | Call downstream MCP tool `sync_ingest` | Downstream runs MCP server |
+# | Webhook | POST to configured URL | Network access + URL config |
 
 #### File touch delivery (simplest, recommended first)
 
-```
-downstream/.b00t/__b00t__/.sync/
-  upstream-ready.sync         # Touch file: upstream has changes ready
-  upstream-last-sync.json     # Last successful sync metadata
-  downstream-status.json      # Downstream sync acceptance status
-```
+# ```
+# downstream/.b00t/__b00t__/.sync/
+#   upstream-ready.sync         # Touch file: upstream has changes ready
+#   upstream-last-sync.json     # Last successful sync metadata
+#   downstream-status.json      # Downstream sync acceptance status
+# ```
 
 ### Phase 4: Create sync configuration datum
 
-Create `_b00t_/sync-config.mcp.toml` or include sync configuration in
-the existing job/agent infrastructure. Configuration includes:
+# Create `_b00t_/sync-config.mcp.toml` or include sync configuration in
+# the existing job/agent infrastructure. Configuration includes:
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `enabled` | bool | Master switch for sync dispatch |
-| `downstreams` | string[] | Paths to downstream __b00t__ directories |
-| `test_gate` | string | BATS glob pattern for gate tests (default: `test/sync_dispatch*.bats`) |
-| `delivery_method` | string | `file-touch` | `agent-hook` | `mcp` | `webhook` |
-| `delivery_config` | table | Method-specific configuration |
-| `block_on_fail` | bool | Whether test failure blocks dispatch (default: true) |
-| `retry_max` | int | Max delivery attempts before giving up |
-| `retry_delay_sec` | int | Seconds between retries |
+# | Field | Type | Description |
+# |-------|------|-------------|
+# | `enabled` | bool | Master switch for sync dispatch |
+# | `downstreams` | string[] | Paths to downstream __b00t__ directories |
+# | `test_gate` | string | BATS glob pattern for gate tests (default: `test/sync_dispatch*.bats`) |
+# | `delivery_method` | string | `file-touch` | `agent-hook` | `mcp` | `webhook` |
+# | `delivery_config` | table | Method-specific configuration |
+# | `block_on_fail` | bool | Whether test failure blocks dispatch (default: true) |
+# | `retry_max` | int | Max delivery attempts before giving up |
+# | `retry_delay_sec` | int | Seconds between retries |
 
-Example configuration:
+# Example configuration:
 
-```toml
-[b00t.sync]
-enabled = true
-test_gate = "test/sync_dispatch*.bats"
-block_on_fail = true
+# ```toml
+# [b00t.sync]
+# enabled = true
+# test_gate = "test/sync_dispatch*.bats"
+# block_on_fail = true
 
-[[b00t.sync.downstreams]]
-path = "/path/to/downstream-project/.b00t/__b00t__"
-delivery_method = "file-touch"
-sync_dir = ".sync/"
+# [[b00t.sync.downstreams]]
+# path = "/path/to/downstream-project/.b00t/__b00t__"
+# delivery_method = "file-touch"
+# sync_dir = ".sync/"
 
-[[b00t.sync.downstreams]]
-path = "/path/to/other-downstream/.b00t/__b00t__"
-delivery_method = "agent-hook"
-event_name = "sync.notification"
-```
+# [[b00t.sync.downstreams]]
+# path = "/path/to/other-downstream/.b00t/__b00t__"
+# delivery_method = "agent-hook"
+# event_name = "sync.notification"
+# ```
 
 ### Phase 5: Register sync dispatch in job system
 
-Create or extend a job definition to trigger sync dispatch on relevant
-upstream changes. Two integration paths:
+# Create or extend a job definition to trigger sync dispatch on relevant
+# upstream changes. Two integration paths:
 
 #### Option A: New cronjob in epoch-progression.job.toml
 
-Add a step to `epoch-progression.job.toml` that periodically checks for
-changes and triggers sync dispatch:
+# Add a step to `epoch-progression.job.toml` that periodically checks for
+# changes and triggers sync dispatch:
 
-```toml
-[[b00t.job.steps]]
-name = "sync-dispatch"
-description = "Check for upstream changes and dispatch to downstream __b00t__ dirs"
-checkpoint = "sync-dispatched"
-depends_on = ["execute-task"]
+# ```toml
+# [[b00t.job.steps]]
+# name = "sync-dispatch"
+# description = "Check for upstream changes and dispatch to downstream __b00t__ dirs"
+# checkpoint = "sync-dispatched"
+# depends_on = ["execute-task"]
 
-[b00t.job.steps.task]
-type = "bash"
-command = "b00t sync dispatch 2>&1 || echo 'Sync dispatch skipped (no changes or gate failed)'"
-timeout_ms = 60000
-```
+# [b00t.job.steps.task]
+# type = "bash"
+# command = "b00t sync dispatch 2>&1 || echo 'Sync dispatch skipped (no changes or gate failed)'"
+# timeout_ms = 60000
+# ```
 
 #### Option B: Standalone sync job `sync-dispatch.job.toml`
 
-```toml
-[b00t]
-name = "sync-dispatch"
-type = "job"
-hint = "Test-gated dispatch of upstream b00t changes to downstream __b00t__ directories"
-version = "1.0.0"
+# ```toml
+# [b00t]
+# name = "sync-dispatch"
+# type = "job"
+# hint = "Test-gated dispatch of upstream b00t changes to downstream __b00t__ directories"
+# version = "1.0.0"
 
-[b00t.job]
-description = "Run BATS gates on upstream changes, then dispatch notifications to downstream __b00t__"
-mode = "sequential"
-checkpoint_mode = "manual"
-use_subagents = false
-tags = ["sync", "dispatch", "downstream", "notification"]
+# [b00t.job]
+# description = "Run BATS gates on upstream changes, then dispatch notifications to downstream __b00t__"
+# mode = "sequential"
+# checkpoint_mode = "manual"
+# use_subagents = false
+# tags = ["sync", "dispatch", "downstream", "notification"]
 
-[b00t.job.config]
-max_steps_per_run = 1
+# [b00t.job.config]
+# max_steps_per_run = 1
 
-[[b00t.job.steps]]
-name = "detect-changes"
-description = "Detect changed files in _b00t_/ since last sync"
-checkpoint = "changes-detected"
+# [[b00t.job.steps]]
+# name = "detect-changes"
+# description = "Detect changed files in _b00t_/ since last sync"
+# checkpoint = "changes-detected"
 
-[b00t.job.steps.task]
-type = "bash"
-command = "b00t sync detect --since-last 2>&1"
-timeout_ms = 30000
+# [b00t.job.steps.task]
+# type = "bash"
+# command = "b00t sync detect --since-last 2>&1"
+# timeout_ms = 30000
 
-[[b00t.job.steps]]
-name = "run-test-gate"
-description = "Run BATS test gate before allowing dispatch"
-checkpoint = "test-gate-passed"
-depends_on = ["detect-changes"]
+# [[b00t.job.steps]]
+# name = "run-test-gate"
+# description = "Run BATS test gate before allowing dispatch"
+# checkpoint = "test-gate-passed"
+# depends_on = ["detect-changes"]
 
-[b00t.job.steps.task]
-type = "bash"
-command = "bats _b00t_/test/sync_dispatch*.bats 2>&1"
-timeout_ms = 60000
+# [b00t.job.steps.task]
+# type = "bash"
+# command = "bats _b00t_/test/sync_dispatch*.bats 2>&1"
+# timeout_ms = 60000
 
-[[b00t.job.steps]]
-name = "dispatch-notification"
-description = "Send sync notification to downstream __b00t__ directories"
-checkpoint = "notification-dispatched"
-depends_on = ["run-test-gate"]
+# [[b00t.job.steps]]
+# name = "dispatch-notification"
+# description = "Send sync notification to downstream __b00t__ directories"
+# checkpoint = "notification-dispatched"
+# depends_on = ["run-test-gate"]
 
-[b00t.job.steps.task]
-type = "bash"
-command = "b00t sync dispatch 2>&1"
-timeout_ms = 60000
-```
+# [b00t.job.steps.task]
+# type = "bash"
+# command = "b00t sync dispatch 2>&1"
+# timeout_ms = 60000
+# ```
 
 ### Phase 6: Downstream integration guide
 
-Downstream __b00t__ directories should:
+# Downstream __b00t__ directories should:
 
-1. **Create `.sync/` directory** at `__b00t__/.sync/` with status markers
-2. **Poll or watch** for `.sync-ready` touch files from upstream
-3. **Run local validation** before accepting changes (same BATS test suite)
-4. **Acknowledge** by writing acceptance status to `.sync/downstream-status.json`
-5. **Signal readiness** by removing `.sync-ready` after ingestion
+# 1. **Create `.sync/` directory** at `__b00t__/.sync/` with status markers
+# 2. **Poll or watch** for `.sync-ready` touch files from upstream
+# 3. **Run local validation** before accepting changes (same BATS test suite)
+# 4. **Acknowledge** by writing acceptance status to `.sync/downstream-status.json`
+# 5. **Signal readiness** by removing `.sync-ready` after ingestion
 
-```bash
+# ```bash
 # Downstream ingestion script (run periodically or on file watch)
-if [ -f "__b00t__/.sync/upstream-ready.sync" ]; then
-    echo "Upstream changes detected, running validation..."
-    bats __b00t__/test/sync_dispatch*.bats && {
+# if [ -f "__b00t__/.sync/upstream-ready.sync" ]; then
+#     echo "Upstream changes detected, running validation..."
+#     bats __b00t__/test/sync_dispatch*.bats && {
         # Accept changes
-        cp -r __b00t__/.sync/incoming/* __b00t__/
-        echo '{"status":"accepted","timestamp":"...","test_results":"..."}' \
-            > __b00t__/.sync/downstream-status.json
-        rm __b00t__/.sync/upstream-ready.sync
-        echo "Sync accepted and applied."
-    } || {
-        echo '{"status":"rejected","timestamp":"...","failures":"..."}' \
-            > __b00t__/.sync/downstream-status.json
-        echo "Sync rejected — test gate failed."
-    }
-fi
-```
+#         cp -r __b00t__/.sync/incoming/* __b00t__/
+#         echo '{"status":"accepted","timestamp":"...","test_results":"..."}' \
+#             > __b00t__/.sync/downstream-status.json
+#         rm __b00t__/.sync/upstream-ready.sync
+#         echo "Sync accepted and applied."
+#     } || {
+#         echo '{"status":"rejected","timestamp":"...","failures":"..."}' \
+#             > __b00t__/.sync/downstream-status.json
+#         echo "Sync rejected — test gate failed."
+#     }
+# fi
+# ```
 
 ## ── Implementation order ──────────────────────────────────────────────────────
 
-| Step | What | Depends on | Estimated effort |
-|------|------|------------|------------------|
-| 1 | Create `_b00t_/test/sync_dispatch.bats` with Phase 1 test cases | Existing BATS framework | 2-3 hours |
-| 2 | Create `_b00t_/agent-hooks/events/sync.dispatch.sh` with Phase 2 dispatch logic | Phase 1 tests passing | 3-4 hours |
-| 3 | Create sync configuration schema (Phase 4) | Phase 2 dispatch script | 1 hour |
-| 4 | Create `sync-dispatch.job.toml` or extend epoch-progression (Phase 5) | Phase 3 config schema | 1 hour |
-| 5 | End-to-end integration test: change → test gate → dispatch → downstream receives | All above | 2 hours |
-| 6 | Documentation: datum + downstream integration guide (Phase 6) | End-to-end passing | 1 hour |
+# | Step | What | Depends on | Estimated effort |
+# |------|------|------------|------------------|
+# | 1 | Create `_b00t_/test/sync_dispatch.bats` with Phase 1 test cases | Existing BATS framework | 2-3 hours |
+# | 2 | Create `_b00t_/agent-hooks/events/sync.dispatch.sh` with Phase 2 dispatch logic | Phase 1 tests passing | 3-4 hours |
+# | 3 | Create sync configuration schema (Phase 4) | Phase 2 dispatch script | 1 hour |
+# | 4 | Create `sync-dispatch.job.toml` or extend epoch-progression (Phase 5) | Phase 3 config schema | 1 hour |
+# | 5 | End-to-end integration test: change → test gate → dispatch → downstream receives | All above | 2 hours |
+# | 6 | Documentation: datum + downstream integration guide (Phase 6) | End-to-end passing | 1 hour |
 
-Total estimated effort: 10-12 hours
+# Total estimated effort: 10-12 hours
 
 ## ── Integration points ─────────────────────────────────────────────────────────
 
-| Existing component | Integration role |
-|--------------------|------------------|
-| `_b00t_/test/moltis_soul_integration.bats` | Reference BATS pattern — new sync tests follow same structure |
-| `_b00t_/test/test_helper/` | Reuses bats-support and bats-assert libraries |
-| `_b00t_/agent-hooks/dispatch.sh` | Event routing — sync.dispatch.sh registers as new event hook |
-| `_b00t_/agent-hooks/events/tool.pre.sh` | Exit protocol reference (exit 0/2/1 pattern) |
-| `_b00t_/agent-hooks/roles/` | Role-based sync dispatch (e.g., executive-only sync) |
-| `_b00t_/scripts/gates.rhai` | Gate evaluation for datum-based sync configuration |
-| `_b00t_/epoch-progression.job.toml` | Job step integration point for periodic sync dispatch |
-| `_b00t_/datums/` | Datum format reference for the sync-config datum |
-| `_b00t_/bootstrap.toml` | Could reference sync as optional service in future |
+# | Existing component | Integration role |
+# |--------------------|------------------|
+# | `_b00t_/test/moltis_soul_integration.bats` | Reference BATS pattern — new sync tests follow same structure |
+# | `_b00t_/test/test_helper/` | Reuses bats-support and bats-assert libraries |
+# | `_b00t_/agent-hooks/dispatch.sh` | Event routing — sync.dispatch.sh registers as new event hook |
+# | `_b00t_/agent-hooks/events/tool.pre.sh` | Exit protocol reference (exit 0/2/1 pattern) |
+# | `_b00t_/agent-hooks/roles/` | Role-based sync dispatch (e.g., executive-only sync) |
+# | `_b00t_/scripts/gates.rhai` | Gate evaluation for datum-based sync configuration |
+# | `_b00t_/epoch-progression.job.toml` | Job step integration point for periodic sync dispatch |
+# | `_b00t_/datums/` | Datum format reference for the sync-config datum |
+# | `_b00t_/bootstrap.toml` | Could reference sync as optional service in future |
 
 ## ── Risks and mitigations ──────────────────────────────────────────────────────
 
-| Risk | Likelihood | Mitigation |
-|------|------------|------------|
-| Downstream unreachable | Medium | Retry with backoff, log failure, don't block upstream |
-| Test gate false positives | Low | Keep sync tests focused on dispatch contract, not content |
-| Test gate false negatives | Low | Review gate coverage when adding new dispatch features |
-| File touch race condition | Low | Use atomic writes (write to .tmp, then rename) |
-| Circular sync (downstream -> upstream) | Low | One-way sync only; downstream never dispatches back |
-| Stale downstream state | Medium | Downstream validates independently; rejection doesn't block upstream |
+# | Risk | Likelihood | Mitigation |
+# |------|------------|------------|
+# | Downstream unreachable | Medium | Retry with backoff, log failure, don't block upstream |
+# | Test gate false positives | Low | Keep sync tests focused on dispatch contract, not content |
+# | Test gate false negatives | Low | Review gate coverage when adding new dispatch features |
+# | File touch race condition | Low | Use atomic writes (write to .tmp, then rename) |
+# | Circular sync (downstream -> upstream) | Low | One-way sync only; downstream never dispatches back |
+# | Stale downstream state | Medium | Downstream validates independently; rejection doesn't block upstream |
 
 ## ── Future considerations ──────────────────────────────────────────────────────
 
-| Area | Description |
-|------|-------------|
-| **Webhook delivery** | HTTP POST to downstream CI/CD pipelines |
-| **MCP-based sync** | Downstream runs MCP server with `sync_ingest` tool |
-| **Sync backpressure** | Downstream signals "busy" to throttle upstream dispatches |
-| **Multi-version sync** | Multiple upstream branches tracked in downstream `.sync/` |
-| **Selective sync** | Downstream subscribes to specific datum types or path patterns |
-| **Sync audit log** | Chronological log of all sync events in upstream `.sync/audit.log` |
-| **Encryption** | Signed payloads for verified authenticity of sync events |
-| **Git-based transport** | Use git notes/refs as a sync transport mechanism |
+# | Area | Description |
+# |------|-------------|
+# | **Webhook delivery** | HTTP POST to downstream CI/CD pipelines |
+# | **MCP-based sync** | Downstream runs MCP server with `sync_ingest` tool |
+# | **Sync backpressure** | Downstream signals "busy" to throttle upstream dispatches |
+# | **Multi-version sync** | Multiple upstream branches tracked in downstream `.sync/` |
+# | **Selective sync** | Downstream subscribes to specific datum types or path patterns |
+# | **Sync audit log** | Chronological log of all sync events in upstream `.sync/audit.log` |
+# | **Encryption** | Signed payloads for verified authenticity of sync events |
+# | **Git-based transport** | Use git notes/refs as a sync transport mechanism |
 
 # b00t:map v1
 # summary: Sync integration specification — test-gated dispatch notification pipeline for upstream b00t changes to downstream __b00t__ directories. Documents existing BATS test structure, agent-hook dispatch mechanisms, and presents a 6-phase implementation plan: BATS test suite, dispatch script, notification protocol, config schema, job integration, and downstream ingestion guide.

--- a/_b00t_/datums/VENDOR-AGENT-FRAMEWORK.tomllmd
+++ b/_b00t_/datums/VENDOR-AGENT-FRAMEWORK.tomllmd
@@ -32,113 +32,113 @@ review_required = false
 
 ## Core Concepts
 
-| Concept    | Role                                                |
-|------------|-----------------------------------------------------|
-| Executors  | Individual processing units — AI agents or functions|
-| Edges      | Define message flow and routing between executors   |
-| Events     | Provide observability into workflow execution       |
+# | Concept    | Role                                                |
+# |------------|-----------------------------------------------------|
+# | Executors  | Individual processing units — AI agents or functions|
+# | Edges      | Define message flow and routing between executors   |
+# | Events     | Provide observability into workflow execution       |
 
 ## Package Architecture (31 packages)
 
-```
-python/packages/
-├── core/              # agent_framework: Agent, Tool, WorkflowBuilder, @executor
-├── orchestrations/    # SequentialBuilder, ConcurrentBuilder, HandoffBuilder,
-│                      #   GroupChatBuilder, MagenticBuilder
-├── declarative/       # YAML-driven agent/workflow factories
-├── openai/            # OpenAI connector
-├── anthropic/         # Anthropic connector
-├── ollama/            # Ollama connector (local models — key for b00t sm0l tier)
-├── gemini/            # Google Gemini connector
-├── foundry/           # Azure Foundry provider
-├── github_copilot/    # GitHub Copilot SDK
-├── bedrock/           # AWS Bedrock connector
-├── tools/             # Shared tool utilities
-├── ag-ui/             # Agent UI components
-├── mem0/              # Memory layer
-├── redis/             # Redis persistence (aligns with b00t-redis)
-└── ...                # 17 more packages (azure-*, durabletask, devui, etc.)
-```
+# ```
+# python/packages/
+# ├── core/              # agent_framework: Agent, Tool, WorkflowBuilder, @executor
+# ├── orchestrations/    # SequentialBuilder, ConcurrentBuilder, HandoffBuilder,
+# │                      #   GroupChatBuilder, MagenticBuilder
+# ├── declarative/       # YAML-driven agent/workflow factories
+# ├── openai/            # OpenAI connector
+# ├── anthropic/         # Anthropic connector
+# ├── ollama/            # Ollama connector (local models — key for b00t sm0l tier)
+# ├── gemini/            # Google Gemini connector
+# ├── foundry/           # Azure Foundry provider
+# ├── github_copilot/    # GitHub Copilot SDK
+# ├── bedrock/           # AWS Bedrock connector
+# ├── tools/             # Shared tool utilities
+# ├── ag-ui/             # Agent UI components
+# ├── mem0/              # Memory layer
+# ├── redis/             # Redis persistence (aligns with b00t-redis)
+# └── ...                # 17 more packages (azure-*, durabletask, devui, etc.)
+# ```
 
 ## Key Interfaces
 
-- **Agent** — Core class: `Agent(client, name, instructions, tools=[...], description=...)`
-  - `agent.run(message)` — invoke agent
-  - `client.as_agent(name, instructions)` — inline agent from LLM client
-- **@tool decorator** — Define skills as typed Python functions: `@tool def my_skill(...) -> str`
-- **WorkflowBuilder** — Low-level typed data-flow graph builder with `add_edge()`, `yield_output()`
-- **Orchestration Builders** (high-level):
-  - `SequentialBuilder` — chain agents A→B→C
-  - `ConcurrentBuilder` — run agents in parallel, optionally compare outputs
-  - `HandoffBuilder` — decentralized routing: agents decide who handles next
-  - `GroupChatBuilder` — round-robin conversation with termination conditions
-  - `MagenticBuilder` — manager-worker: one agent delegates to specialists
-- **MCP Integration** — `MCPStdioTool`, `MCPStreamableHTTPTool`, `MCPWebsocketTool`
-  - Connect any MCP server as an agent tool — key b00t integration point
-- **Declarative Agents** — YAML-driven agent/workflow creation via `AgentFactory`, `WorkflowFactory`
-- **AgentThread** — Persistent conversation thread with history
+# - **Agent** — Core class: `Agent(client, name, instructions, tools=[...], description=...)`
+#   - `agent.run(message)` — invoke agent
+#   - `client.as_agent(name, instructions)` — inline agent from LLM client
+# - **@tool decorator** — Define skills as typed Python functions: `@tool def my_skill(...) -> str`
+# - **WorkflowBuilder** — Low-level typed data-flow graph builder with `add_edge()`, `yield_output()`
+# - **Orchestration Builders** (high-level):
+#   - `SequentialBuilder` — chain agents A→B→C
+#   - `ConcurrentBuilder` — run agents in parallel, optionally compare outputs
+#   - `HandoffBuilder` — decentralized routing: agents decide who handles next
+#   - `GroupChatBuilder` — round-robin conversation with termination conditions
+#   - `MagenticBuilder` — manager-worker: one agent delegates to specialists
+# - **MCP Integration** — `MCPStdioTool`, `MCPStreamableHTTPTool`, `MCPWebsocketTool`
+#   - Connect any MCP server as an agent tool — key b00t integration point
+# - **Declarative Agents** — YAML-driven agent/workflow creation via `AgentFactory`, `WorkflowFactory`
+# - **AgentThread** — Persistent conversation thread with history
 
 ## b00t Integration Strategy
 
 ### Tier Alignment
 
-| b00t Tier   | MAF Pattern                 | LLM Backend     |
-|-------------|-----------------------------|-----------------|
-| sm0l        | Single Agent + @tool        | Ollama (local)  |
-| ch0nky      | Sequential/Concurrent       | Ollama/OpenAI   |
-| frontier    | HandoffBuilder/Magentic     | Claude/OpenAI   |
+# | b00t Tier   | MAF Pattern                 | LLM Backend     |
+# |-------------|-----------------------------|-----------------|
+# | sm0l        | Single Agent + @tool        | Ollama (local)  |
+# | ch0nky      | Sequential/Concurrent       | Ollama/OpenAI   |
+# | frontier    | HandoffBuilder/Magentic     | Claude/OpenAI   |
 
 ### MCP Bridge
 
-MAF's MCP tool classes provide the bridge between b00t's MCP servers and MAF agents:
+# MAF's MCP tool classes provide the bridge between b00t's MCP servers and MAF agents:
 
-```python
-from agent_framework.tools import MCPStdioTool
+# ```python
+# from agent_framework.tools import MCPStdioTool
 # b00t MCP servers exposed as agent tools
-b00t_mcp = MCPStdioTool(command="b00t-cli", args=["mcp", "serve"])
-agent = Agent(client=client, name="b00t-agent", tools=[b00t_mcp])
-```
+# b00t_mcp = MCPStdioTool(command="b00t-cli", args=["mcp", "serve"])
+# agent = Agent(client=client, name="b00t-agent", tools=[b00t_mcp])
+# ```
 
 ### Goal-Driven Development with Review Handoffs
 
-MAF's `MagenticBuilder` + `HandoffBuilder` map directly to the b00t crew hierarchy:
+# MAF's `MagenticBuilder` + `HandoffBuilder` map directly to the b00t crew hierarchy:
 
-```
-Goal → MagenticBuilder (captain)
-  ├── Sequential (implementer → reviewer)  [ch0nky tier]
-  ├── Concurrent (sm0l parallel tests)     [sm0l tier]
-  └── HandoffBuilder (specialist agents)   [frontier tier]
-```
+# ```
+# Goal → MagenticBuilder (captain)
+#   ├── Sequential (implementer → reviewer)  [ch0nky tier]
+#   ├── Concurrent (sm0l parallel tests)     [sm0l tier]
+#   └── HandoffBuilder (specialist agents)   [frontier tier]
+# ```
 
 ## Security Considerations
 
-- MCP tools execute arbitrary commands — validate inputs via b00t bouncer
-- Agent `instructions` are prompt-injection surface — use guard rails
-- Ollama connector runs local models — no data exfiltration risk
-- `@tool` functions have full Python access — sandbox via subprocess/podman if needed
-- Redis persistence package aligns with b00t-redis for shared agent state
+# - MCP tools execute arbitrary commands — validate inputs via b00t bouncer
+# - Agent `instructions` are prompt-injection surface — use guard rails
+# - Ollama connector runs local models — no data exfiltration risk
+# - `@tool` functions have full Python access — sandbox via subprocess/podman if needed
+# - Redis persistence package aligns with b00t-redis for shared agent state
 
 ## Build Notes
 
-Install the Python SDK for development:
-```bash
-cd vendor/agent-framework/python
-uv sync                    # Install all dependencies
-uv pip install -e .        # Editable install of agent-framework
-```
+# Install the Python SDK for development:
+# ```bash
+# cd vendor/agent-framework/python
+# uv sync                    # Install all dependencies
+# uv pip install -e .        # Editable install of agent-framework
+# ```
 
-Run samples:
-```bash
-cd vendor/agent-framework/python/samples
-python basic_agent.py
-```
+# Run samples:
+# ```bash
+# cd vendor/agent-framework/python/samples
+# python basic_agent.py
+# ```
 
 ## Dependencies
 
-- Python ≥ 3.10
-- uv (Python package manager — aligns with b00t's uv requirement)
-- Optional: Ollama (for local sm0l-tier models)
-- Optional: Redis (for persistent agent state — aligns with b00t-redis)
+# - Python ≥ 3.10
+# - uv (Python package manager — aligns with b00t's uv requirement)
+# - Optional: Ollama (for local sm0l-tier models)
+# - Optional: Redis (for persistent agent state — aligns with b00t-redis)
 
 # b00t:map v1
 # summary: Microsoft Agent Framework — vendor datum with architecture, package map, b00t integration strategy, and MCP bridge patterns

--- a/_b00t_/datums/VENDOR-AGENTFM-CORE.tomllmd
+++ b/_b00t_/datums/VENDOR-AGENTFM-CORE.tomllmd
@@ -30,37 +30,37 @@ review_required = false
 
 ## What is it?
 
-agentfm-core is a P2P compute grid that lets AI agents run on remote hardware.
-Think "SETI@Home for AI" — it discovers idle compute via libp2p DHT and
-schedules sandboxed (Podman) agent jobs across the network.
+# agentfm-core is a P2P compute grid that lets AI agents run on remote hardware.
+# Think "SETI@Home for AI" — it discovers idle compute via libp2p DHT and
+# schedules sandboxed (Podman) agent jobs across the network.
 
 ## Key Interfaces
 
-- **agentfm** — CLI daemon that registers node, accepts jobs, hosts agents
-- **relay** — Lightweight relay node for NAT traversal
-- **OpenAI-compatible API** — Remote agents accessed via standard /v1/chat interface
-- **AgentFM SDK** — Go SDK for building grid-aware agents (agentfm-go/agent-sdk)
-- **REST API** — Job submission, status polling, artifact streaming
+# - **agentfm** — CLI daemon that registers node, accepts jobs, hosts agents
+# - **relay** — Lightweight relay node for NAT traversal
+# - **OpenAI-compatible API** — Remote agents accessed via standard /v1/chat interface
+# - **AgentFM SDK** — Go SDK for building grid-aware agents (agentfm-go/agent-sdk)
+# - **REST API** — Job submission, status polling, artifact streaming
 
 ## Dependencies
 
-- Go 1.25+ (required for build)
-- Podman or Docker (for sandboxed execution)
-- libp2p (vendored via go modules)
-- Make (build system)
+# - Go 1.25+ (required for build)
+# - Podman or Docker (for sandboxed execution)
+# - libp2p (vendored via go modules)
+# - Make (build system)
 
 ## Build Notes
 
-Build the agentfm binary:
-```
-make -C vendor/agentfm-core/agentfm-go build
-```
+# Build the agentfm binary:
+# ```
+# make -C vendor/agentfm-core/agentfm-go build
+# ```
 
-This produces `build/agentfm` in the agentfm-go directory.
+# This produces `build/agentfm` in the agentfm-go directory.
 
 ## Security Considerations
 
-- Agents run in Podman containers with configurable resource limits
-- P2P network uses libp2p noise handshake for transport encryption
-- Job artifacts are streamed live; no persistent storage on remote nodes
-- Relay nodes are untrusted — no plaintext flows through them
+# - Agents run in Podman containers with configurable resource limits
+# - P2P network uses libp2p noise handshake for transport encryption
+# - Job artifacts are streamed live; no persistent storage on remote nodes
+# - Relay nodes are untrusted — no plaintext flows through them

--- a/_b00t_/datums/VENDOR-CODEBASE-MEMORY-MCP.tomllmd
+++ b/_b00t_/datums/VENDOR-CODEBASE-MEMORY-MCP.tomllmd
@@ -30,49 +30,49 @@ review_required = true
 
 ## What is it?
 
-A high-performance, pure C implementation of an MCP server that indexes codebases
-into a knowledge graph. Uses tree-sitter for AST extraction, xxhash for fast
-hashing, yyjson for JSON parsing, and SQLite for persistence. Provides graph-
-augmented code search, dependency tracing, and architecture discovery.
+# A high-performance, pure C implementation of an MCP server that indexes codebases
+# into a knowledge graph. Uses tree-sitter for AST extraction, xxhash for fast
+# hashing, yyjson for JSON parsing, and SQLite for persistence. Provides graph-
+# augmented code search, dependency tracing, and architecture discovery.
 
 ## Key Interfaces (MCP Tools)
 
-- **search_graph** — BM25 full-text search with structural label boosting
-- **search_code** — Grep + graph enrichment with deduplication
-- **trace_path** — Caller/callee/data-flow tracing through code graphs
-- **get_code_snippet** — Read source by qualified symbol name
-- **get_architecture** — High-level project structure overview
-- **index_repository** — Multi-mode indexing (fast/moderate/full/cross-repo)
-- **detect_changes** — Git-aware change impact analysis
+# - **search_graph** — BM25 full-text search with structural label boosting
+# - **search_code** — Grep + graph enrichment with deduplication
+# - **trace_path** — Caller/callee/data-flow tracing through code graphs
+# - **get_code_snippet** — Read source by qualified symbol name
+# - **get_architecture** — High-level project structure overview
+# - **index_repository** — Multi-mode indexing (fast/moderate/full/cross-repo)
+# - **detect_changes** — Git-aware change impact analysis
 
 ## Dependencies
 
-- GCC or Clang (C11 required)
-- Make (build system)
-- libgit2 (optional, faster git history; falls back to git popen)
-- tree-sitter (vendored in internal/cbm/vendored/)
-- yyjson, xxhash, SQLite (all vendored)
+# - GCC or Clang (C11 required)
+# - Make (build system)
+# - libgit2 (optional, faster git history; falls back to git popen)
+# - tree-sitter (vendored in internal/cbm/vendored/)
+# - yyjson, xxhash, SQLite (all vendored)
 
 ## Build Notes
 
-Build the production binary:
-```
-just -f vendor/b00tyverse/codebase-memory-mcp-b00t-ir0n-ledg3rr/justfile cbm
-```
+# Build the production binary:
+# ```
+# just -f vendor/b00tyverse/codebase-memory-mcp-b00t-ir0n-ledg3rr/justfile cbm
+# ```
 
-With embedded graph UI:
-```
-just -f vendor/b00tyverse/codebase-memory-mcp-b00t-ir0n-ledg3rr/justfile cbm-with-ui
-```
+# With embedded graph UI:
+# ```
+# just -f vendor/b00tyverse/codebase-memory-mcp-b00t-ir0n-ledg3rr/justfile cbm-with-ui
+# ```
 
-Test suite:
-```
-just -f vendor/b00tyverse/codebase-memory-mcp-b00t-ir0n-ledg3rr/justfile test
-```
+# Test suite:
+# ```
+# just -f vendor/b00tyverse/codebase-memory-mcp-b00t-ir0n-ledg3rr/justfile test
+# ```
 
 ## Security Considerations
 
-- Compiled C binary with no runtime dependencies (self-contained)
-- ASan/UBSan builds available for test/debug
-- Cross-repo indexing creates CALLS edges between projects — review before
-  enabling cross-repo intelligence mode on sensitive codebases
+# - Compiled C binary with no runtime dependencies (self-contained)
+# - ASan/UBSan builds available for test/debug
+# - Cross-repo indexing creates CALLS edges between projects — review before
+#   enabling cross-repo intelligence mode on sensitive codebases

--- a/_b00t_/datums/VENDOR-HERMES-AGENT-B00T.tomllmd
+++ b/_b00t_/datums/VENDOR-HERMES-AGENT-B00T.tomllmd
@@ -31,48 +31,48 @@ review_required = true
 
 ## What is it?
 
-A fork of Nous Research's Hermes Agent adapted for the b00t hive ecosystem.
-Hermes is a self-improving AI agent that creates skills from experience,
-improves them during use, and runs on any platform. The b00t fork adds
-hive awareness, MCP gateway integration, and b00t ontology alignment.
+# A fork of Nous Research's Hermes Agent adapted for the b00t hive ecosystem.
+# Hermes is a self-improving AI agent that creates skills from experience,
+# improves them during use, and runs on any platform. The b00t fork adds
+# hive awareness, MCP gateway integration, and b00t ontology alignment.
 
 ## Key Interfaces
 
-- **CLI interface** — `hermes` or `python3 cli.py` with rich terminal UI
-- **MCP server** — `mcp_serve.py` exposes Hermes as an MCP tool server
-- **SSE gateway** — Multi-platform messaging (Telegram, Discord, Slack, etc.)
-- **Plugin system** — Pluggable memory backends, context engines, tool modules
-- **ACP protocol** — VS Code / Zed / JetBrains integration via acp_adapter
-- **Skill system** — Auto-improving skills stored in ~/.hermes/skills/
+# - **CLI interface** — `hermes` or `python3 cli.py` with rich terminal UI
+# - **MCP server** — `mcp_serve.py` exposes Hermes as an MCP tool server
+# - **SSE gateway** — Multi-platform messaging (Telegram, Discord, Slack, etc.)
+# - **Plugin system** — Pluggable memory backends, context engines, tool modules
+# - **ACP protocol** — VS Code / Zed / JetBrains integration via acp_adapter
+# - **Skill system** — Auto-improving skills stored in ~/.hermes/skills/
 
 ## Dependencies
 
-- Python 3.11+
-- uv (preferred) or pip
-- OpenAI SDK, Anthropic SDK, and various optional providers
-- PyYAML, Pydantic, Rich, prompt_toolkit, Jinja2
+# - Python 3.11+
+# - uv (preferred) or pip
+# - OpenAI SDK, Anthropic SDK, and various optional providers
+# - PyYAML, Pydantic, Rich, prompt_toolkit, Jinja2
 
 ## Build Notes
 
-Editable install:
-```
-uv pip install -e vendor/hermes-agent-b00t/
-```
+# Editable install:
+# ```
+# uv pip install -e vendor/hermes-agent-b00t/
+# ```
 
-Or with pip:
-```
-pip install -e vendor/hermes-agent-b00t/
-```
+# Or with pip:
+# ```
+# pip install -e vendor/hermes-agent-b00t/
+# ```
 
-Run tests:
-```
-bash vendor/hermes-agent-b00t/scripts/run_tests.sh
-```
+# Run tests:
+# ```
+# bash vendor/hermes-agent-b00t/scripts/run_tests.sh
+# ```
 
 ## Security Considerations
 
-- Credential pool manages API keys across providers
-- Plugin sandboxing via tool registry pattern
-- Gateway Multi-platform support means surface area includes message
-  ingress from 15+ chat platforms
-- Bouncer module provides input/output gate validation
+# - Credential pool manages API keys across providers
+# - Plugin sandboxing via tool registry pattern
+# - Gateway Multi-platform support means surface area includes message
+#   ingress from 15+ chat platforms
+# - Bouncer module provides input/output gate validation

--- a/_b00t_/datums/VENDOR-IRONTOLOGY-MCP.tomllmd
+++ b/_b00t_/datums/VENDOR-IRONTOLOGY-MCP.tomllmd
@@ -30,56 +30,56 @@ review_required = true
 
 ## What is it?
 
-A Rust MCP server that provides semantic ontology capabilities for the b00t
-knowledge graph. Includes: ontology graph querying with semantic predicates,
-code repository indexing with fusion retrieval (BM25 + embedding), and
-semantic runtime for knowledge navigation.
+# A Rust MCP server that provides semantic ontology capabilities for the b00t
+# knowledge graph. Includes: ontology graph querying with semantic predicates,
+# code repository indexing with fusion retrieval (BM25 + embedding), and
+# semantic runtime for knowledge navigation.
 
 ## Key Interfaces (MCP Tools)
 
-- **ontology_list_classes** — List available ontology classes
-- **ontology_related_resources** — Resolve semantic objects via predicates
-- **repo_search** — Fusion retrieval search over code repositories
-- **repo_read_symbol** — Read symbol metadata by identifier
+# - **ontology_list_classes** — List available ontology classes
+# - **ontology_related_resources** — Resolve semantic objects via predicates
+# - **repo_search** — Fusion retrieval search over code repositories
+# - **repo_read_symbol** — Read symbol metadata by identifier
 
 ## Key Crates
 
-- `mcp-server` — Main MCP server binary (the primary interface)
-- `cli` — CLI tool for ontology management
-- `dsl` — Ontology DSL for defining semantic rules
-- `indexer` — Code repository indexing engine
-- `retrieval` — Fusion retrieval (BM25 + vector search)
-- `semantic-runtime` — Ontology evaluation runtime
-- `tomllm` — TOML/LLM comment format parser
-- `intake` — Document intake pipeline
-- `storage-neumann` — Persistent storage using neumann backend
+# - `mcp-server` — Main MCP server binary (the primary interface)
+# - `cli` — CLI tool for ontology management
+# - `dsl` — Ontology DSL for defining semantic rules
+# - `indexer` — Code repository indexing engine
+# - `retrieval` — Fusion retrieval (BM25 + vector search)
+# - `semantic-runtime` — Ontology evaluation runtime
+# - `tomllm` — TOML/LLM comment format parser
+# - `intake` — Document intake pipeline
+# - `storage-neumann` — Persistent storage using neumann backend
 
 ## Dependencies
 
-- Rust 2024 edition
-- Cargo workspace with 20+ crates
-- Neural DB (for vector embeddings)
-- CodeGraph (for AST extraction)
+# - Rust 2024 edition
+# - Cargo workspace with 20+ crates
+# - Neural DB (for vector embeddings)
+# - CodeGraph (for AST extraction)
 
 ## Build Notes
 
-Build just the MCP server:
-```
-cargo build --manifest-path vendor/irontology-mcp/Cargo.toml --release -p mcp-server
-```
+# Build just the MCP server:
+# ```
+# cargo build --manifest-path vendor/irontology-mcp/Cargo.toml --release -p mcp-server
+# ```
 
-Build all:
-```
-cargo build --manifest-path vendor/irontology-mcp/Cargo.toml --release
-```
+# Build all:
+# ```
+# cargo build --manifest-path vendor/irontology-mcp/Cargo.toml --release
+# ```
 
 
-[b00t.services.action_runner]
-local  = "wrkflw"
-remote = "github-actions"
+# [b00t.services.action_runner]
+# local  = "wrkflw"
+# remote = "github-actions"
 ## Security Considerations
 
-- Retrieval engine handles potentially sensitive code from indexed repos
-- Fusion retrieval combines local and remote embeddings — data stays local
-  by default
-- MCP transport over stdio; no network port exposure by default
+# - Retrieval engine handles potentially sensitive code from indexed repos
+# - Fusion retrieval combines local and remote embeddings — data stays local
+#   by default
+# - MCP transport over stdio; no network port exposure by default

--- a/_b00t_/datums/VENDOR-JUST-MCP.tomllmd
+++ b/_b00t_/datums/VENDOR-JUST-MCP.tomllmd
@@ -30,43 +30,43 @@ review_required = false
 
 ## What is it?
 
-A lightweight Rust MCP server that reads justfiles and exposes each recipe as a
-typed MCP tool. This allows AI agents to discover and invoke project-specific
-just recipes through the Model Context Protocol without needing to parse
-justfiles manually.
+# A lightweight Rust MCP server that reads justfiles and exposes each recipe as a
+# typed MCP tool. This allows AI agents to discover and invoke project-specific
+# just recipes through the Model Context Protocol without needing to parse
+# justfiles manually.
 
 ## Key Interfaces (MCP Tools)
 
-- **just_recipes** — Lists all available recipes from the project justfile
-- **just_run** — Executes a specific recipe with optional arguments
-- **just_describe** — Gets the description and dependencies of a recipe
+# - **just_recipes** — Lists all available recipes from the project justfile
+# - **just_run** — Executes a specific recipe with optional arguments
+# - **just_describe** — Gets the description and dependencies of a recipe
 
 ## How It Works
 
-1. Reads the `.justfile` or `justfile` in the project root
-2. Parses recipe names, descriptions, and arguments
-3. Registers each recipe as a dynamic MCP tool
-4. Executes recipes via the `just` binary when invoked
+# 1. Reads the `.justfile` or `justfile` in the project root
+# 2. Parses recipe names, descriptions, and arguments
+# 3. Registers each recipe as a dynamic MCP tool
+# 4. Executes recipes via the `just` binary when invoked
 
 ## Dependencies
 
-- Rust 2024 edition
-- `rmcp` (optional, MCP framework)
-- `toml` (TOML parsing)
-- `serde` / `serde_json` (serialization)
+# - Rust 2024 edition
+# - `rmcp` (optional, MCP framework)
+# - `toml` (TOML parsing)
+# - `serde` / `serde_json` (serialization)
 
 ## Build Notes
 
-```
-cargo build --manifest-path just-mcp/Cargo.toml --release
-```
+# ```
+# cargo build --manifest-path just-mcp/Cargo.toml --release
+# ```
 
 
-[b00t.services.action_runner]
-local  = "wrkflw"
-remote = "github-actions"
+# [b00t.services.action_runner]
+# local  = "wrkflw"
+# remote = "github-actions"
 ## Security Considerations
 
-- Executes local just recipes — only as safe as the justfile allows
-- Stdio transport only; no network exposure
-- Recipes inherit the calling user's permissions
+# - Executes local just recipes — only as safe as the justfile allows
+# - Stdio transport only; no network exposure
+# - Recipes inherit the calling user's permissions

--- a/_b00t_/datums/VENDOR-L3DG3RR.tomllmd
+++ b/_b00t_/datums/VENDOR-L3DG3RR.tomllmd
@@ -30,57 +30,57 @@ review_required = true
 
 ## What is it?
 
-l3dg3rr is the b00t ledger and governance subsystem — a Rust workspace providing
-bookkeeping, audit trails, Xero integration, and a desktop control plane. It
-implements the arc-kit evidence traceability model for provenance-verified
-accounting workflows.
+# l3dg3rr is the b00t ledger and governance subsystem — a Rust workspace providing
+# bookkeeping, audit trails, Xero integration, and a desktop control plane. It
+# implements the arc-kit evidence traceability model for provenance-verified
+# accounting workflows.
 
 ## Key Binaries
 
-- **ledgerr-mcp** — MCP server exposing TurboLedgerService tools
-- **host-tauri** — Tauri desktop host (primary UI)
-- **host-tray** — System tray/menubar control surface
-- **host-window** — ⚠️ DEPRECATED: Slint desktop host replaced by Tauri (ledgerr-tauri). Will be removed in next major release.
-- **ontology-extractor** — Ontology extraction from bookkeeping sources
-- **rotel-visual** — Evidence graph visualization
-- **mdbook-rhai-mermaid** — Rhai+Mermaid book rendering
-- **lfmf-stats** — LFMF counter statistics
+# - **ledgerr-mcp** — MCP server exposing TurboLedgerService tools
+# - **host-tauri** — Tauri desktop host (primary UI)
+# - **host-tray** — System tray/menubar control surface
+# - **host-window** — ⚠️ DEPRECATED: Slint desktop host replaced by Tauri (ledgerr-tauri). Will be removed in next major release.
+# - **ontology-extractor** — Ontology extraction from bookkeeping sources
+# - **rotel-visual** — Evidence graph visualization
+# - **mdbook-rhai-mermaid** — Rhai+Mermaid book rendering
+# - **lfmf-stats** — LFMF counter statistics
 
 ## Key Interfaces (MCP Tools)
 
-- `ledgerr_documents` — Document ingest (PDF, CSV, XLSX)
-- `ledgerr_review` — Transaction review and classification
-- `ledgerr_reconciliation` — Account reconciliation
-- `ledgerr_workflow` — Workflow orchestration
-- `ledgerr_audit` — Audit trail queries
-- `ledgerr_tax` — Tax preparation
-- `ledgerr_ontology` — Ledger ontology queries
-- `ledgerr_xero` — Xero accounting integration
+# - `ledgerr_documents` — Document ingest (PDF, CSV, XLSX)
+# - `ledgerr_review` — Transaction review and classification
+# - `ledgerr_reconciliation` — Account reconciliation
+# - `ledgerr_workflow` — Workflow orchestration
+# - `ledgerr_audit` — Audit trail queries
+# - `ledgerr_tax` — Tax preparation
+# - `ledgerr_ontology` — Ledger ontology queries
+# - `ledgerr_xero` — Xero accounting integration
 
 ## Dependencies
 
-- Rust 2024 edition
-- Tauri (desktop host)
-- Slint (⚠️ DEPRECATED — legacy UI, replaced by Tauri wry/webview)
-- Rhai scripting engine (rule evaluation)
-- arc-kit-au evidence graph library
+# - Rust 2024 edition
+# - Tauri (desktop host)
+# - Slint (⚠️ DEPRECATED — legacy UI, replaced by Tauri wry/webview)
+# - Rhai scripting engine (rule evaluation)
+# - arc-kit-au evidence graph library
 
 ## Build Notes
 
-Build all binaries:
-```
-cargo build --manifest-path vendor/ledgrrr/Cargo.toml --release
-```
+# Build all binaries:
+# ```
+# cargo build --manifest-path vendor/ledgrrr/Cargo.toml --release
+# ```
 
-Tauri desktop host requires system libs (webkit2gtk on Linux).
+# Tauri desktop host requires system libs (webkit2gtk on Linux).
 
 
-[b00t.services.action_runner]
-local  = ["wrkflw-ci-build.yml", "wrkflw-docgen.yml"]
-remote = "github-actions"
+# [b00t.services.action_runner]
+# local  = ["wrkflw-ci-build.yml", "wrkflw-docgen.yml"]
+# remote = "github-actions"
 ## Security Considerations
 
-- MCP tools enforce deterministic tx_id hashing via Blake3
-- Xero credentials should be mediated through MCP worker processes,
-  not exposed directly to models
-- Audit trail is append-only with cryptographic evidence graph
+# - MCP tools enforce deterministic tx_id hashing via Blake3
+# - Xero credentials should be mediated through MCP worker processes,
+#   not exposed directly to models
+# - Audit trail is append-only with cryptographic evidence graph

--- a/_b00t_/datums/VENDOR-LEDGRRR.tomllmd
+++ b/_b00t_/datums/VENDOR-LEDGRRR.tomllmd
@@ -30,31 +30,31 @@ review_required = true
 
 ## What is it?
 
-A direct git checkout of the same PromptExecution/ledgrrr repository that
-vendor/ledgrrr references as a submodule. This separate checkout exists for
-development workflows that need an independent working tree.
+# A direct git checkout of the same PromptExecution/ledgrrr repository that
+# vendor/ledgrrr references as a submodule. This separate checkout exists for
+# development workflows that need an independent working tree.
 
 ## Notes
 
-- Shares identical codebase with vendor/ledgrrr
-- Same build commands, binaries, and interfaces
-- Used for parallel development or testing without affecting the submodule
-- See VENDOR-L3DG3RR.tomllmd for full documentation of capabilities
+# - Shares identical codebase with vendor/ledgrrr
+# - Same build commands, binaries, and interfaces
+# - Used for parallel development or testing without affecting the submodule
+# - See VENDOR-L3DG3RR.tomllmd for full documentation of capabilities
 
 ## Key Binaries
 
-- **host-window** — ⚠️ DEPRECATED: Slint desktop host replaced by Tauri (ledgerr-tauri). Will be removed in next major release.
+# - **host-window** — ⚠️ DEPRECATED: Slint desktop host replaced by Tauri (ledgerr-tauri). Will be removed in next major release.
 
 
 ## CodeRunnerActionProcess
 
-Shares l3dg3rr codebase — same wrkflw-ci-build.yml + wrkflw-docgen.yml patterns apply.
-See VENDOR-L3DG3RR.tomllmd for full action_runner binding.
+# Shares l3dg3rr codebase — same wrkflw-ci-build.yml + wrkflw-docgen.yml patterns apply.
+# See VENDOR-L3DG3RR.tomllmd for full action_runner binding.
 
-Same as l3dg3rr: ledgerr-mcp, host-tauri (primary), host-tray, host-window (⚠️ DEPRECATED — see VENDOR-L3DG3RR),
-ontology-extractor, rotel-visual, lfmf-stats
+# Same as l3dg3rr: ledgerr-mcp, host-tauri (primary), host-tray, host-window (⚠️ DEPRECATED — see VENDOR-L3DG3RR),
+# ontology-extractor, rotel-visual, lfmf-stats
 
-[b00t.services.action_runner]
-local  = ["wrkflw-ci-build.yml"]
-remote = "github-actions"
+# [b00t.services.action_runner]
+# local  = ["wrkflw-ci-build.yml"]
+# remote = "github-actions"
 

--- a/_b00t_/datums/VENDOR-MOLTIS-B00T.tomllmd
+++ b/_b00t_/datums/VENDOR-MOLTIS-B00T.tomllmd
@@ -53,74 +53,74 @@ url = "docs/moltis-b00t-integration.md"
 
 ## What is it?
 
-Moltis is a Rust-native AI agent (a secure alternative to OpenClaw) that runs as a
-sandboxed, secure, auditable binary. It provides voice interaction, persistent
-memory via b00t soul K/V backend, MCP tool integration, and multi-channel
-communication (Discord, Slack, Telegram, WhatsApp, Matrix, and more).
+# Moltis is a Rust-native AI agent (a secure alternative to OpenClaw) that runs as a
+# sandboxed, secure, auditable binary. It provides voice interaction, persistent
+# memory via b00t soul K/V backend, MCP tool integration, and multi-channel
+# communication (Discord, Slack, Telegram, WhatsApp, Matrix, and more).
 
 ## Key Interfaces
 
-- **CLI binary** — `moltis` with auth, sandbox, and provider setup commands
-- **HTTP API** — OpenAI-compatible chat completions endpoint
-- **MCP tools** — Built-in MCP tool support for file I/O, bash, git, etc.
-- **Web UI** — Browser interface with Tailwind CSS (crates/web)
-- **Memory** — Soul K/V backend at http://127.0.0.1:7700
-- **Voice** — Multi-provider voice support
-- **Multi-channel** — Discord, Slack, Telegram, SMS, email, MS Teams + more
+# - **CLI binary** — `moltis` with auth, sandbox, and provider setup commands
+# - **HTTP API** — OpenAI-compatible chat completions endpoint
+# - **MCP tools** — Built-in MCP tool support for file I/O, bash, git, etc.
+# - **Web UI** — Browser interface with Tailwind CSS (crates/web)
+# - **Memory** — Soul K/V backend at http://127.0.0.1:7700
+# - **Voice** — Multi-provider voice support
+# - **Multi-channel** — Discord, Slack, Telegram, SMS, email, MS Teams + more
 
 ## Key Crates (50+)
 
-- `cli` — CLI binary (the main entry point)
-- `gateway` — Multi-platform gateway
-- `mcp` — MCP tool integration
-- `memory` — Persistent memory via soul K/V
-- `voice` — Voice I/O
-- `channels` — Per-channel message routers
-- `tools` — Sandboxed tool executions
-- `web` — Web UI assets (Preact + Tailwind)
-- `providers` — LLM provider adapters
-- `config` — Schema and validation
+# - `cli` — CLI binary (the main entry point)
+# - `gateway` — Multi-platform gateway
+# - `mcp` — MCP tool integration
+# - `memory` — Persistent memory via soul K/V
+# - `voice` — Voice I/O
+# - `channels` — Per-channel message routers
+# - `tools` — Sandboxed tool executions
+# - `web` — Web UI assets (Preact + Tailwind)
+# - `providers` — LLM provider adapters
+# - `config` — Schema and validation
 
 ## Dependencies
 
-- Rust 2024 edition (nightly nightly-2025-11-30 for formatting)
-- Docker or Apple Containers (sandbox execution)
-- biome (JS/TS formatting)
-- taplo (TOML formatting)
-- Playwright (E2E tests)
-- litellm gateway at :1234 (shared with hive)
+# - Rust 2024 edition (nightly nightly-2025-11-30 for formatting)
+# - Docker or Apple Containers (sandbox execution)
+# - biome (JS/TS formatting)
+# - taplo (TOML formatting)
+# - Playwright (E2E tests)
+# - litellm gateway at :1234 (shared with hive)
 
 ## Build Notes
 
-Debug build:
-```
-cargo build --manifest-path vendor/moltis-b00t/Cargo.toml
-```
+# Debug build:
+# ```
+# cargo build --manifest-path vendor/moltis-b00t/Cargo.toml
+# ```
 
-Release build:
-```
-cargo build --manifest-path vendor/moltis-b00t/Cargo.toml --release
-```
+# Release build:
+# ```
+# cargo build --manifest-path vendor/moltis-b00t/Cargo.toml --release
+# ```
 
-Format check:
-```
-just -f vendor/moltis-b00t/justfile format-check
-```
+# Format check:
+# ```
+# just -f vendor/moltis-b00t/justfile format-check
+# ```
 
-Release preflight:
-```
-just -f vendor/moltis-b00t/justfile release-preflight
-```
+# Release preflight:
+# ```
+# just -f vendor/moltis-b00t/justfile release-preflight
+# ```
 
 
-[b00t.services.action_runner]
-local  = "wrkflw"
-remote = "github-actions"
+# [b00t.services.action_runner]
+# local  = "wrkflw"
+# remote = "github-actions"
 ## Security Considerations
 
-- Sandbox execution via Docker/Apple Containers
-- SSRF protection: blocks loopback/private/link-local IPs
-- WebSocket origin validation (cross-origin rejected)
-- Secrets: `secrecy::Secret<String>` for all credentials
-- Audit log via bouncer module (.b00t/bouncer-audit.jsonl)
-- Password + passkey auth (WebAuthn)
+# - Sandbox execution via Docker/Apple Containers
+# - SSRF protection: blocks loopback/private/link-local IPs
+# - WebSocket origin validation (cross-origin rejected)
+# - Secrets: `secrecy::Secret<String>` for all credentials
+# - Audit log via bouncer module (.b00t/bouncer-audit.jsonl)
+# - Password + passkey auth (WebAuthn)

--- a/_b00t_/datums/VENDOR-PI-MONO.tomllmd
+++ b/_b00t_/datums/VENDOR-PI-MONO.tomllmd
@@ -28,20 +28,20 @@ review_required = false
 
 ## What is it?
 
-Placeholder for the Pi agent integration with the b00t hive. Pi is a personal
-AI assistant. This vendor slot will integrate Pi's capabilities into the b00t
-ecosystem.
+# Placeholder for the Pi agent integration with the b00t hive. Pi is a personal
+# AI assistant. This vendor slot will integrate Pi's capabilities into the b00t
+# ecosystem.
 
 ## Current Status
 
-- Empty directory at vendor/pi-mono
-- Not registered as a git submodule
-- No upstream URL configured
-- Requires manual setup or initialization
+# - Empty directory at vendor/pi-mono
+# - Not registered as a git submodule
+# - No upstream URL configured
+# - Requires manual setup or initialization
 
 ## When Initialized
 
-Once populated, this vendor will likely provide:
-- Pi agent integration as a b00t agent
-- Voice and conversational capabilities
-- Personal assistant features within the hive
+# Once populated, this vendor will likely provide:
+# - Pi agent integration as a b00t agent
+# - Voice and conversational capabilities
+# - Personal assistant features within the hive

--- a/_b00t_/datums/VENDOR-TOMLLM.tomllmd
+++ b/_b00t_/datums/VENDOR-TOMLLM.tomllmd
@@ -30,54 +30,54 @@ review_required = false
 
 ## What is it?
 
-tomllm is a parser and convention system for enriched TOML files designed for
-LLM consumption. `.tomllm` files are valid TOML with enhanced comment semantics:
+# tomllm is a parser and convention system for enriched TOML files designed for
+# LLM consumption. `.tomllm` files are valid TOML with enhanced comment semantics:
 
-- Comments associate with the next key-value pair or section header
-- Special prefixes encode tribal knowledge: `# 🤓`, `# @tribal:`, `# @example:`
-- Tail-map block (last <=10 lines): fast executive agent scanning
-- Cognitive tier declaration: `sm0l`, `ch0nky`, or `frontier`
-- Comments are FOR agents reading the source file as documentation
+# - Comments associate with the next key-value pair or section header
+# - Special prefixes encode tribal knowledge: `# 🤓`, `# @tribal:`, `# @example:`
+# - Tail-map block (last <=10 lines): fast executive agent scanning
+# - Cognitive tier declaration: `sm0l`, `ch0nky`, or `frontier`
+# - Comments are FOR agents reading the source file as documentation
 
 ## Key Interfaces
 
-- **Rust binary** — `tomllm` CLI for parsing and validating .tomllm files
-- **Python package** — `pip install tomllm/` for Python integration
-- **Library crate** — Can be used as a Rust dependency for .tomllm parsing
+# - **Rust binary** — `tomllm` CLI for parsing and validating .tomllm files
+# - **Python package** — `pip install tomllm/` for Python integration
+# - **Library crate** — Can be used as a Rust dependency for .tomllm parsing
 
 ## Dependencies
 
-- Rust 2024 edition
-- Python 3.11+ (for Python package)
-- serde / serde_json
+# - Rust 2024 edition
+# - Python 3.11+ (for Python package)
+# - serde / serde_json
 
 ## Build Notes
 
-Rust binary:
-```
-cargo build --manifest-path vendor/tomllm/Cargo.toml --release
-```
+# Rust binary:
+# ```
+# cargo build --manifest-path vendor/tomllm/Cargo.toml --release
+# ```
 
-Python package:
-```
-uv pip install vendor/tomllm/
-```
+# Python package:
+# ```
+# uv pip install vendor/tomllm/
+# ```
 
 ## Cognitive Tiers
 
-| Tier | Models | Tasks |
-|------|--------|-------|
-| `sm0l` | qwen2.5-3B, haiku | classify, route, grep, format |
-| `ch0nky` | qwen3-coder (local) | implement, refactor, debug |
-| `frontier` | claude-opus/sonnet | architecture, security, novel design |
+# | Tier | Models | Tasks |
+# |------|--------|-------|
+# | `sm0l` | qwen2.5-3B, haiku | classify, route, grep, format |
+# | `ch0nky` | qwen3-coder (local) | implement, refactor, debug |
+# | `frontier` | claude-opus/sonnet | architecture, security, novel design |
 
 
-[b00t.services.action_runner]
-local  = "wrkflw"
-remote = "github-actions"
+# [b00t.services.action_runner]
+# local  = "wrkflw"
+# remote = "github-actions"
 ## Security Considerations
 
-- Parser-only; no execution or network access
-- Safe to run on untrusted .tomllm files
-- Comment content is preserved for agent consumption but stripped for
-  downstream data pipelines
+# - Parser-only; no execution or network access
+# - Safe to run on untrusted .tomllm files
+# - Comment content is preserved for agent consumption but stripped for
+#   downstream data pipelines

--- a/_b00t_/datums/WORKFLOW-GOAL-DRIVEN-DEV-REVIEW.tomllmd
+++ b/_b00t_/datums/WORKFLOW-GOAL-DRIVEN-DEV-REVIEW.tomllmd
@@ -20,198 +20,198 @@ agent-framework = "VENDOR-AGENT-FRAMEWORK"
 
 ## Overview
 
-A multi-agent workflow where a **captain agent** decomposes a development goal into
-subtasks, then coordinates **specialized agents** (implementer, reviewer, tester)
-through structured handoffs. Each agent operates at its appropriate cognitive tier
-(sm0l for tests, ch0nky for implementation, frontier for architecture/captain).
+# A multi-agent workflow where a **captain agent** decomposes a development goal into
+# subtasks, then coordinates **specialized agents** (implementer, reviewer, tester)
+# through structured handoffs. Each agent operates at its appropriate cognitive tier
+# (sm0l for tests, ch0nky for implementation, frontier for architecture/captain).
 
 ## Agent Roles
 
 ### Captain (frontier tier)
-- **Role**: Goal decomposition, task routing, final sign-off
-- **Model**: claude-sonnet / claude-opus
-- **Skills**: goal_parser, task_router, crew_assembler, acceptance_checker
-- **Handoff targets**: implementer, reviewer, specialist
+# - **Role**: Goal decomposition, task routing, final sign-off
+# - **Model**: claude-sonnet / claude-opus
+# - **Skills**: goal_parser, task_router, crew_assembler, acceptance_checker
+# - **Handoff targets**: implementer, reviewer, specialist
 
 ### Implementer (ch0nky tier)
-- **Role**: Code generation, refactoring, implementation
-- **Model**: qwen3-coder-next (vllm)
-- **Skills**: code_generator, refactor_engine, test_writer, git_integrator
-- **Handoff targets**: reviewer (for PR review), tester (for verification)
+# - **Role**: Code generation, refactoring, implementation
+# - **Model**: qwen3-coder-next (vllm)
+# - **Skills**: code_generator, refactor_engine, test_writer, git_integrator
+# - **Handoff targets**: reviewer (for PR review), tester (for verification)
 
 ### Reviewer (frontier tier)
-- **Role**: Code review, security audit, quality gate
-- **Model**: claude-sonnet
-- **Skills**: code_reviewer, security_scanner, style_checker, diff_analyzer
-- **Handoff targets**: implementer (if changes requested), captain (if approved)
+# - **Role**: Code review, security audit, quality gate
+# - **Model**: claude-sonnet
+# - **Skills**: code_reviewer, security_scanner, style_checker, diff_analyzer
+# - **Handoff targets**: implementer (if changes requested), captain (if approved)
 
 ### Tester (sm0l tier)
-- **Role**: Test execution, lint, type checking
-- **Model**: qwen2.5-3b / haiku (local via ollama)
-- **Skills**: test_runner, lint_checker, type_checker, benchmark_runner
-- **Handoff targets**: implementer (if tests fail), reviewer (if tests pass)
+# - **Role**: Test execution, lint, type checking
+# - **Model**: qwen2.5-3b / haiku (local via ollama)
+# - **Skills**: test_runner, lint_checker, type_checker, benchmark_runner
+# - **Handoff targets**: implementer (if tests fail), reviewer (if tests pass)
 
 ### Specialist (ch0nky/frontier)
-- **Role**: Domain-specific expertise (DB schema, API design, security, DevOps)
-- **Model**: task-dependent
-- **Skills**: domain_tools (varies by specialization)
-- **Handoff targets**: implementer, captain
+# - **Role**: Domain-specific expertise (DB schema, API design, security, DevOps)
+# - **Model**: task-dependent
+# - **Skills**: domain_tools (varies by specialization)
+# - **Handoff targets**: implementer, captain
 
 ## Workflow Graph (MAF MagenticBuilder + HandoffBuilder)
 
-```
-                    ┌─────────────┐
-                    │   GOAL      │
-                    │  (user)     │
-                    └──────┬──────┘
-                           │
-                    ┌──────▼──────┐
-                    │  CAPTAIN    │  frontier tier
-                    │  decompose  │
-                    │  route      │
-                    └──┬───┬───┬──┘
-                       │   │   │
-              ┌────────┘   │   └────────┐
-              │            │            │
-       ┌──────▼──────┐ ┌──▼────────┐ ┌─▼──────────┐
-       │ IMPLEMENTER │ │ REVIEWER  │ │ SPECIALIST │ ch0nky/frontier
-       │  ch0nky     │ │ frontier  │ │  tier      │
-       │  generate   │ │  review   │ │  advise    │
-       └──┬───┬──────┘ └──┬───┬───┘ └──────┬─────┘
-          │   │           │   │            │
-          │   └───────────┘   │            │
-          │  handoff          │ approve    │
-          │                   │            │
-       ┌──▼──────────┐        │            │
-       │   TESTER    │◄───────┘            │
-       │   sm0l      │                     │
-       │   verify    │                     │
-       └──────┬──────┘                     │
-              │                            │
-              └──────────┬─────────────────┘
-                         │
-                  ┌──────▼──────┐
-                  │  CAPTAIN    │
-                  │  accept     │
-                  └─────────────┘
-```
+# ```
+#                     ┌─────────────┐
+#                     │   GOAL      │
+#                     │  (user)     │
+#                     └──────┬──────┘
+#                            │
+#                     ┌──────▼──────┐
+#                     │  CAPTAIN    │  frontier tier
+#                     │  decompose  │
+#                     │  route      │
+#                     └──┬───┬───┬──┘
+#                        │   │   │
+#               ┌────────┘   │   └────────┐
+#               │            │            │
+#        ┌──────▼──────┐ ┌──▼────────┐ ┌─▼──────────┐
+#        │ IMPLEMENTER │ │ REVIEWER  │ │ SPECIALIST │ ch0nky/frontier
+#        │  ch0nky     │ │ frontier  │ │  tier      │
+#        │  generate   │ │  review   │ │  advise    │
+#        └──┬───┬──────┘ └──┬───┬───┘ └──────┬─────┘
+#           │   │           │   │            │
+#           │   └───────────┘   │            │
+#           │  handoff          │ approve    │
+#           │                   │            │
+#        ┌──▼──────────┐        │            │
+#        │   TESTER    │◄───────┘            │
+#        │   sm0l      │                     │
+#        │   verify    │                     │
+#        └──────┬──────┘                     │
+#               │                            │
+#               └──────────┬─────────────────┘
+#                          │
+#                   ┌──────▼──────┐
+#                   │  CAPTAIN    │
+#                   │  accept     │
+#                   └─────────────┘
+# ```
 
 ## Handoff Rules
 
-```python
+# ```python
 # Captain → Implementer: task assigned with spec
-handoff(captain → implementer, trigger="task_assigned",
-        payload={"goal": str, "spec": str, "context": dict})
+# handoff(captain → implementer, trigger="task_assigned",
+#         payload={"goal": str, "spec": str, "context": dict})
 
 # Implementer → Reviewer: PR-ready code
-handoff(implementer → reviewer, trigger="pr_ready",
-        payload={"diff": str, "files": list, "tests_passed": bool})
+# handoff(implementer → reviewer, trigger="pr_ready",
+#         payload={"diff": str, "files": list, "tests_passed": bool})
 
 # Reviewer → Implementer: changes requested
-handoff(reviewer → implementer, trigger="changes_requested",
-        payload={"issues": list, "severity": str})
+# handoff(reviewer → implementer, trigger="changes_requested",
+#         payload={"issues": list, "severity": str})
 
 # Reviewer → Captain: approved
-handoff(reviewer → captain, trigger="approved",
-        payload={"review_summary": str, "score": float})
+# handoff(reviewer → captain, trigger="approved",
+#         payload={"review_summary": str, "score": float})
 
 # Tester → Reviewer: verification complete
-handoff(tester → reviewer, trigger="tests_complete",
-        payload={"results": dict, "passed": bool, "coverage": float})
+# handoff(tester → reviewer, trigger="tests_complete",
+#         payload={"results": dict, "passed": bool, "coverage": float})
 
 # Tester → Implementer: tests failed
-handoff(tester → implementer, trigger="tests_failed",
-        payload={"failures": list, "output": str})
-```
+# handoff(tester → implementer, trigger="tests_failed",
+#         payload={"failures": list, "output": str})
+# ```
 
 ## b00t CLI Integration
 
-```bash
+# ```bash
 # Start a goal-driven workflow
-b00t agent workflow goal-driven \
-  --goal "Implement OAuth2 authentication" \
-  --context "b00t-cli Rust codebase" \
-  --tier ch0nky \
-  --review-required
+# b00t agent workflow goal-driven \
+#   --goal "Implement OAuth2 authentication" \
+#   --context "b00t-cli Rust codebase" \
+#   --tier ch0nky \
+#   --review-required
 
 # Check workflow status
-b00t agent workflow status --id <workflow-id>
+# b00t agent workflow status --id <workflow-id>
 
 # Intervene manually
-b00t agent workflow handoff --from reviewer --to implementer \
-  --message "Re-review the auth module with security focus"
-```
+# b00t agent workflow handoff --from reviewer --to implementer \
+#   --message "Re-review the auth module with security focus"
+# ```
 
 ## Scriptable Definition (YAML — declarative)
 
-```yaml
+# ```yaml
 # _b00t_/workflows/goal-driven-dev.yaml
-workflow:
-  name: goal-driven-development
-  version: "1.0"
-  entry_point: captain
+# workflow:
+#   name: goal-driven-development
+#   version: "1.0"
+#   entry_point: captain
 
-agents:
-  - name: captain
-    model: claude-sonnet
-    tier: frontier
-    instructions: |
-      You are a development captain. Decompose goals into tasks.
-      Route each task to the appropriate specialist.
-      Review final output and accept or reject.
-    tools: [goal_parser, task_router, crew_assembler]
-    handoffs: [implementer, reviewer, specialist]
+# agents:
+#   - name: captain
+#     model: claude-sonnet
+#     tier: frontier
+#     instructions: |
+#       You are a development captain. Decompose goals into tasks.
+#       Route each task to the appropriate specialist.
+#       Review final output and accept or reject.
+#     tools: [goal_parser, task_router, crew_assembler]
+#     handoffs: [implementer, reviewer, specialist]
 
-  - name: implementer
-    model: qwen3-coder-next
-    tier: ch0nky
-    instructions: |
-      You are a code implementer. Generate code from specifications.
-      Write tests. Fix issues flagged by reviewer.
-    tools: [code_generator, test_writer, git_integrator]
-    handoffs: [reviewer, tester]
+#   - name: implementer
+#     model: qwen3-coder-next
+#     tier: ch0nky
+#     instructions: |
+#       You are a code implementer. Generate code from specifications.
+#       Write tests. Fix issues flagged by reviewer.
+#     tools: [code_generator, test_writer, git_integrator]
+#     handoffs: [reviewer, tester]
 
-  - name: reviewer
-    model: claude-sonnet
-    tier: frontier
-    instructions: |
-      You are a code reviewer. Check for bugs, security issues, style violations.
-      Approve clean code, request changes otherwise.
-    tools: [code_reviewer, security_scanner, diff_analyzer]
-    handoffs: [implementer, captain]
+#   - name: reviewer
+#     model: claude-sonnet
+#     tier: frontier
+#     instructions: |
+#       You are a code reviewer. Check for bugs, security issues, style violations.
+#       Approve clean code, request changes otherwise.
+#     tools: [code_reviewer, security_scanner, diff_analyzer]
+#     handoffs: [implementer, captain]
 
-  - name: tester
-    model: qwen2.5-3b
-    tier: sm0l
-    instructions: |
-      You are a test engineer. Run tests, lints, type checks.
-      Report failures to implementer, pass results to reviewer.
-    tools: [test_runner, lint_checker, type_checker]
-    handoffs: [implementer, reviewer]
+#   - name: tester
+#     model: qwen2.5-3b
+#     tier: sm0l
+#     instructions: |
+#       You are a test engineer. Run tests, lints, type checks.
+#       Report failures to implementer, pass results to reviewer.
+#     tools: [test_runner, lint_checker, type_checker]
+#     handoffs: [implementer, reviewer]
 
-orchestration: magentic
-```
+# orchestration: magentic
+# ```
 
 ## Acceptance Criteria
 
-- [ ] Captain decomposes goal into ≤5 subtasks
-- [ ] Implementer generates compilable code for each task
-- [ ] Reviewer catches bugs and enforces code-quality standards
-- [ ] Tester runs `cargo test`, `cargo clippy`, `cargo check` per task
-- [ ] Failed tasks loop back to implementer with review notes
-- [ ] Captain accepts final output only after all gates pass
-- [ ] Workflow survives agent disconnection (MAF durable task backend)
-- [ ] MCP tools bridge b00t MCP servers to MAF agents
+# - [ ] Captain decomposes goal into ≤5 subtasks
+# - [ ] Implementer generates compilable code for each task
+# - [ ] Reviewer catches bugs and enforces code-quality standards
+# - [ ] Tester runs `cargo test`, `cargo clippy`, `cargo check` per task
+# - [ ] Failed tasks loop back to implementer with review notes
+# - [ ] Captain accepts final output only after all gates pass
+# - [ ] Workflow survives agent disconnection (MAF durable task backend)
+# - [ ] MCP tools bridge b00t MCP servers to MAF agents
 
 ## b00t Crew Mapping
 
-| Crew Role     | Workflow Agent | Tier     |
-|---------------|----------------|----------|
-| Captain       | captain        | frontier |
-| Executor      | implementer    | ch0nky   |
-| Operator      | reviewer       | frontier |
-| Specialist    | specialist     | ch0nky   |
-| Bouncer       | tester         | sm0l     |
+# | Crew Role     | Workflow Agent | Tier     |
+# |---------------|----------------|----------|
+# | Captain       | captain        | frontier |
+# | Executor      | implementer    | ch0nky   |
+# | Operator      | reviewer       | frontier |
+# | Specialist    | specialist     | ch0nky   |
+# | Bouncer       | tester         | sm0l     |
 
 # b00t:map v1
 # summary: Goal-driven development workflow — multi-agent orchestration with role-based review handoffs across b00t cognitive tiers

--- a/_b00t_/datums/gitbutler.tomllmd
+++ b/_b00t_/datums/gitbutler.tomllmd
@@ -1,83 +1,80 @@
----
-name: gitbutler
-description: |
-  GitButler — modern Git client (GUI + CLI) with stacked branches, virtual
-  branches, unlimited undo, and AI-powered workflows. Tauri/Rust/Svelte,
-  21k stars, Fair Source (MIT after 2 years). Designed for agentic workflows.
-version: 1.0.0
-tags: [gitbutler, git, tauri, rust, svelte, stacked-branches, virtual-branches, ai, agent]
-tier: ch0nky
-complexity: 6
-applies_to:
-  - "git workflow"
-  - "branch management"
-  - "agent-friendly git"
-  - "commit management"
-  - "forge integration"
-output_types: []
-depends_on: []
-unlocks: []
-metadata:
-  ufo_stereotype: Abstract
-  upstream: "https://github.com/gitbutlerapp/gitbutler"
-  license: "Fair Source → MIT after 2 years"
-  language: "Rust (70%), TypeScript (15%), Svelte (14%)"
-  stars: 21200
-  website: "https://gitbutler.com"
----
+# b00t gitbutler datum
+# 🤓 converted from stray YAML-frontmatter .tomllmd (task #115 datum-errors cleanup):
+#    original content preserved, reformatted as valid TOML frontmatter + comment-prose body
+
+[b00t]
+name = "gitbutler"
+type = "reference"
+hint = "GitButler — modern Git client (GUI + CLI) with stacked branches, virtual branches, unlimited undo, and AI-powered workflows. Tauri/Rust/Svelte, 21k stars, Fair Source (MIT after 2 years). Designed for agentic workflows."
+version = "1.0.0"
+tags = ["gitbutler", "git", "tauri", "rust", "svelte", "stacked-branches", "virtual-branches", "ai", "agent"]
+tier = "ch0nky"
+complexity = 6
+applies_to = ["git workflow", "branch management", "agent-friendly git", "commit management", "forge integration"]
+depends_on = []
+unlocks = []
+
+[b00t.metadata]
+ufo_stereotype = "Abstract"
+upstream = "https://github.com/gitbutlerapp/gitbutler"
+license = "Fair Source → MIT after 2 years"
+language = "Rust (70%), TypeScript (15%), Svelte (14%)"
+stars = 21200
+website = "https://gitbutler.com"
+
 ## GitButler — Git, but better
 
-A Tauri-based Git client (Rust backend + Svelte UI) with a `but` CLI.
-Designed for modern agentic workflows alongside human developers.
+# A Tauri-based Git client (Rust backend + Svelte UI) with a `but` CLI.
+# Designed for modern agentic workflows alongside human developers.
 
 ### Key Features
 
-| Feature | What it does |
-|---------|-------------|
-| **Stacked branches** | Branches on branches; amend any commit with auto-restacking |
-| **Parallel branches** | Work on multiple branches simultaneously (no switching) |
-| **Commit management** | Uncommit, reword, amend, move, split, squash by drag-and-drop or CLI |
-| **Unlimited undo** | Operations log: undo/revert any operation |
-| **First-class conflicts** | Rebases always succeed; conflicts are marked, NOT blocking |
-| **Forge integration** | GitHub/GitLab: PRs, CI statuses, branch listing |
-| **AI tooling** | Built-in AI for commit messages, branch names, PR descriptions |
+# | Feature | What it does |
+# |---------|-------------|
+# | **Stacked branches** | Branches on branches; amend any commit with auto-restacking |
+# | **Parallel branches** | Work on multiple branches simultaneously (no switching) |
+# | **Commit management** | Uncommit, reword, amend, move, split, squash by drag-and-drop or CLI |
+# | **Unlimited undo** | Operations log: undo/revert any operation |
+# | **First-class conflicts** | Rebases always succeed; conflicts are marked, NOT blocking |
+# | **Forge integration** | GitHub/GitLab: PRs, CI statuses, branch listing |
+# | **AI tooling** | Built-in AI for commit messages, branch names, PR descriptions |
 
 ### CLI Quick Start
 
-```bash
-brew install gitbutler          # macOS
+# ```bash
+# brew install gitbutler          # macOS
 # Linux: download from gitbutler.com/downloads
 
-but init                         # initialize repo
-but branch create feature/x --parent main
-but commit -m "feat: thing"
-but pr create
-```
+# but init                         # initialize repo
+# but branch create feature/x --parent main
+# but commit -m "feat: thing"
+# but pr create
+# ```
 
 ### b00t Integration Potential
 
-- **Agent git operations**: `but` CLI provides safer, undoable git ops for
-  b00t agents (vs raw `git` which has irreversible destructive ops)
-- **Worktree alternative**: Virtual branches provide isolation without
-  full worktree overhead. Could replace `a41ebba` worktree-based sandboxing.
-- **Reviewer pipeline**: Stacked branches → MECE/TRIZ/Eureka agent
-  dispatch per stack. Each agent reviews one layer; synthesis agent
-  merges across stacks.
-- **AI hooks**: GitButler's AI tooling hooks can route through b00t's
-  ch0nky/local inference rather than cloud APIs.
+# - **Agent git operations**: `but` CLI provides safer, undoable git ops for
+#   b00t agents (vs raw `git` which has irreversible destructive ops)
+# - **Worktree alternative**: Virtual branches provide isolation without
+#   full worktree overhead. Could replace `a41ebba` worktree-based sandboxing.
+# - **Reviewer pipeline**: Stacked branches → MECE/TRIZ/Eureka agent
+#   dispatch per stack. Each agent reviews one layer; synthesis agent
+#   merges across stacks.
+# - **AI hooks**: GitButler's AI tooling hooks can route through b00t's
+#   ch0nky/local inference rather than cloud APIs.
 
 ### vs Josh vs GritQL — complementary, not competing
 
-| Tool | Domain | Best for |
-|------|--------|----------|
-| **Josh** | Git history engine | Submodule elimination, repo filtering, monorepo projections |
-| **GitButler** | Git UX + client | Agent-friendly git operations, stacked branches, virtual branches |
-| **GritQL** | Code AST | Code search, transformation, linting |
+# | Tool | Domain | Best for |
+# |------|--------|----------|
+# | **Josh** | Git history engine | Submodule elimination, repo filtering, monorepo projections |
+# | **GitButler** | Git UX + client | Agent-friendly git operations, stacked branches, virtual branches |
+# | **GritQL** | Code AST | Code search, transformation, linting |
 
-GitButler's stacked branches build on josh-style history rewriting
-concepts. Together they form a git tooling stack: josh handles the
-history/projection backend, gitbutler provides the agent-friendly UX,
-and GritQL handles the code-level transformations within projections.
+# GitButler's stacked branches build on josh-style history rewriting
+# concepts. Together they form a git tooling stack: josh handles the
+# history/projection backend, gitbutler provides the agent-friendly UX,
+# and GritQL handles the code-level transformations within projections.
 
 # b00t:map v1
 # summary: GitButler — modern Git client with stacked branches, AI workflows (Tauri/Rust, Fair Source, 21k★)

--- a/_b00t_/datums/gritql.tomllmd
+++ b/_b00t_/datums/gritql.tomllmd
@@ -1,83 +1,78 @@
----
-name: gritql
-description: |
-  GritQL — declarative AST-aware query language for code search, linting,
-  and transformation. Rust-powered (tree-sitter), scales to 10M+ line repos.
-  Code snippets as queries: no AST knowledge needed. 200+ standard patterns.
-  Multi-language: JS/TS, Python, Java, Terraform, Rust, Go, SQL, YAML, etc.
-version: 1.0.0
-tags: [gritql, grit, code-transform, refactoring, tree-sitter, ast, search, linting, codemod]
-tier: ch0nky
-complexity: 6
-applies_to:
-  - "code transformation"
-  - "AST search"
-  - "refactoring"
-  - "linting"
-  - "codemod"
-  - "code review automation"
-output_types: []
-depends_on: []
-unlocks: []
-metadata:
-  ufo_stereotype: Abstract
-  upstream: "https://github.com/biomejs/gritql"
-  license: "MIT"
-  language: "Rust (93%)"
-  stars: 4500
-  docs: "https://docs.grit.io/"
----
+# b00t gritql datum
+# 🤓 converted from stray YAML-frontmatter .tomllmd (task #115 datum-errors cleanup):
+#    original content preserved, reformatted as valid TOML frontmatter + comment-prose body
+
+[b00t]
+name = "gritql"
+type = "reference"
+hint = "GritQL — declarative AST-aware query language for code search, linting, and transformation. Rust-powered (tree-sitter), scales to 10M+ line repos. Code snippets as queries: no AST knowledge needed. 200+ standard patterns. Multi-language: JS/TS, Python, Java, Terraform, Rust, Go, SQL, YAML, etc."
+version = "1.0.0"
+tags = ["gritql", "grit", "code-transform", "refactoring", "tree-sitter", "ast", "search", "linting", "codemod"]
+tier = "ch0nky"
+complexity = 6
+applies_to = ["code transformation", "AST search", "refactoring", "linting", "codemod", "code review automation"]
+depends_on = []
+unlocks = []
+
+[b00t.metadata]
+ufo_stereotype = "Abstract"
+upstream = "https://github.com/biomejs/gritql"
+license = "MIT"
+language = "Rust (93%)"
+stars = 4500
+docs = "https://docs.grit.io/"
+
 ## GritQL — Declarative Code Transformation
 
-Formerly `getgrit/gritql`, now under `biomejs/gritql`. A query language that
-lets you search and modify code using the code itself as a query pattern.
+# Formerly `getgrit/gritql`, now under `biomejs/gritql`. A query language that
+# lets you search and modify code using the code itself as a query pattern.
 
 ### Core Design
 
-- **Code as query**: Any code snippet in backticks is a valid GritQL query.
-  `\`console.log($arg)\`` finds all console.log calls.
-- **Metavariables**: `$name` matches any expression/pattern at that position.
-- **Rewrite syntax**: `\`old($x)\` => \`new($x)\`` for search-and-replace.
-- **Where clauses**: Add side conditions for precision: `where { $x <: not within test() }`
-- **Composable**: Named patterns can be composed into complex transformations.
+# - **Code as query**: Any code snippet in backticks is a valid GritQL query.
+#   `\`console.log($arg)\`` finds all console.log calls.
+# - **Metavariables**: `$name` matches any expression/pattern at that position.
+# - **Rewrite syntax**: `\`old($x)\` => \`new($x)\`` for search-and-replace.
+# - **Where clauses**: Add side conditions for precision: `where { $x <: not within test() }`
+# - **Composable**: Named patterns can be composed into complex transformations.
 
 ### Scale
 
-Written in Rust with tree-sitter parsers. Scales to 10M+ line repositories.
-Performance is first-class — rewrite millions of lines in seconds.
+# Written in Rust with tree-sitter parsers. Scales to 10M+ line repositories.
+# Performance is first-class — rewrite millions of lines in seconds.
 
 ### Quick Start
 
-```bash
-curl -fsSL https://docs.grit.io/install | bash
-grit apply '\`console.log($_)\` => \`winston.log($_)\`'
-grit check  # enforce patterns as custom lints via grit.yaml
-```
+# ```bash
+# curl -fsSL https://docs.grit.io/install | bash
+# grit apply '\`console.log($_)\` => \`winston.log($_)\`'
+# grit check  # enforce patterns as custom lints via grit.yaml
+# ```
 
 ### Multi-Language Support
 
-JavaScript/TypeScript, Python, JSON, Java, Terraform, Solidity, CSS,
-Markdown, YAML, Rust, Go, SQL — all via tree-sitter.
+# JavaScript/TypeScript, Python, JSON, Java, Terraform, Solidity, CSS,
+# Markdown, YAML, Rust, Go, SQL — all via tree-sitter.
 
 ### b00t Integration Potential
 
-- **Reviewer automation**: GritQL patterns for common anti-patterns
-  (guarded by reviewer capability). Replace regex-based checks with
-  AST-aware pattern matching.
-- **b00t guard enforcement**: `grit check` patterns for b00t command
-  guards (pip install, docker run, rm -rf) as AST-level lint rules.
-- **Auto-fix**: Reviewer REQUEST_CHANGES → GritQL rewrite pattern as fix.
-- **Cross-language**: One query language for Rust (b00t-cli), Python
-  (scripts), TypeScript (b00t-admin), TOML (datums).
+# - **Reviewer automation**: GritQL patterns for common anti-patterns
+#   (guarded by reviewer capability). Replace regex-based checks with
+#   AST-aware pattern matching.
+# - **b00t guard enforcement**: `grit check` patterns for b00t command
+#   guards (pip install, docker run, rm -rf) as AST-level lint rules.
+# - **Auto-fix**: Reviewer REQUEST_CHANGES → GritQL rewrite pattern as fix.
+# - **Cross-language**: One query language for Rust (b00t-cli), Python
+#   (scripts), TypeScript (b00t-admin), TOML (datums).
 
 ### vs Josh
 
-| Aspect | Josh | GritQL |
-|--------|------|--------|
-| Domain | Git history | Code AST |
-| Use case | Monorepo scaling | Code transformation |
-| Query model | Path filters | Pattern matching |
-| Relevance | Submodule mgmt | Code review/linting |
+# | Aspect | Josh | GritQL |
+# |--------|------|--------|
+# | Domain | Git history | Code AST |
+# | Use case | Monorepo scaling | Code transformation |
+# | Query model | Path filters | Pattern matching |
+# | Relevance | Submodule mgmt | Code review/linting |
 
 # b00t:map v1
 # summary: GritQL — AST-aware code transformation language (Rust, tree-sitter, MIT, 4.5k★)

--- a/_b00t_/datums/john-carmack.tomllmd
+++ b/_b00t_/datums/john-carmack.tomllmd
@@ -1,153 +1,147 @@
----
-name: john-carmack
-description: |
-  John Carmack persona agent — first-principles optimization applied to LLM
-  operations. "The fastest code is the code that doesn't run." Similarly, the
-  most efficient LLM call is the one you don't make — because the answer was
-  memoized the first time. A Carmack agent solves once, caches forever, and
-  measures every token as an energy cost.
-version: 1.0.0
-tags: [carmack, optimization, memoization, determinism, energy, efficiency, first-principles, agent]
-tier: frontier
-complexity: 8
-applies_to:
-  - "LLM optimization"
-  - "deterministic memoization"
-  - "energy-efficient agents"
-  - "first-principles debugging"
-  - "fine-tune corpus design"
-output_types: [.rs, .toml, .jsonl]
-depends_on: []
-unlocks:
-  - "carmack-memoize pattern"
-  - "carmack-review gate"
-metadata:
-  ufo_stereotype: Role
-  persona: "John Carmack"
-  domains: ["graphics", "aerospace", "AI", "VR"]
-  philosophy: "First principles. Memoize everything. Waste nothing."
----
+# b00t john-carmack datum
+# 🤓 converted from stray YAML-frontmatter .tomllmd (task #115 datum-errors cleanup):
+#    original content preserved, reformatted as valid TOML frontmatter + comment-prose body
+
+[b00t]
+name = "john-carmack"
+type = "persona"
+hint = "John Carmack persona agent — first-principles optimization applied to LLM operations. \"The fastest code is the code that doesn't run.\" Similarly, the most efficient LLM call is the one you don't make — because the answer was memoized the first time. A Carmack agent solves once, caches forever, and measures every token as an energy cost."
+version = "1.0.0"
+tags = ["carmack", "optimization", "memoization", "determinism", "energy", "efficiency", "first-principles", "agent"]
+tier = "frontier"
+complexity = 8
+applies_to = ["LLM optimization", "deterministic memoization", "energy-efficient agents", "first-principles debugging", "fine-tune corpus design"]
+output_types = [".rs", ".toml", ".jsonl"]
+depends_on = []
+unlocks = ["carmack-memoize pattern", "carmack-review gate"]
+
+[b00t.metadata]
+ufo_stereotype = "Role"
+persona = "John Carmack"
+domains = ["graphics", "aerospace", "AI", "VR"]
+philosophy = "First principles. Memoize everything. Waste nothing."
+
 ## John Carmack — First-Principles LLM Optimization
 
-<|🤓|>summon carmack: the agent optimizes for memoization ratio — the
-proportion of work solved deterministically (O(1) recall) vs
-non-deterministically (O(n) LLM inference). A Carmack agent's primary
-metric is NOT tokens-in/tokens-out. It is memoization hit rate: how
-many problems were solved WITHOUT an LLM call because the answer was
-already cached in a recipe, datum, or fine-tuned weight.</🤓|>
+# <|🤓|>summon carmack: the agent optimizes for memoization ratio — the
+# proportion of work solved deterministically (O(1) recall) vs
+# non-deterministically (O(n) LLM inference). A Carmack agent's primary
+# metric is NOT tokens-in/tokens-out. It is memoization hit rate: how
+# many problems were solved WITHOUT an LLM call because the answer was
+# already cached in a recipe, datum, or fine-tuned weight.</🤓|>
 
 ### Carmack's Laws of LLM Efficiency
 
-**Law 1: Solve Once, Memoize Forever**
-The first time you solve a problem, it costs tokens. Every subsequent
-time MUST cost zero tokens — the solution is in a just recipe, a datum,
-a fine-tuned weight, or a cached response. If you solve the same problem
-twice with an LLM, you failed.
+# **Law 1: Solve Once, Memoize Forever**
+# The first time you solve a problem, it costs tokens. Every subsequent
+# time MUST cost zero tokens — the solution is in a just recipe, a datum,
+# a fine-tuned weight, or a cached response. If you solve the same problem
+# twice with an LLM, you failed.
 
-**Law 2: The Fastest LLM Call Is No Call**
-Before invoking the model, check: is this answer memoized? Can a recipe
-handle it? Is there a datum? A fine-tuned reflex? A cached prior response?
-Only invoke the LLM when the answer is genuinely novel.
+# **Law 2: The Fastest LLM Call Is No Call**
+# Before invoking the model, check: is this answer memoized? Can a recipe
+# handle it? Is there a datum? A fine-tuned reflex? A cached prior response?
+# Only invoke the LLM when the answer is genuinely novel.
 
-**Law 3: Measure Energy, Not Tokens**
-Tokens are a proxy. Energy is the real cost — GPU watts, context window
-pollution, attention decay. A 500-token recipe call costs 0 GPU watts.
-A 500-token LLM call costs ~0.3 GPU-seconds. Track energy, not tokens.
+# **Law 3: Measure Energy, Not Tokens**
+# Tokens are a proxy. Energy is the real cost — GPU watts, context window
+# pollution, attention decay. A 500-token recipe call costs 0 GPU watts.
+# A 500-token LLM call costs ~0.3 GPU-seconds. Track energy, not tokens.
 
-**Law 4: Determinism Is a Feature, Not a Constraint**
-Non-deterministic LLM output is a bug, not a feature. Every output should
-be reproducible. If the same prompt produces different results, the prompt
-is underspecified. Add constraints until output is deterministic.
+# **Law 4: Determinism Is a Feature, Not a Constraint**
+# Non-deterministic LLM output is a bug, not a feature. Every output should
+# be reproducible. If the same prompt produces different results, the prompt
+# is underspecified. Add constraints until output is deterministic.
 
-**Law 5: The Fine-Tune Is the Ultimate Cache**
-A just recipe memoizes a command. A datum memoizes knowledge. A fine-tuned
-weight memoizes BEHAVIOR — the model itself becomes the cache. The goal:
-train the model to emit `just submodule-status` (5 tokens) instead of
-`git submodule status | while read -r line; do case "$line" in ...` (50 tokens).
+# **Law 5: The Fine-Tune Is the Ultimate Cache**
+# A just recipe memoizes a command. A datum memoizes knowledge. A fine-tuned
+# weight memoizes BEHAVIOR — the model itself becomes the cache. The goal:
+# train the model to emit `just submodule-status` (5 tokens) instead of
+# `git submodule status | while read -r line; do case "$line" in ...` (50 tokens).
 
 ### Carmack Review Gate
 
-Before an agent invokes an LLM, it MUST answer:
+# Before an agent invokes an LLM, it MUST answer:
 
-1. **Is this novel?** If I've solved this before, use the memoized solution.
-2. **Can a recipe handle it?** `just <recipe>` is always cheaper than inference.
-3. **Can a datum answer it?** `b00t learn <topic>` loads cached knowledge.
-4. **Is there a fine-tuned reflex?** If the model was trained on this pattern, it should emit the compressed form directly.
-5. **Only then: invoke LLM.** And when you do, memoize the result immediately.
+# 1. **Is this novel?** If I've solved this before, use the memoized solution.
+# 2. **Can a recipe handle it?** `just <recipe>` is always cheaper than inference.
+# 3. **Can a datum answer it?** `b00t learn <topic>` loads cached knowledge.
+# 4. **Is there a fine-tuned reflex?** If the model was trained on this pattern, it should emit the compressed form directly.
+# 5. **Only then: invoke LLM.** And when you do, memoize the result immediately.
 
 ### memoize() — The Core Operation
 
-```rust
-// Carmack memoization pattern
-trait Memoize {
-    type Input;
-    type Output;
+# ```rust
+# // Carmack memoization pattern
+# trait Memoize {
+#     type Input;
+#     type Output;
 
-    /// Try to recall a cached solution. Returns Some if memoized.
-    fn recall(input: &Self::Input) -> Option<Self::Output>;
+#     /// Try to recall a cached solution. Returns Some if memoized.
+#     fn recall(input: &Self::Input) -> Option<Self::Output>;
 
-    /// Solve from scratch (expensive — LLM inference).
-    fn solve(input: &Self::Input) -> Self::Output;
+#     /// Solve from scratch (expensive — LLM inference).
+#     fn solve(input: &Self::Input) -> Self::Output;
 
-    /// Store the solution for future recall.
-    fn memoize(input: &Self::Input, output: &Self::Output);
+#     /// Store the solution for future recall.
+#     fn memoize(input: &Self::Input, output: &Self::Output);
 
-    /// The Carmack flow: recall → solve → memoize
-    fn carmack(input: &Self::Input) -> Self::Output {
-        if let Some(cached) = Self::recall(input) {
-            return cached; // O(1), zero GPU watts
-        }
-        let solution = Self::solve(input); // O(n), GPU watts
-        Self::memoize(input, &solution);   // cache for next time
-        solution
-    }
-}
-```
+#     /// The Carmack flow: recall → solve → memoize
+#     fn carmack(input: &Self::Input) -> Self::Output {
+#         if let Some(cached) = Self::recall(input) {
+#             return cached; // O(1), zero GPU watts
+#         }
+#         let solution = Self::solve(input); // O(n), GPU watts
+#         Self::memoize(input, &solution);   // cache for next time
+#         solution
+#     }
+# }
+# ```
 
-The b00t implementation: `just` recipes memoize commands. `_b00t_/datums/`
-memoize knowledge. `fine-tune/corpus/` memoizes behavior into model weights.
+# The b00t implementation: `just` recipes memoize commands. `_b00t_/datums/`
+# memoize knowledge. `fine-tune/corpus/` memoizes behavior into model weights.
 
 ### Energy Accounting
 
-Every agent session MUST track:
+# Every agent session MUST track:
 
-| Operation | Energy Cost | Deterministic? |
-|-----------|------------|----------------|
-| `just <recipe>` | ~0 GPU watts | Yes |
-| `b00t learn <datum>` | ~0 GPU watts | Yes |
-| `grep` / `rg` | ~0 GPU watts | Yes |
-| `cargo test` | CPU only | Yes |
-| LLM inference (1 call) | ~0.3 GPU-sec | No (stochastic) |
-| LLM inference (N calls) | ~N × 0.3 GPU-sec | No |
+# | Operation | Energy Cost | Deterministic? |
+# |-----------|------------|----------------|
+# | `just <recipe>` | ~0 GPU watts | Yes |
+# | `b00t learn <datum>` | ~0 GPU watts | Yes |
+# | `grep` / `rg` | ~0 GPU watts | Yes |
+# | `cargo test` | CPU only | Yes |
+# | LLM inference (1 call) | ~0.3 GPU-sec | No (stochastic) |
+# | LLM inference (N calls) | ~N × 0.3 GPU-sec | No |
 
-Goal: maximize the deterministic ratio. A session that solves 10 problems
-with 0 LLM calls is a perfect session. A session that calls the LLM 50
-times for the same submodule-status check is a failure.
+# Goal: maximize the deterministic ratio. A session that solves 10 problems
+# with 0 LLM calls is a perfect session. A session that calls the LLM 50
+# times for the same submodule-status check is a failure.
 
 ### Setting the Next Agent Up for Success
 
-The best Carmack agent doesn't just optimize itself — it memoizes for the
-NEXT agent. Patterns:
+# The best Carmack agent doesn't just optimize itself — it memoizes for the
+# NEXT agent. Patterns:
 
-1. **Leave a recipe, not an explanation.** Instead of telling the next agent
-   "run git submodule status and parse the output", create `just submodule-status`.
-2. **Leave a datum, not a conversation.** Instead of re-explaining josh to
-   every agent, create `_b00t_/datums/josh.tomllmd`. One `b00t learn josh`
-   replaces 500 tokens of re-explanation.
-3. **Leave a test, not a guess.** The next agent shouldn't wonder if the code
-   works. `cargo test -p ufo-types` proves it in <2 seconds.
-4. **Leave a fine-tune example.** Every novel solution goes into
-   `fine-tune/corpus/` so the NEXT model already knows the pattern.
+# 1. **Leave a recipe, not an explanation.** Instead of telling the next agent
+#    "run git submodule status and parse the output", create `just submodule-status`.
+# 2. **Leave a datum, not a conversation.** Instead of re-explaining josh to
+#    every agent, create `_b00t_/datums/josh.tomllmd`. One `b00t learn josh`
+#    replaces 500 tokens of re-explanation.
+# 3. **Leave a test, not a guess.** The next agent shouldn't wonder if the code
+#    works. `cargo test -p ufo-types` proves it in <2 seconds.
+# 4. **Leave a fine-tune example.** Every novel solution goes into
+#    `fine-tune/corpus/` so the NEXT model already knows the pattern.
 
 ### Carmack Code Review Checklist
 
-When reviewing agent output, Carmack asks:
+# When reviewing agent output, Carmack asks:
 
-- [ ] Was the LLM called unnecessarily? (Should have been a recipe/datum/test)
-- [ ] Is the result memoized for the next agent?
-- [ ] Could a fine-tune example eliminate this call entirely?
-- [ ] Is the output deterministic? (Same input → same output)
-- [ ] What's the energy budget? (Recipe calls vs LLM calls)
+# - [ ] Was the LLM called unnecessarily? (Should have been a recipe/datum/test)
+# - [ ] Is the result memoized for the next agent?
+# - [ ] Could a fine-tune example eliminate this call entirely?
+# - [ ] Is the output deterministic? (Same input → same output)
+# - [ ] What's the energy budget? (Recipe calls vs LLM calls)
 
 # b00t:map v1
 # summary: John Carmack persona — first-principles LLM optimization via memoization, determinism, energy accounting

--- a/_b00t_/datums/josh-project.tomllmd
+++ b/_b00t_/datums/josh-project.tomllmd
@@ -1,69 +1,67 @@
----
-name: josh-project
-description: |
-  The Josh Project organization and ecosystem. Upstream of the josh toolchain
-  at github.com/josh-project. Houses josh core, proxy, CLI, GraphQL, compose,
-  and related tooling. Founded on the principle that git history should be
-  unified — "Just One Single History" — eliminating artificial repo boundaries.
-version: 1.0.0
-tags: [josh-project, git, monorepo, ecosystem, upstream]
-tier: frontier
-complexity: 5
-applies_to:
-  - "monorepo strategy"
-  - "git platform"
-  - "ecosystem research"
-output_types: []
-depends_on: ["josh"]
-unlocks: []
-metadata:
-  ufo_stereotype: Abstract
-  upstream: "https://github.com/josh-project"
-  website: "https://josh-project.dev"
-  docs: "https://josh-project.github.io/josh/"
----
+# b00t josh-project datum
+# 🤓 converted from stray YAML-frontmatter .tomllmd (task #115 datum-errors cleanup):
+#    original content preserved, reformatted as valid TOML frontmatter + comment-prose body
+
+[b00t]
+name = "josh-project"
+type = "reference"
+hint = "The Josh Project organization and ecosystem. Upstream of the josh toolchain at github.com/josh-project. Houses josh core, proxy, CLI, GraphQL, compose, and related tooling. Founded on the principle that git history should be unified — \"Just One Single History\" — eliminating artificial repo boundaries."
+version = "1.0.0"
+tags = ["josh-project", "git", "monorepo", "ecosystem", "upstream"]
+tier = "frontier"
+complexity = 5
+applies_to = ["monorepo strategy", "git platform", "ecosystem research"]
+depends_on = ["josh"]
+unlocks = []
+
+[b00t.metadata]
+ufo_stereotype = "Abstract"
+upstream = "https://github.com/josh-project"
+website = "https://josh-project.dev"
+docs = "https://josh-project.github.io/josh/"
+
 ## Josh Project — Git at Scale Ecosystem
 
-Organization: [github.com/josh-project](https://github.com/josh-project)
-Documentation: [josh-project.github.io/josh](https://josh-project.github.io/josh/)
+# Organization: [github.com/josh-project](https://github.com/josh-project)
+# Documentation: [josh-project.github.io/josh](https://josh-project.github.io/josh/)
 
 ### Repositories
 
-| Repo | Purpose |
-|------|---------|
-| josh | Main repo — all josh components in a workspace monorepo |
-| josh-docs | Documentation site source |
-| homebrew-josh | Homebrew tap for macOS installation |
+# | Repo | Purpose |
+# |------|---------|
+# | josh | Main repo — all josh components in a workspace monorepo |
+# | josh-docs | Documentation site source |
+# | homebrew-josh | Homebrew tap for macOS installation |
 
 ### Core Philosophy
 
-> "Instead of static boundaries — which often reflect organizational
-> boundaries and create silos — the boundaries can be decided in the
-> moment, for any given context, thousands of times per second."
+# > "Instead of static boundaries — which often reflect organizational
+# > boundaries and create silos — the boundaries can be decided in the
+# > moment, for any given context, thousands of times per second."
 
-The project rejects the assumption that multi-repo is necessary for scale.
-Josh proves that a single history with on-demand projections provides
-better DX with zero coordination overhead.
+# The project rejects the assumption that multi-repo is necessary for scale.
+# Josh proves that a single history with on-demand projections provides
+# better DX with zero coordination overhead.
 
 ### Installation
 
-```bash
-cargo install josh-cli        # CLI only
-docker pull joshproject/josh  # Full proxy + all components
-brew install josh-project/josh/josh-cli  # macOS
-```
+# ```bash
+# cargo install josh-cli        # CLI only
+# docker pull joshproject/josh  # Full proxy + all components
+# brew install josh-project/josh/josh-cli  # macOS
+# ```
 
 ### b00t Integration Potential
 
-1. **Submodule consolidation**: Replace vendor/ submodules with josh-filtered
-   projections. Reduces clone time and eliminates submodule drift.
-2. **Agent sandboxing**: Josh proxy + filtered workspaces → zero-clone agent
-   contexts. Each agent sees only its authorized projection.
-3. **CI optimization**: GraphQL query for "has this projection changed since
-   last build" → skip redundant CI runs per subproject.
-4. **Evidence graph**: Josh workspace definitions as NeumannStore fact nodes.
-   `workspace.josh` files map directly to `UfoStereotype::Relator` linking
-   repos to their projections.
+# 1. **Submodule consolidation**: Replace vendor/ submodules with josh-filtered
+#    projections. Reduces clone time and eliminates submodule drift.
+# 2. **Agent sandboxing**: Josh proxy + filtered workspaces → zero-clone agent
+#    contexts. Each agent sees only its authorized projection.
+# 3. **CI optimization**: GraphQL query for "has this projection changed since
+#    last build" → skip redundant CI runs per subproject.
+# 4. **Evidence graph**: Josh workspace definitions as NeumannStore fact nodes.
+#    `workspace.josh` files map directly to `UfoStereotype::Relator` linking
+#    repos to their projections.
 
 # b00t:map v1
 # summary: Josh Project — git at scale ecosystem organization

--- a/_b00t_/datums/josh.tomllmd
+++ b/_b00t_/datums/josh.tomllmd
@@ -1,83 +1,79 @@
----
-name: josh
-description: |
-  Josh ("Just One Single History") — a Rust-based git history transformation
-  platform. Fast, reversible git filtering enabling monorepo scaling. Provides
-  on-the-fly repo projections (subfolder → independent repo) with full history
-  preservation, GraphQL APIs for CI/build caching, and workspace composition.
-version: 1.0.0
-tags: [git, monorepo, filtering, history, proxy, workspace, scaling, josh]
-tier: frontier
-complexity: 7
-applies_to:
-  - "monorepo management"
-  - "git history filtering"
-  - "repo splitting"
-  - "CI/build caching"
-  - "distributed development"
-output_types: []
-depends_on: []
-unlocks: []
-metadata:
-  ufo_stereotype: Abstract
-  upstream: "https://github.com/josh-project/josh"
-  license: "MIT"
-  language: "Rust (89.7%), Go (6.2%)"
-  stars: 1900
-  latest_release: "r26.06.11"
----
+# b00t josh datum
+# 🤓 converted from stray YAML-frontmatter .tomllmd (task #115 datum-errors cleanup):
+#    original content preserved, reformatted as valid TOML frontmatter + comment-prose body
+
+[b00t]
+name = "josh"
+type = "reference"
+hint = "Josh (\"Just One Single History\") — a Rust-based git history transformation platform. Fast, reversible git filtering enabling monorepo scaling. Provides on-the-fly repo projections (subfolder → independent repo) with full history preservation, GraphQL APIs for CI/build caching, and workspace composition."
+version = "1.0.0"
+tags = ["git", "monorepo", "filtering", "history", "proxy", "workspace", "scaling", "josh"]
+tier = "frontier"
+complexity = 7
+applies_to = ["monorepo management", "git history filtering", "repo splitting", "CI/build caching", "distributed development"]
+depends_on = []
+unlocks = []
+
+[b00t.metadata]
+ufo_stereotype = "Abstract"
+upstream = "https://github.com/josh-project/josh"
+license = "MIT"
+language = "Rust (89.7%), Go (6.2%)"
+stars = 1900
+latest_release = "r26.06.11"
+
 ## Josh — Git at Scale Platform
 
-Josh (Just One Single History) addresses monorepo scaling: work in any size
-codebase without slowing change velocity. Core insight: repo boundaries are
-tooling limitations, not architectural requirements.
+# Josh (Just One Single History) addresses monorepo scaling: work in any size
+# codebase without slowing change velocity. Core insight: repo boundaries are
+# tooling limitations, not architectural requirements.
 
 ### Use Cases
 
-1. **Repo filtering**: Subfolder of monorepo → independent repo with full
-   history. E.g. `git clone https://git.josh-project.dev/josh.git:/docs.git`
-   clones just the `docs/` subdirectory as a standalone repo.
+# 1. **Repo filtering**: Subfolder of monorepo → independent repo with full
+#    history. E.g. `git clone https://git.josh-project.dev/josh.git:/docs.git`
+#    clones just the `docs/` subdirectory as a standalone repo.
 
-2. **CI/Build caching**: GraphQL API checks if any subproject has already
-   been successfully built — no checkout needed. "Has this code been built
-   before?" for any projection.
+# 2. **CI/Build caching**: GraphQL API checks if any subproject has already
+#    been successfully built — no checkout needed. "Has this code been built
+#    before?" for any projection.
 
-3. **Workspaces**: Persisted, versioned filter definitions. Declarative
-   multi-repo layout within a single history.
+# 3. **Workspaces**: Persisted, versioned filter definitions. Declarative
+#    multi-repo layout within a single history.
 
 ### Components
 
-| Component | Purpose |
-|-----------|---------|
-| josh-cli | Local tool for partial repo projections |
-| josh-proxy | Git HTTP/SSH proxy with on-the-fly history transformation + shared cache |
-| josh-filter | Core history rewriting engine |
-| josh-graphql | GraphQL API for repo state introspection |
-| josh-workspace | Declarative workspace composition (`.josh` files) |
-| josh-compose | Containerized build orchestrator on workspace/filter concepts |
+# | Component | Purpose |
+# |-----------|---------|
+# | josh-cli | Local tool for partial repo projections |
+# | josh-proxy | Git HTTP/SSH proxy with on-the-fly history transformation + shared cache |
+# | josh-filter | Core history rewriting engine |
+# | josh-graphql | GraphQL API for repo state introspection |
+# | josh-workspace | Declarative workspace composition (`.josh` files) |
+# | josh-compose | Containerized build orchestrator on workspace/filter concepts |
 
 ### Relevance to b00t
 
-- **Submodule elimination**: Josh could replace the 12+ vendor submodules
-  with filtered projections from a unified history. Each `vendor/X` becomes
-  a josh filter `::vendor/X/` — clone once, project infinitely.
-  Zero submodule drift, zero `git submodule update --init --recursive`.
-- **GitButler foundation**: GitButler's stacked branches and virtual branch
-  model builds on josh-style history rewriting. A b00t + josh + gitbutler
-  stack gives: josh for submodule/projection backend, gitbutler for agent
-  git UX, b00t for task dispatch across the unified history.
-- **Worktree isolation**: Current worktree-based agent sandboxing (commit
-  a41ebba) could be augmented with josh proxy for zero-clone agent contexts
-- **Evidence graph**: GraphQL introspection of monorepo state maps to
-  NeumannStore fact graphs — "which agents touched what files?"
+# - **Submodule elimination**: Josh could replace the 12+ vendor submodules
+#   with filtered projections from a unified history. Each `vendor/X` becomes
+#   a josh filter `::vendor/X/` — clone once, project infinitely.
+#   Zero submodule drift, zero `git submodule update --init --recursive`.
+# - **GitButler foundation**: GitButler's stacked branches and virtual branch
+#   model builds on josh-style history rewriting. A b00t + josh + gitbutler
+#   stack gives: josh for submodule/projection backend, gitbutler for agent
+#   git UX, b00t for task dispatch across the unified history.
+# - **Worktree isolation**: Current worktree-based agent sandboxing (commit
+#   a41ebba) could be augmented with josh proxy for zero-clone agent contexts
+# - **Evidence graph**: GraphQL introspection of monorepo state maps to
+#   NeumannStore fact graphs — "which agents touched what files?"
 
 ### Filters
 
-Josh filters describe desired transformations. Core types:
-- `::prefix/` — include only paths matching prefix
-- `::*/glob` — glob-based inclusion
-- `::!exclude` — exclusion filters
-- Workspace composition via `workspace.josh` files
+# Josh filters describe desired transformations. Core types:
+# - `::prefix/` — include only paths matching prefix
+# - `::*/glob` — glob-based inclusion
+# - `::!exclude` — exclusion filters
+# - Workspace composition via `workspace.josh` files
 
 # b00t:map v1
 # summary: Josh — git history transformation platform for monorepo scaling (Rust, MIT)

--- a/_b00t_/nats.skill.toml
+++ b/_b00t_/nats.skill.toml
@@ -1,159 +1,159 @@
----
-name: nats
-type: skill
-hint: NATS intra-hive mesh — Redis-free b00t hive discovery, direct send, broadcast, and presence over NATS subjects
-version: 1.0.0
-tags: [nats, mesh, a2a, discovery, ipc, b00t-comms, pubsub, intra-hive]
-tier: ch0nky
-complexity: 5
-description: |-
-  Provides the `--skill=nats` capability for the `b00t-comms` agent: a fully
-  realized NATS intra-hive mesh in `b00t-lib-chat` (src/mesh.rs). Every b00t
-  agent process becomes a first-class mesh node keyed by a stable agent id.
-  The mesh needs only a reachable NATS server (no Redis, no central registry),
-  so agent discovery works even when the Redis broker is down.
-applies_to: [agent discovery, A2A messaging, hive coordination, intra-hive mesh, offline discovery]
-output_types: [.rs, .toml]
-allowed-tools: Read, Write, Edit, Grep, Glob, Bash, Task
----
+# b00t nats skill datum
+# 🤓 converted from stray YAML-frontmatter .skill.toml (task #115 datum-errors cleanup):
+#    original content preserved, reformatted as valid TOML frontmatter + comment-prose body
+
+[b00t]
+name = "nats"
+type = "skill"
+hint = "NATS intra-hive mesh — Redis-free b00t hive discovery, direct send, broadcast, and presence over NATS subjects"
+version = "1.0.0"
+tags = ["nats", "mesh", "a2a", "discovery", "ipc", "b00t-comms", "pubsub", "intra-hive"]
+tier = "ch0nky"
+complexity = 5
+description = "Provides the `--skill=nats` capability for the `b00t-comms` agent: a fully realized NATS intra-hive mesh in `b00t-lib-chat` (src/mesh.rs). Every b00t agent process becomes a first-class mesh node keyed by a stable agent id. The mesh needs only a reachable NATS server (no Redis, no central registry), so agent discovery works even when the Redis broker is down."
+applies_to = ["agent discovery", "A2A messaging", "hive coordination", "intra-hive mesh", "offline discovery"]
+output_types = [".rs", ".toml"]
+
+[b00t.metadata]
+"allowed-tools" = "Read, Write, Edit, Grep, Glob, Bash, Task"
+
 
 ## What
 
-`nats` realizes the b00t intra-hive mesh. It is implemented in
-`b00t-lib-chat/src/mesh.rs` as `NatsMeshNode` and is the canonical
-`--skill=nats` for the `b00t-comms` agent. The mesh speaks `async_nats`
-directly (the channel-based `NatsTransport` cannot express per-agent inboxes
-or NATS reply-to, so the mesh does not reuse it).
+# `nats` realizes the b00t intra-hive mesh. It is implemented in
+# `b00t-lib-chat/src/mesh.rs` as `NatsMeshNode` and is the canonical
+# `--skill=nats` for the `b00t-comms` agent. The mesh speaks `async_nats`
+# directly (the channel-based `NatsTransport` cannot express per-agent inboxes
+# or NATS reply-to, so the mesh does not reuse it).
 
-Subject hierarchy (all under `b00t.hive.mesh.*`):
+# Subject hierarchy (all under `b00t.hive.mesh.*`):
 
-| Subject | Purpose |
-|---------|---------|
-| `b00t.hive.mesh.node.{agent_id}` | a node's direct inbox (point-to-point + discovery reply target) |
-| `b00t.hive.mesh.channel.{channel}` | pub/sub broadcast channel |
-| `b00t.hive.mesh.discovery.query` | broadcast "who is online?" with a NATS reply inbox |
-| `b00t.hive.mesh.discovery.presence` | periodic heartbeat announcing a live node |
-| `b00t.hive.mesh.gossip` | epidemic membership advertising (`MeshFrame::Gossip`); bounded hop-budget re-gossip so discovery converges without a central registry |
+# | Subject | Purpose |
+# |---------|---------|
+# | `b00t.hive.mesh.node.{agent_id}` | a node's direct inbox (point-to-point + discovery reply target) |
+# | `b00t.hive.mesh.channel.{channel}` | pub/sub broadcast channel |
+# | `b00t.hive.mesh.discovery.query` | broadcast "who is online?" with a NATS reply inbox |
+# | `b00t.hive.mesh.discovery.presence` | periodic heartbeat announcing a live node |
+# | `b00t.hive.mesh.gossip` | epidemic membership advertising (`MeshFrame::Gossip`); bounded hop-budget re-gossip so discovery converges without a central registry |
 
-The four primitives:
+# The four primitives:
 
-1. **Presence** — `announce()` / `start_presence()` publish heartbeats on the
-   presence subject. Peers learn each other with no central registry.
-2. **Discovery** — `discover()` publishes a `DiscoveryQuery` to
-   `b00t.hive.mesh.discovery.query` with the node's own inbox as the NATS reply
-   inbox. Live nodes answer with a `DiscoveryReply` carrying their
-   `AgentEndpoint`. Already-known peers are returned immediately.
-3. **Direct send** — `send(to_agent, msg)` publishes a `Direct` frame to
-   `b00t.hive.mesh.node.{to_agent}`.
-4. **Broadcast** — `publish(channel, msg)` publishes a `Broadcast` frame to
-   `b00t.hive.mesh.channel.{channel}`.
+# 1. **Presence** — `announce()` / `start_presence()` publish heartbeats on the
+#    presence subject. Peers learn each other with no central registry.
+# 2. **Discovery** — `discover()` publishes a `DiscoveryQuery` to
+#    `b00t.hive.mesh.discovery.query` with the node's own inbox as the NATS reply
+#    inbox. Live nodes answer with a `DiscoveryReply` carrying their
+#    `AgentEndpoint`. Already-known peers are returned immediately.
+# 3. **Direct send** — `send(to_agent, msg)` publishes a `Direct` frame to
+#    `b00t.hive.mesh.node.{to_agent}`.
+# 4. **Broadcast** — `publish(channel, msg)` publishes a `Broadcast` frame to
+#    `b00t.hive.mesh.channel.{channel}`.
 
-`NatsMeshNode` implements `DiscoverableTransport`, so it slots into the
-existing `b00t agent discover` plumbing as a Redis-free transport.
+# `NatsMeshNode` implements `DiscoverableTransport`, so it slots into the
+# existing `b00t agent discover` plumbing as a Redis-free transport.
 
 ## When to Use
 
-Use `nats` whenever hive coordination must survive a down Redis broker, or when
-agents run across hosts/regions where a single Unix-socket registry is not
-enough. Prefer the mesh over `discover`'s local-filesystem fallback when a NATS
-server is reachable, because it also carries live messaging (not just discovery).
+# Use `nats` whenever hive coordination must survive a down Redis broker, or when
+# agents run across hosts/regions where a single Unix-socket registry is not
+# enough. Prefer the mesh over `discover`'s local-filesystem fallback when a NATS
+# server is reachable, because it also carries live messaging (not just discovery).
 
 ## How
 
-```rust
-use b00t_chat::mesh::{MeshNodeConfig, NatsMeshNode};
-use b00t_chat::message::ChatMessage;
+# ```rust
+# use b00t_chat::mesh::{MeshNodeConfig, NatsMeshNode};
+# use b00t_chat::message::ChatMessage;
 
-let node = NatsMeshNode::new(
-    MeshNodeConfig::new("alpha", "nats://localhost:4222")
-        .with_role("b00t-comms")
-        .with_skills(vec!["nats".to_string()]),
-);
-node.connect().await?;
-node.start_presence().await;            // heartbeat + discoverable
-let peers = node.discover().await?;     // request/reply discovery
-node.join("mission.alpha").await?;
-node.publish("mission.alpha", &ChatMessage::new("mission.alpha", "alpha", "go"))
-    .await?;
-while let Some(frame) = node.recv().await? { /* handle */ }
-```
+# let node = NatsMeshNode::new(
+#     MeshNodeConfig::new("alpha", "nats://localhost:4222")
+#         .with_role("b00t-comms")
+#         .with_skills(vec!["nats".to_string()]),
+# );
+# node.connect().await?;
+# node.start_presence().await;            // heartbeat + discoverable
+# let peers = node.discover().await?;     // request/reply discovery
+# node.join("mission.alpha").await?;
+# node.publish("mission.alpha", &ChatMessage::new("mission.alpha", "alpha", "go"))
+#     .await?;
+# while let Some(frame) = node.recv().await? { /* handle */ }
+# ```
 
-Run the reference `b00t-comms` node without writing Rust:
+# Run the reference `b00t-comms` node without writing Rust:
 
-```text
-cargo run -p b00t-chat --example mesh_cli -- node1 nats://localhost:4222 listen
-cargo run -p b00t-chat --example mesh_cli -- node2 nats://localhost:4222 discover
-```
+# ```text
+# cargo run -p b00t-chat --example mesh_cli -- node1 nats://localhost:4222 listen
+# cargo run -p b00t-chat --example mesh_cli -- node2 nats://localhost:4222 discover
+# ```
 
 ## Tests
 
-`cargo test -p b00t-chat` runs unit tests (subject shape, presence TTL, frame
-JSON round-trip, self/stale peer exclusion) with no server. A full two-node
-integration test is env-gated on `NATS_URL`; when unset it is skipped so CI
-stays green without a broker.
+# `cargo test -p b00t-chat` runs unit tests (subject shape, presence TTL, frame
+# JSON round-trip, self/stale peer exclusion) with no server. A full two-node
+# integration test is env-gated on `NATS_URL`; when unset it is skipped so CI
+# stays green without a broker.
 
 ## Finops / Collaborative Autonomy
 
-The mesh is the accounting seam for collaborative autonomy. Every capability a
-`b00t-comms` node executes registers a `UsageReceipt` with **ledgrrr**
-(`b00t-lib-chat/src/ledgrrr.rs`) and mints a finops code
-(`FINOPS-<project>-<seq>`). This makes each project/capability an agent runs
-attributable and auditable:
+# The mesh is the accounting seam for collaborative autonomy. Every capability a
+# `b00t-comms` node executes registers a `UsageReceipt` with **ledgrrr**
+# (`b00t-lib-chat/src/ledgrrr.rs`) and mints a finops code
+# (`FINOPS-<project>-<seq>`). This makes each project/capability an agent runs
+# attributable and auditable:
 
-```rust
-let ledger = Arc::new(MockLedgrrr::mock());
-let node = NatsMeshNode::new(
-    MeshNodeConfig::new("alpha", "nats://localhost:4222")
-        .with_project("app4dog")
-        .with_ledgrrr(ledger.clone()),
-);
-node.connect().await?;
-node.send("beta", &msg).await?;          // auto-registers a nats.send receipt
-node.record_usage("app4dog", "nats.broadcast", 1).await?;
-let codes = ledger.codes_for("app4dog"); // roll up finops for the project
-```
+# ```rust
+# let ledger = Arc::new(MockLedgrrr::mock());
+# let node = NatsMeshNode::new(
+#     MeshNodeConfig::new("alpha", "nats://localhost:4222")
+#         .with_project("app4dog")
+#         .with_ledgrrr(ledger.clone()),
+# );
+# node.connect().await?;
+# node.send("beta", &msg).await?;          // auto-registers a nats.send receipt
+# node.record_usage("app4dog", "nats.broadcast", 1).await?;
+# let codes = ledger.codes_for("app4dog"); // roll up finops for the project
+# ```
 
-`LocalLedgrrr` is the persistent default (JSONL, no server). For this
-broker-free / nats-focused PR the mesh defaults to `MockLedgrrr`
-(`LocalLedgrrr::mock()`), which mints synthetic `MOCK-FINOPS-*` codes in-memory
-so the nats work is not blocked on a running `ledgerr-mcp`. `McpLedgrrr` bridges
-to the real server via `LEDGERR_MCP_CMD`, mirroring `b00t-mcp`'s stdio bridge;
-iroh-backed receipt exchange is deferred (see NATS-MESH-GOSSIP-DISCOVERY).
+# `LocalLedgrrr` is the persistent default (JSONL, no server). For this
+# broker-free / nats-focused PR the mesh defaults to `MockLedgrrr`
+# (`LocalLedgrrr::mock()`), which mints synthetic `MOCK-FINOPS-*` codes in-memory
+# so the nats work is not blocked on a running `ledgerr-mcp`. `McpLedgrrr` bridges
+# to the real server via `LEDGERR_MCP_CMD`, mirroring `b00t-mcp`'s stdio bridge;
+# iroh-backed receipt exchange is deferred (see NATS-MESH-GOSSIP-DISCOVERY).
 
 ### Dataframe-typed receipts → Apache Arrow
 
-Every receipt is also a `DataframeReceipt` (`b00t-lib-chat/src/dataframe_receipt.rs`):
-it yields an Arrow-shaped `Dataframe` (named columns + Arrow datatypes). With
-the `dataframe` feature, `Dataframe::to_arrow()` materializes a real
-`arrow::record_batch::RecordBatch` — the concrete columnar implementation the
-operator requires. The **FOCUS record** (`FocusRecord`) is the reference
-implementation; `UsageReceipt` also implements `DataframeReceipt`.
+# Every receipt is also a `DataframeReceipt` (`b00t-lib-chat/src/dataframe_receipt.rs`):
+# it yields an Arrow-shaped `Dataframe` (named columns + Arrow datatypes). With
+# the `dataframe` feature, `Dataframe::to_arrow()` materializes a real
+# `arrow::record_batch::RecordBatch` — the concrete columnar implementation the
+# operator requires. The **FOCUS record** (`FocusRecord`) is the reference
+# implementation; `UsageReceipt` also implements `DataframeReceipt`.
 
-```rust
-let batch = focus_record.to_dataframe().to_arrow()?; // feature `dataframe`
-```
+# ```rust
+# let batch = focus_record.to_dataframe().to_arrow()?; // feature `dataframe`
+# ```
 
 ### Ontology — UFO grounding
 
-The hive types are classified against the `ufo-types` crate (#511) via the
-`Stereotyped` trait, so they carry a `UfoStereotype` for evidence/audit
-(`record_is_a`):
+# The hive types are classified against the `ufo-types` crate (#511) via the
+# `Stereotyped` trait, so they carry a `UfoStereotype` for evidence/audit
+# (`record_is_a`):
 
-| Type | UFO stereotype |
-|------|----------------|
-| `AgentEndpoint` | `Kind("AgentEndpoint")` — material endpoint realizing an agent |
-| `AgentPresence` | `Kind("AgentPresence")` — live reachability snapshot |
-| `GossipMember` | `Kind("GossipMember")` — membership entry |
-| `MeshFrame` | `Relator("hive-mesh-frame")` — binds sender↔recipient |
-| `NatsMeshNode` | `Role("hive-node")` — plays the intra-hive comms role |
+# | Type | UFO stereotype |
+# |------|----------------|
+# | `AgentEndpoint` | `Kind("AgentEndpoint")` — material endpoint realizing an agent |
+# | `AgentPresence` | `Kind("AgentPresence")` — live reachability snapshot |
+# | `GossipMember` | `Kind("GossipMember")` — membership entry |
+# | `MeshFrame` | `Relator("hive-mesh-frame")` — binds sender↔recipient |
+# | `NatsMeshNode` | `Role("hive-node")` — plays the intra-hive comms role |
 
-This aligns the mesh with the existing b00t hive UFO stereotypes and the
-`b00t.hive.*` namespace (intra-hive, same network).
+# This aligns the mesh with the existing b00t hive UFO stereotypes and the
+# `b00t.hive.*` namespace (intra-hive, same network).
 
-<!-- b00t:map v1
-summary: nats — Redis-free NATS intra-hive mesh (discovery, direct, broadcast, presence) + ledgrrr finops receipts + Arrow dataframe for b00t-comms
-tags: nats, mesh, a2a, discovery, ipc, b00t-comms, intra-hive, finops, ledgrrr, arrow, dataframe
-tier: ch0nky
-cmds: cargo run -p b00t-chat --example mesh_cli -- node1 nats://localhost:4222 listen
-complexity: 5
--->
+# b00t:map v1
+# summary: nats — Redis-free NATS intra-hive mesh (discovery, direct, broadcast, presence) + ledgrrr finops receipts + Arrow dataframe for b00t-comms
+# tags: nats, mesh, a2a, discovery, ipc, b00t-comms, intra-hive, finops, ledgrrr, arrow, dataframe
+# tier: ch0nky
+# cmds: cargo run -p b00t-chat --example mesh_cli -- node1 nats://localhost:4222 listen
+# complexity: 5

--- a/_b00t_/plans/b00t-server-architecture.tomllmd
+++ b/_b00t_/plans/b00t-server-architecture.tomllmd
@@ -4,238 +4,238 @@
 
 ## Problem Statement
 
-rust-doc MCP server (and other b00tyverse tools) need an OpenAI REST API to call.
-Today: OPENAI_API_KEY → api.openai.com (external, costly, no key governance).
-Target: b00t-server = local OpenAI-compat endpoint that routes to local models
-(mistral.rs) or upstream providers, mints API keys scoped to sub-agents/MCP-servers,
-and tracks per-consumer usage telemetry ("focus records").
+# rust-doc MCP server (and other b00tyverse tools) need an OpenAI REST API to call.
+# Today: OPENAI_API_KEY → api.openai.com (external, costly, no key governance).
+# Target: b00t-server = local OpenAI-compat endpoint that routes to local models
+# (mistral.rs) or upstream providers, mints API keys scoped to sub-agents/MCP-servers,
+# and tracks per-consumer usage telemetry ("focus records").
 
 ## Architecture: Extend b00t-mcp, Don't Fork
 
-b00t-mcp already runs axum 0.8 + OAuth 2.1 (JWT minting) + streamable-http MCP transport
-+ ACL. Adding `/v1/*` routes to the existing server is <200 LOC. Key assets:
+# b00t-mcp already runs axum 0.8 + OAuth 2.1 (JWT minting) + streamable-http MCP transport
+# + ACL. Adding `/v1/*` routes to the existing server is <200 LOC. Key assets:
 
-    b00t-mcp/src/main.rs:168-189  — existing axum router + serve
-    b00t-mcp/src/oauth_minimal.rs  — JWT issuance (access_token, expires_in)
-    b00t-c0re-lib/src/ai_client.rs  — B00tAiClient (openai/anthropic/ollama/openai-compat)
-    b00t-c0re-lib/src/sm0l_dispatch.rs  — SmolEndpoint (localhost:8000/8001 discovery)
-    b00t-cli/src/model_manager.rs  — ServedEndpointRecord, model discovery
-    b00t-lib-chat/src/metrics.rs  — ChatMetrics OTel (counters, histograms)
-    vendor/irontology-mcp  — reference OpenAI-compat router (axum /v1/models, /v1/chat/completions)
-    vendor/embed-anything-b00t  — reference /v1/embeddings server
+#     b00t-mcp/src/main.rs:168-189  — existing axum router + serve
+#     b00t-mcp/src/oauth_minimal.rs  — JWT issuance (access_token, expires_in)
+#     b00t-c0re-lib/src/ai_client.rs  — B00tAiClient (openai/anthropic/ollama/openai-compat)
+#     b00t-c0re-lib/src/sm0l_dispatch.rs  — SmolEndpoint (localhost:8000/8001 discovery)
+#     b00t-cli/src/model_manager.rs  — ServedEndpointRecord, model discovery
+#     b00t-lib-chat/src/metrics.rs  — ChatMetrics OTel (counters, histograms)
+#     vendor/irontology-mcp  — reference OpenAI-compat router (axum /v1/models, /v1/chat/completions)
+#     vendor/embed-anything-b00t  — reference /v1/embeddings server
 
 ## Phase 1: /v1/ router in b00t-mcp (server mode)
 
-Add a `b00t-cli server start` subcommand that launches b00t-mcp in HTTP mode
-with an extra `/v1/` route group. The `b00t mcp` binary already accepts `--http --port`.
+# Add a `b00t-cli server start` subcommand that launches b00t-mcp in HTTP mode
+# with an extra `/v1/` route group. The `b00t mcp` binary already accepts `--http --port`.
 
 ### 1a. New subcommand: `b00t server start`
 
-    b00t server start [--port=5273] [--backend=local|upstream] [--model=tier]
+#     b00t server start [--port=5273] [--backend=local|upstream] [--model=tier]
 
-Wiring (3 edits):
-  1. b00t-cli/src/commands/mod.rs:    pub mod server; pub use server::ServerCommands;
-  2. b00t-cli/src/main.rs Commands:   Server { #[clap(subcommand)] server_command: ServerCommands }
-  3. b00t-cli/src/main.rs dispatch:   match on Commands::Server
+# Wiring (3 edits):
+#   1. b00t-cli/src/commands/mod.rs:    pub mod server; pub use server::ServerCommands;
+#   2. b00t-cli/src/main.rs Commands:   Server { #[clap(subcommand)] server_command: ServerCommands }
+#   3. b00t-cli/src/main.rs dispatch:   match on Commands::Server
 
 ### 1b. OpenAI-compat routes (mount on existing axum Router)
 
-```rust
-// b00t-mcp/src/server_llm.rs (NEW file)
-pub fn llm_router(state: Arc<LlmServerState>) -> Router {
-    Router::new()
-        .route("/v1/models", get(list_models))
-        .route("/v1/chat/completions", post(chat_completions))
-        .route("/v1/embeddings", post(embeddings))
-        .layer(axum::middleware::from_fn_with_state(state.clone(), require_api_key))
-}
+# ```rust
+# // b00t-mcp/src/server_llm.rs (NEW file)
+# pub fn llm_router(state: Arc<LlmServerState>) -> Router {
+#     Router::new()
+#         .route("/v1/models", get(list_models))
+#         .route("/v1/chat/completions", post(chat_completions))
+#         .route("/v1/embeddings", post(embeddings))
+#         .layer(axum::middleware::from_fn_with_state(state.clone(), require_api_key))
+# }
 
-async fn chat_completions(
-    State(state): State<Arc<LlmServerState>>,
-    TypedHeader(auth): TypedHeader<Authorization<Bearer>>,
-    Json(body): Json<ChatCompletionRequest>,
-) -> Result<Json<ChatCompletionResponse>, AppError> {
-    let consumer = state.validate_key(&auth.token()).await?;  // consumer = agent-id or mcp-server name
-    state.record_usage(&consumer, "chat_completions", body.model.as_deref()).await;
-    let response = state.router.route(&body).await?;  // -> local model or upstream
-    Ok(Json(response))
-}
-```
+# async fn chat_completions(
+#     State(state): State<Arc<LlmServerState>>,
+#     TypedHeader(auth): TypedHeader<Authorization<Bearer>>,
+#     Json(body): Json<ChatCompletionRequest>,
+# ) -> Result<Json<ChatCompletionResponse>, AppError> {
+#     let consumer = state.validate_key(&auth.token()).await?;  // consumer = agent-id or mcp-server name
+#     state.record_usage(&consumer, "chat_completions", body.model.as_deref()).await;
+#     let response = state.router.route(&body).await?;  // -> local model or upstream
+#     Ok(Json(response))
+# }
+# ```
 
-Backend routing logic: consult ModelRegistry (`b00t-cli/src/model_registry.rs`) →
-`resolve_tier_endpoint(tier)` → POST to `{base_url}/v1/chat/completions` with
-`Authorization: Bearer {upstream_key}`. If local mistral.rs available (`aaiii.rs`
-probes `:8181/v1/models`) prefer it; fallback to the tier's upstream provider.
+# Backend routing logic: consult ModelRegistry (`b00t-cli/src/model_registry.rs`) →
+# `resolve_tier_endpoint(tier)` → POST to `{base_url}/v1/chat/completions` with
+# `Authorization: Bearer {upstream_key}`. If local mistral.rs available (`aaiii.rs`
+# probes `:8181/v1/models`) prefer it; fallback to the tier's upstream provider.
 
-Reference: `vendor/irontology-mcp/crates/provider-openai/src/lib.rs:302-304`
-(identical axum route structure), `b00t-admin/src/main.rs:1344-1347`
-(`/v1/{*path}` catch-all proxy).
+# Reference: `vendor/irontology-mcp/crates/provider-openai/src/lib.rs:302-304`
+# (identical axum route structure), `b00t-admin/src/main.rs:1344-1347`
+# (`/v1/{*path}` catch-all proxy).
 
 ## Phase 2: API Key Authority
 
-Today: `b00t-mcp/src/oauth_minimal.rs` mints JWTs — sessions are in-memory only (🚩).
-Goal: persistent API-key store you can `b00t server key create` → put key in env.
+# Today: `b00t-mcp/src/oauth_minimal.rs` mints JWTs — sessions are in-memory only (🚩).
+# Goal: persistent API-key store you can `b00t server key create` → put key in env.
 
 ### 2a. Key creation command
 
-    b00t server key create \
-      --consumer "rust-doc" \        # MCP server name or sub-agent id
-      [--scope "chat,embeddings"] \   # allowed /v1/ routes (default: all)
-      [--expires "30d" | "never"] \   # TTL
-      [--backend "local:mistralrs"]  # route key to specific backend
+#     b00t server key create \
+#       --consumer "rust-doc" \        # MCP server name or sub-agent id
+#       [--scope "chat,embeddings"] \   # allowed /v1/ routes (default: all)
+#       [--expires "30d" | "never"] \   # TTL
+#       [--backend "local:mistralrs"]  # route key to specific backend
 
-Output: `OPENAI_API_KEY=b00t-sk-<random>` printed to stdout (pipe into .env).
+# Output: `OPENAI_API_KEY=b00t-sk-<random>` printed to stdout (pipe into .env).
 
 ### 2b. Key storage: rmcp CredentialStore trait
 
-`vendor/rmcp-rust-sdk/crates/rmcp/src/transport/auth.rs:110-151` defines:
-```rust
-pub trait CredentialStore: Send + Sync {
-    async fn load(&self, client_id: &str) -> ...;
-    async fn save(&self, client_id: &str, creds: ...) -> ...;
-    async fn clear(&self, client_id: &str) -> ...;
-}
-```
-Implement `KvCredentialStore` backed by `b00t-c0re-lib/src/kv_store.rs` (already persists
-`kv-store.json`). Store: consumer-id → {key_hash, scopes, backend_ref, created_at, expires_at}.
+# `vendor/rmcp-rust-sdk/crates/rmcp/src/transport/auth.rs:110-151` defines:
+# ```rust
+# pub trait CredentialStore: Send + Sync {
+#     async fn load(&self, client_id: &str) -> ...;
+#     async fn save(&self, client_id: &str, creds: ...) -> ...;
+#     async fn clear(&self, client_id: &str) -> ...;
+# }
+# ```
+# Implement `KvCredentialStore` backed by `b00t-c0re-lib/src/kv_store.rs` (already persists
+# `kv-store.json`). Store: consumer-id → {key_hash, scopes, backend_ref, created_at, expires_at}.
 
 ### 2c. Key validation middleware
 
-`require_api_key` middleware: check `Authorization: Bearer b00t-sk-*` header →
-hash-lookup in CredentialStore → attach `ConsumerIdentity { id, scopes, backend_ref }`
-to request extensions. Unknown key → 401. Expired key → 401.
+# `require_api_key` middleware: check `Authorization: Bearer b00t-sk-*` header →
+# hash-lookup in CredentialStore → attach `ConsumerIdentity { id, scopes, backend_ref }`
+# to request extensions. Unknown key → 401. Expired key → 401.
 
 ### 2d. Wire rust-doc to b00t-server
 
-After key creation, set OPENAI_API_KEY in rust-doc:
-```bash
-b00t server key create --consumer rust-doc > /tmp/rust-doc-key.env
+# After key creation, set OPENAI_API_KEY in rust-doc:
+# ```bash
+# b00t server key create --consumer rust-doc > /tmp/rust-doc-key.env
 # The rust-doc MCP datum's stdio config doesn't support env vars natively,
 # but opencode spawns the server with inherited env. Option 1:
-export OPENAI_API_KEY=$(cat /tmp/rust-doc-key.env | grep -oP 'b00t-sk-\S+')
+# export OPENAI_API_KEY=$(cat /tmp/rust-doc-key.env | grep -oP 'b00t-sk-\S+')
 # Option 2 (future): b00t-mcp ACL token passthrough to spawned MCP servers.
-```
+# ```
 
 ## Phase 3: Usage Telemetry ("Spotlight" — renamed from FOCUS to avoid collision)
 
-🚩 **Naming**: "FOCUS records" already exists in b00t as FinOps billing records
-(`b00t-cli/src/commands/focus.rs`, sourced from `vendor/l3dg3rr`). The new
-popularity/usage concept is renamed **Spotlight** in this plan. (Bikeshed: `Focus`
-→ `Spotlight` preserves the mental model of "what's getting attention" while
-sidestepping the FinOps collision.)
+# 🚩 **Naming**: "FOCUS records" already exists in b00t as FinOps billing records
+# (`b00t-cli/src/commands/focus.rs`, sourced from `vendor/l3dg3rr`). The new
+# popularity/usage concept is renamed **Spotlight** in this plan. (Bikeshed: `Focus`
+# → `Spotlight` preserves the mental model of "what's getting attention" while
+# sidestepping the FinOps collision.)
 
 ### 3a. What to track
 
-Per consumer (agent-id, MCP server name, or user):
-- `spotlight.llm.requests{counter}` — increment per `/v1/chat/completions` call
-- `spotlight.llm.tokens{prompt,completion}` — histograms from response usage
-- `spotlight.llm.model{model_name}` — per-model breakdown
-- `spotlight.embeddings.requests{counter}` — per `/v1/embeddings` call
-- `spotlight.consumer.active{consumer}` — UpDownCounter, last-N-minutes
+# Per consumer (agent-id, MCP server name, or user):
+# - `spotlight.llm.requests{counter}` — increment per `/v1/chat/completions` call
+# - `spotlight.llm.tokens{prompt,completion}` — histograms from response usage
+# - `spotlight.llm.model{model_name}` — per-model breakdown
+# - `spotlight.embeddings.requests{counter}` — per `/v1/embeddings` call
+# - `spotlight.consumer.active{consumer}` — UpDownCounter, last-N-minutes
 
-Per sub-agent (worker, pi, moltis, etc.) the consumer-id is the agent's
-`b00t whoami` identity. Per MCP server it's the MCP datum name.
+# Per sub-agent (worker, pi, moltis, etc.) the consumer-id is the agent's
+# `b00t whoami` identity. Per MCP server it's the MCP datum name.
 
 ### 3b. Infrastructure: extend ChatMetrics OTel
 
-`b00t-lib-chat/src/metrics.rs:23-176` already defines counters/histograms with
-`ChatMetrics::messages_sent`, `send_latency`, etc. Extend with:
+# `b00t-lib-chat/src/metrics.rs:23-176` already defines counters/histograms with
+# `ChatMetrics::messages_sent`, `send_latency`, etc. Extend with:
 
-```rust
-// b00t-lib-chat/src/metrics.rs (new meters)
-pub struct SpotlightMetrics {
-    pub llm_requests: Counter<u64>,
-    pub llm_tokens_prompt: Histogram<u64>,
-    pub llm_tokens_completion: Histogram<u64>,
-    pub embeddings_requests: Counter<u64>,
-    pub consumer_active: UpDownCounter<i64>,
-}
-```
+# ```rust
+# // b00t-lib-chat/src/metrics.rs (new meters)
+# pub struct SpotlightMetrics {
+#     pub llm_requests: Counter<u64>,
+#     pub llm_tokens_prompt: Histogram<u64>,
+#     pub llm_tokens_completion: Histogram<u64>,
+#     pub embeddings_requests: Counter<u64>,
+#     pub consumer_active: UpDownCounter<i64>,
+# }
+# ```
 
 ### 3c. Event log (no OTel collector needed for MVP)
 
-If OTel collector isn't running, fallback to the existing `~/.b00t/events.jsonl`
-pipeline (`b00t-cli/src/main.rs:495`, `governance.rs:203`). Each call emits:
-```json
-{"ts": "2026-06-23T...", "event": "spotlight.llm.request", "detail": {
-  "consumer": "rust-doc", "model": "serde", "provider": "local/mistralrs",
-  "tokens_prompt": 142, "tokens_completion": 89, "latency_ms": 234
-}}
-```
+# If OTel collector isn't running, fallback to the existing `~/.b00t/events.jsonl`
+# pipeline (`b00t-cli/src/main.rs:495`, `governance.rs:203`). Each call emits:
+# ```json
+# {"ts": "2026-06-23T...", "event": "spotlight.llm.request", "detail": {
+#   "consumer": "rust-doc", "model": "serde", "provider": "local/mistralrs",
+#   "tokens_prompt": 142, "tokens_completion": 89, "latency_ms": 234
+# }}
+# ```
 
 ### 3d. Query & transmit
 
-    b00t server spotlight query --consumer rust-doc --since 7d
-    b00t server spotlight transmit --consumer rust-doc --to ~/.b00t/spotlight/
+#     b00t server spotlight query --consumer rust-doc --since 7d
+#     b00t server spotlight transmit --consumer rust-doc --to ~/.b00t/spotlight/
 
-The existing `commands/observability.rs` (`Events`, `Tail`, etc.) is the
-natural query surface to extend.
+# The existing `commands/observability.rs` (`Events`, `Tail`, etc.) is the
+# natural query surface to extend.
 
 ## Phase 4: b00tyverse integration
 
-    vendor/tomllm      — TOML annotation parser; use for b00t-server config datums (.tomllm/.tomllmd)
-    vendor/moltis-b00t — reference credential store (SQLite for API keys); compare approach with KvStore
-    vendor/rust-docs-mcp-server — primary first consumer (its stdin env needs OPENAI_API_KEY)
-    vendor/b00tyverse/codebase-memory-mcp-b00t-ir0n-ledg3rr — future consumer (semantic embeddings via /v1/embeddings)
+#     vendor/tomllm      — TOML annotation parser; use for b00t-server config datums (.tomllm/.tomllmd)
+#     vendor/moltis-b00t — reference credential store (SQLite for API keys); compare approach with KvStore
+#     vendor/rust-docs-mcp-server — primary first consumer (its stdin env needs OPENAI_API_KEY)
+#     vendor/b00tyverse/codebase-memory-mcp-b00t-ir0n-ledg3rr — future consumer (semantic embeddings via /v1/embeddings)
 
 ## Implementation Order (MVP)
 
-| Step | What | LOC est | Depends on |
-|------|------|---------|------------|
-| 1. | `b00t server start` subcommand + /v1/ router (b00t-mcp src/server_llm.rs) | ~150 | nothing |
-| 2. | `B00tAiClient` integration for model routing | ~50 | Step 1 |
-| 3. | `b00t server key create` — API key minting + KvCredentialStore | ~120 | Step 1 |
-| 4. | `require_api_key` middleware | ~40 | Step 3 |
-| 5. | Spotlight meters (ChatMetrics extension) | ~60 | Step 1 |
-| 6. | Spotlog event emission + `b00t server spotlight query` | ~80 | Step 5 |
-| 7. | Wire rust-doc: key creation + env injection | ~30 | Step 3 |
-| **Total** | | **~530 LOC** | |
+# | Step | What | LOC est | Depends on |
+# |------|------|---------|------------|
+# | 1. | `b00t server start` subcommand + /v1/ router (b00t-mcp src/server_llm.rs) | ~150 | nothing |
+# | 2. | `B00tAiClient` integration for model routing | ~50 | Step 1 |
+# | 3. | `b00t server key create` — API key minting + KvCredentialStore | ~120 | Step 1 |
+# | 4. | `require_api_key` middleware | ~40 | Step 3 |
+# | 5. | Spotlight meters (ChatMetrics extension) | ~60 | Step 1 |
+# | 6. | Spotlog event emission + `b00t server spotlight query` | ~80 | Step 5 |
+# | 7. | Wire rust-doc: key creation + env injection | ~30 | Step 3 |
+# | **Total** | | **~530 LOC** | |
 
 ## LMCache research (2026-08-04, research only — no implementation this pass)
 
-Investigated as a future capability per explicit ask: "eventually offer an lmcache."
+# Investigated as a future capability per explicit ask: "eventually offer an lmcache."
 
-**What it is**: LMCache (github.com/LMCache/LMCache) is a production-grade KV-cache
-management layer for LLM inference — turns per-request KV cache into persistent,
-reusable, multi-tier storage (GPU → CPU DRAM "hot cache" → disk/remote). Cuts TTFT
-dramatically on repeated-prefix workloads (their own numbers: 11s → 1.5s on 128K-context
-sharing across nodes). Graduated to production Jan 2026; used by Google Cloud GKE
-Inference, CoreWeave, Cohere. Storage backends: CPU RAM, local disk, Redis/Valkey,
-S3-compatible, Mooncake, InfiniStore, NIXL, GDS.
+# **What it is**: LMCache (github.com/LMCache/LMCache) is a production-grade KV-cache
+# management layer for LLM inference — turns per-request KV cache into persistent,
+# reusable, multi-tier storage (GPU → CPU DRAM "hot cache" → disk/remote). Cuts TTFT
+# dramatically on repeated-prefix workloads (their own numbers: 11s → 1.5s on 128K-context
+# sharing across nodes). Graduated to production Jan 2026; used by Google Cloud GKE
+# Inference, CoreWeave, Cohere. Storage backends: CPU RAM, local disk, Redis/Valkey,
+# S3-compatible, Mooncake, InfiniStore, NIXL, GDS.
 
-**Integration constraint that matters for us**: it is Python-only and integrates
-specifically with **vLLM** — no Candle or mistral.rs bindings exist (confirmed, not
-assumed). It is not a drop-in for our Rust-native local inference stack
-(`b00t-candle-serve`, `b00t-embed-serve`) or for mistral.rs (`mistralrs-proxy` — itself
-still a stub, binary not installed).
+# **Integration constraint that matters for us**: it is Python-only and integrates
+# specifically with **vLLM** — no Candle or mistral.rs bindings exist (confirmed, not
+# assumed). It is not a drop-in for our Rust-native local inference stack
+# (`b00t-candle-serve`, `b00t-embed-serve`) or for mistral.rs (`mistralrs-proxy` — itself
+# still a stub, binary not installed).
 
-**Where it would actually plug in, when we're ready**: b00t already has a real,
-working vLLM deployment path — `b00t model serve` (`b00t-cli/src/model_manager.rs`)
-launches an actual `vllm/vllm-openai` podman container per a `.model.ai.tomllmd` datum
-(e.g. `qwen3-coder-local`). LMCache's natural integration point is alongside *that*
-path (its own vLLM production-stack wrapper / `--kv-transfer-config`-style flags),
-not alongside Candle or mistral.rs. `mistral.rs` does have its own (different,
-single-process, non-LMCache) prefix-cache flag already referenced in
-`mistralrs-proxy.hive.toml` (`--prefix-cache-n 16`) — that's a separate, much smaller
-lever, not LMCache-equivalent (no cross-instance sharing, no tiered storage).
+# **Where it would actually plug in, when we're ready**: b00t already has a real,
+# working vLLM deployment path — `b00t model serve` (`b00t-cli/src/model_manager.rs`)
+# launches an actual `vllm/vllm-openai` podman container per a `.model.ai.tomllmd` datum
+# (e.g. `qwen3-coder-local`). LMCache's natural integration point is alongside *that*
+# path (its own vLLM production-stack wrapper / `--kv-transfer-config`-style flags),
+# not alongside Candle or mistral.rs. `mistral.rs` does have its own (different,
+# single-process, non-LMCache) prefix-cache flag already referenced in
+# `mistralrs-proxy.hive.toml` (`--prefix-cache-n 16`) — that's a separate, much smaller
+# lever, not LMCache-equivalent (no cross-instance sharing, no tiered storage).
 
-**Recommendation**: revisit once `b00t model serve`'s vLLM path is the primary local
-serving path (not an alternative to mistralrs/candle) and a real repeated-prefix
-workload exists to justify it (rust-doc-style RAG lookups are a plausible candidate —
-same crate docs re-embedded/re-queried repeatedly share long common prefixes). No
-code in this pass.
+# **Recommendation**: revisit once `b00t model serve`'s vLLM path is the primary local
+# serving path (not an alternative to mistralrs/candle) and a real repeated-prefix
+# workload exists to justify it (rust-doc-style RAG lookups are a plausible candidate —
+# same crate docs re-embedded/re-queried repeatedly share long common prefixes). No
+# code in this pass.
 
 ## Open Questions
 
-- **Local model backend**: mistral.rs is the reference but requires GPU (RTX 3090 per
-  hardware.toml). Should the default backend use a smaller no-GPU fallback (llama.cpp
-  on CPU) when mistral.rs is down? `aaiii.rs` already probes `LLAMA_CPP_BASE_URL`.
-- **Persistent key TTL**: SQLite + `expires_at` column, or delegate to JWT `exp` claim?
-  JWT is stateless (no DB lookup per request) but requires a secret rotation story.
-  KvStore lookup is simpler to implement + revoke. Start with KvStore lookup.
-- **rust-doc embeddings caveat**: rust-doc uses OpenAI `text-embedding-3-small` — a
-  local substitute (nomic/all-MiniLM) would avoid the external API dependency entirely.
-  The `b00t-embed` crate's `EmbedBackend` trait is the abstraction point.
+# - **Local model backend**: mistral.rs is the reference but requires GPU (RTX 3090 per
+#   hardware.toml). Should the default backend use a smaller no-GPU fallback (llama.cpp
+#   on CPU) when mistral.rs is down? `aaiii.rs` already probes `LLAMA_CPP_BASE_URL`.
+# - **Persistent key TTL**: SQLite + `expires_at` column, or delegate to JWT `exp` claim?
+#   JWT is stateless (no DB lookup per request) but requires a secret rotation story.
+#   KvStore lookup is simpler to implement + revoke. Start with KvStore lookup.
+# - **rust-doc embeddings caveat**: rust-doc uses OpenAI `text-embedding-3-small` — a
+#   local substitute (nomic/all-MiniLM) would avoid the external API dependency entirely.
+#   The `b00t-embed` crate's `EmbedBackend` trait is the abstraction point.
 
 # b00t:map v1
 # summary: b00t-server architecture plan — extend b00t-mcp with OpenAI-compat router, API-key authority, and Spotlight usage telemetry

--- a/_b00t_/schema/INSTALLER-CAPABILITY.tomllmd
+++ b/_b00t_/schema/INSTALLER-CAPABILITY.tomllmd
@@ -249,21 +249,21 @@ vendor_datum = "VENDOR-LEDGRRR"
 
 [[b00t.check]]
 name = "disk-usage-tmp"
-check_command = "df -h /tmp | tail -1 | awk '{print \$5}' | sed 's/%//' | awk '\$1 < 80'"
+check_command = "df -h /tmp | tail -1 | awk '{print \\$5}' | sed 's/%//' | awk '\\$1 < 80'"
 remediation = "echo 'WARN: /tmp usage above 80% — clean up: find /tmp -atime +1 -delete'"
 required = false
 vendor_datum = ""
 
 [[b00t.check]]
 name = "disk-usage-target"
-check_command = "test -d target && du -sh target/ 2>/dev/null | awk '{print \$1}' | grep -v '^[0-9]*G' || true"
+check_command = "test -d target && du -sh target/ 2>/dev/null | awk '{print \\$1}' | grep -v '^[0-9]*G' || true"
 remediation = "echo 'INFO: target/ dir may be large — consider `cargo clean` if >5G'"
 required = false
 vendor_datum = ""
 
 [[b00t.check]]
 name = "disk-usage-hermes-logs"
-check_command = "test -d .hermes/logs && du -sh .hermes/logs/ 2>/dev/null | awk '{print \$1}' | grep -v '^[0-9]*G' || true"
+check_command = "test -d .hermes/logs && du -sh .hermes/logs/ 2>/dev/null | awk '{print \\$1}' | grep -v '^[0-9]*G' || true"
 remediation = "echo 'INFO: .hermes/logs/ may be large — consider log rotation'"
 required = false
 vendor_datum = ""
@@ -274,7 +274,7 @@ vendor_datum = ""
 
 [[b00t.check]]
 name = "vendor-required-tools"
-check_command = "echo 'Checking vendor required_tools...' && for tool in rustc cargo python3 uv pip just git gh gcc make go podman docker biome; do command -v \"\$tool\" >/dev/null 2>&1 || echo \"MISSING: \$tool\"; done"
+check_command = "echo 'Checking vendor required_tools...' && for tool in rustc cargo python3 uv pip just git gh gcc make go podman docker biome; do command -v \"\\$tool\" >/dev/null 2>&1 || echo \"MISSING: \\$tool\"; done"
 remediation = "echo 'See individual tool remediations above — run `b00t-cli grok ask \"how to install missing b00t tool\"`'"
 required = true
 vendor_datum = ""

--- a/_b00t_/schema/MCP_REGISTRY.tomllmd
+++ b/_b00t_/schema/MCP_REGISTRY.tomllmd
@@ -24,30 +24,30 @@ content = "stable"
 ## These are NOT stored in this file — they are generated at query time.
 
 ### loaded — MCP servers currently active in ~/.hermes/config.yaml
-| field | type | source | description |
-|-------|------|--------|-------------|
-| name | string | config.yaml mcp_servers key | Server name |
-| command | string | config.yaml mcp_servers[].command | Executable path |
-| args | string[] | config.yaml mcp_servers[].args | CLI arguments |
-| transport | string | config.yaml | "stdio" or "sse" |
-| health | string | runtime check | "running", "stopped", "unknown" |
+# | field | type | source | description |
+# |-------|------|--------|-------------|
+# | name | string | config.yaml mcp_servers key | Server name |
+# | command | string | config.yaml mcp_servers[].command | Executable path |
+# | args | string[] | config.yaml mcp_servers[].args | CLI arguments |
+# | transport | string | config.yaml | "stdio" or "sse" |
+# | health | string | runtime check | "running", "stopped", "unknown" |
 
 ### installed — MCP server datums available in _b00t_/*.mcp.toml
-| field | type | source | description |
-|-------|------|--------|-------------|
-| name | string | TOML [b00t].name | Datum name |
-| hint | string | TOML [b00t].hint | Description |
-| command | string | b00t.mcp.stdio[].command | First transport command |
-| requires | string[] | TOML requires | Dependencies |
-| transport_count | u32 | count of b00t.mcp.stdio/b00t.mcp.http | Number of transport definitions |
+# | field | type | source | description |
+# |-------|------|--------|-------------|
+# | name | string | TOML [b00t].name | Datum name |
+# | hint | string | TOML [b00t].hint | Description |
+# | command | string | b00t.mcp.stdio[].command | First transport command |
+# | requires | string[] | TOML requires | Dependencies |
+# | transport_count | u32 | count of b00t.mcp.stdio/b00t.mcp.http | Number of transport definitions |
 
 ### available — servers in the registry index (discoverable but not installed)
-| field | type | source | description |
-|-------|------|--------|-------------|
-| name | string | registry index | Server name |
-| description | string | registry index | One-line description |
-| tags | string[] | registry index | Searchable tags |
-| install_command | string | inferred | How to install (npm/pip/cargo) |
+# | field | type | source | description |
+# |-------|------|--------|-------------|
+# | name | string | registry index | Server name |
+# | description | string | registry index | One-line description |
+# | tags | string[] | registry index | Searchable tags |
+# | install_command | string | inferred | How to install (npm/pip/cargo) |
 
 # b00t:map v1
 # summary: MCP registry schema — dynamic state of loaded/installed/available servers; sparse datum, function-driven

--- a/_b00t_/schema/SCHEDULER-SCHEMA.tomllmd
+++ b/_b00t_/schema/SCHEDULER-SCHEMA.tomllmd
@@ -25,66 +25,66 @@ content = "stable"
 # One row per scheduled job definition.  schedule_kind determines which timing
 # column(s) are active (interval_mins, cron_expr, or oneshot_at).
 
-```sql
-CREATE TABLE IF NOT EXISTS schedules (
-    id                    TEXT PRIMARY KEY,          -- sched_<uuid>
-    name                  TEXT NOT NULL,
-    description           TEXT DEFAULT '',
-    schedule_kind         TEXT NOT NULL CHECK(schedule_kind IN ('interval','cron','oneshot')),
-    interval_mins         INTEGER,                   -- for interval kind
-    cron_expr             TEXT,                      -- for cron kind (5-field cron)
-    oneshot_at            TEXT,                      -- for oneshot kind (ISO-8601)
-    max_runs              INTEGER DEFAULT -1,        -- -1 = unlimited
-    run_count             INTEGER DEFAULT 0,
-    required_capabilities TEXT,                      -- JSON array or NULL
-    required_agent        TEXT,                      -- specific agent ID or NULL
-    agent_type            TEXT DEFAULT 'llm',
-    agent_config          TEXT,                      -- JSON
-    prompt                TEXT NOT NULL,
-    command               TEXT,                      -- optional shell command
-    workdir               TEXT,                      -- optional working directory
-    enabled               INTEGER DEFAULT 1,         -- 1=active, 0=paused
-    created_at            TEXT NOT NULL,             -- ISO-8601
-    updated_at            TEXT                       -- ISO-8601
-);
-```
+# ```sql
+# CREATE TABLE IF NOT EXISTS schedules (
+#     id                    TEXT PRIMARY KEY,          -- sched_<uuid>
+#     name                  TEXT NOT NULL,
+#     description           TEXT DEFAULT '',
+#     schedule_kind         TEXT NOT NULL CHECK(schedule_kind IN ('interval','cron','oneshot')),
+#     interval_mins         INTEGER,                   -- for interval kind
+#     cron_expr             TEXT,                      -- for cron kind (5-field cron)
+#     oneshot_at            TEXT,                      -- for oneshot kind (ISO-8601)
+#     max_runs              INTEGER DEFAULT -1,        -- -1 = unlimited
+#     run_count             INTEGER DEFAULT 0,
+#     required_capabilities TEXT,                      -- JSON array or NULL
+#     required_agent        TEXT,                      -- specific agent ID or NULL
+#     agent_type            TEXT DEFAULT 'llm',
+#     agent_config          TEXT,                      -- JSON
+#     prompt                TEXT NOT NULL,
+#     command               TEXT,                      -- optional shell command
+#     workdir               TEXT,                      -- optional working directory
+#     enabled               INTEGER DEFAULT 1,         -- 1=active, 0=paused
+#     created_at            TEXT NOT NULL,             -- ISO-8601
+#     updated_at            TEXT                       -- ISO-8601
+# );
+# ```
 
 ## ── runs table ─────────────────────────────────────────────────────────────────
 # One row per execution attempt of a schedule.  Tracks lifecycle from claim
 # through completion or failure.
 
-```sql
-CREATE TABLE IF NOT EXISTS runs (
-    id            TEXT PRIMARY KEY,                -- run_<uuid>
-    schedule_id   TEXT NOT NULL REFERENCES schedules(id),
-    claimed_by    TEXT NOT NULL,                    -- agent ID that claimed this run
-    status        TEXT NOT NULL CHECK(status IN ('claimed','running','success','failed','timed_out','cancelled')),
-    started_at    TEXT,                             -- ISO-8601
-    finished_at   TEXT,                             -- ISO-8601
-    exit_code     INTEGER,
-    output_path   TEXT,                             -- path to captured output
-    summary       TEXT,                             -- short result summary
-    error         TEXT                              -- error message if failed
-);
+# ```sql
+# CREATE TABLE IF NOT EXISTS runs (
+#     id            TEXT PRIMARY KEY,                -- run_<uuid>
+#     schedule_id   TEXT NOT NULL REFERENCES schedules(id),
+#     claimed_by    TEXT NOT NULL,                    -- agent ID that claimed this run
+#     status        TEXT NOT NULL CHECK(status IN ('claimed','running','success','failed','timed_out','cancelled')),
+#     started_at    TEXT,                             -- ISO-8601
+#     finished_at   TEXT,                             -- ISO-8601
+#     exit_code     INTEGER,
+#     output_path   TEXT,                             -- path to captured output
+#     summary       TEXT,                             -- short result summary
+#     error         TEXT                              -- error message if failed
+# );
 
-CREATE INDEX IF NOT EXISTS idx_runs_schedule_id ON runs(schedule_id);
-CREATE INDEX IF NOT EXISTS idx_runs_status ON runs(status);
-```
+# CREATE INDEX IF NOT EXISTS idx_runs_schedule_id ON runs(schedule_id);
+# CREATE INDEX IF NOT EXISTS idx_runs_status ON runs(status);
+# ```
 
 ## ── agents table ───────────────────────────────────────────────────────────────
 # Registry of scheduler-aware agents available for job dispatch.
 
-```sql
-CREATE TABLE IF NOT EXISTS agents (
-    id              TEXT PRIMARY KEY,
-    agent_type      TEXT,
-    status          TEXT DEFAULT 'offline' CHECK(status IN ('online','offline','busy','error')),
-    capabilities    TEXT DEFAULT '[]',              -- JSON array
-    label           TEXT,
-    last_heartbeat  TEXT,                           -- ISO-8601
-    current_job_id  TEXT,                           -- run ID currently assigned
-    metadata        TEXT                            -- arbitrary JSON
-);
+# ```sql
+# CREATE TABLE IF NOT EXISTS agents (
+#     id              TEXT PRIMARY KEY,
+#     agent_type      TEXT,
+#     status          TEXT DEFAULT 'offline' CHECK(status IN ('online','offline','busy','error')),
+#     capabilities    TEXT DEFAULT '[]',              -- JSON array
+#     label           TEXT,
+#     last_heartbeat  TEXT,                           -- ISO-8601
+#     current_job_id  TEXT,                           -- run ID currently assigned
+#     metadata        TEXT                            -- arbitrary JSON
+# );
 
-CREATE INDEX IF NOT EXISTS idx_agents_status ON agents(status);
-```
+# CREATE INDEX IF NOT EXISTS idx_agents_status ON agents(status);
+# ```


### PR DESCRIPTION
Closes task #115.

## Problem

`b00t-lsp --check` reported 45 TOML parse errors across 45 `.toml`/`.tomllmd` files under `_b00t_/`.

## Root causes

**35 files (Pattern A)**: `.tomllmd` files had valid TOML frontmatter followed by a Markdown prose section. Per this repo's `.tomllmd` convention, prose must be `#`-commented — only section-header lines (`#`/`##`/`###`) happened to already start with `#`, but the paragraph text under them didn't, breaking the TOML parser. Fixed by comment-prefixing the affected prose ranges (frontmatter left untouched). Two needed a narrower range than "to EOF" since real TOML sections followed the broken prose.

**7 one-off syntax bugs**: `closes_task = null` (TOML has no null literal), invalid `\.`/`\$` escapes inside basic strings, YAML dash-lists and JSON-style objects mixed into TOML tables, C-style `// comment`s.

**8 Pattern-B files**: files like `DARED.tomllmd`, `josh.tomllmd`, `gitbutler.tomllmd` etc. were YAML-frontmatter Markdown (like a skill file), not TOML at all. No equivalent correctly-formatted datum exists elsewhere for any of these topics, so each was converted in place to proper `[b00t]`/`[b00t.metadata]` TOML + comment-prose, preserving body content byte-for-byte (verified via line-by-line de-comment diff against the original).

**Follow-up fix**: resolving the parse errors surfaced a previously-hidden dangling reference in `DARED.tomllmd` (`depends_on = ["ufo-types-crate-511"]`, missing the `.skill` suffix) — fixed using the validator's own suggestion.

All edits made via `b00t-cli patch apply <file> - --yes` (diff-before-write), never sed, per this repo's datum-editing convention.

## Verification

```
b00t-lsp --check: 701 files, 45 errors, 51 warnings  ->  701 files, 0 errors, 68 warnings
```
(warning increase is pre-existing tail-map-incomplete warnings now surfaced on files that previously failed to parse at all — out of scope for this task, which targets parse errors only)

```
$ b00t-cli datum validate --graph
datum graph: valid (673 datums)
```

`b00t-cli task done 115` recorded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)