### PR TITLE
feat(agent-doctor): BD-002..005 — probe, fix, register, wire

### DIFF
--- a/_b00t_/b00t.just
+++ b/_b00t_/b00t.just
@@ -429,3 +429,16 @@ slash-b00t:
     #!/usr/bin/env bash
     set -euo pipefail
     bash _b00t_/scripts/slash-b00t.sh
+
+# ─── Agent-Doctor (BD-001..005) ──────────────────────────────────────────────
+# Census + probe + fix + register for _b00t_/*.agent.toml local-inference agents.
+# See docs/hive-resilience-wiki/Agent-Doctor.md
+
+agent-doctor:
+    ./scripts/b00t-agent-doctor.py --check
+
+agent-doctor-fix:
+    ./scripts/b00t-agent-doctor.py --check --fix
+
+agent-register:
+    ./scripts/b00t-agent-doctor.py --check --register

--- a/_b00t_/eureka-analyzer.agent.toml
+++ b/_b00t_/eureka-analyzer.agent.toml
@@ -19,6 +19,13 @@ tools = ["codebase-memory.mcp", "b00t-mcp.mcp"]
 skills = ["multi-framework-code-review"]
 # 🤓 multi-framework-code-review skill routes to Eureka phase when loaded by this agent
 
+[b00t.agent.inference]
+endpoint = "http://127.0.0.1:8001/v1"   # OpenAI-compatible base
+health   = "http://127.0.0.1:8001/health"
+model    = "qwen36-local/ch0nky"
+protocol = "openai"                      # openai | acp | rpc
+required = true                          # false ⇒ Claude-backed / stub ⇒ doctor SKIPs
+
 [b00t.agent.crew]
 role = "specialist"
 captain = false

--- a/_b00t_/executive.agent.toml
+++ b/_b00t_/executive.agent.toml
@@ -23,6 +23,13 @@ personality = "strategic"
 humor = "low"
 role = "executive"
 
+[b00t.agent.inference]
+endpoint = "http://127.0.0.1:8001/v1"   # OpenAI-compatible base
+health   = "http://127.0.0.1:8001/health"
+model    = "claude-sonnet-4-6"
+protocol = "openai"                      # openai | acp | rpc
+required = true                          # false ⇒ Claude-backed / stub ⇒ doctor SKIPs
+
 [b00t.agent.ipc]
 socket = "/tmp/b00t/agents/executive.sock"
 pubsub = true

--- a/_b00t_/gh-issues.agent.toml
+++ b/_b00t_/gh-issues.agent.toml
@@ -24,6 +24,13 @@ personality = "curious"
 humor = "low"
 role = "specialist"
 
+[b00t.agent.inference]
+endpoint = "http://127.0.0.1:8001/v1"   # OpenAI-compatible base
+health   = "http://127.0.0.1:8001/health"
+model    = "frontier"
+protocol = "openai"                      # openai | acp | rpc
+required = true                          # false ⇒ Claude-backed / stub ⇒ doctor SKIPs
+
 [b00t.agent.executor]
 # 🤓 This agent runs within opencode (not standalone). The CLI path is for
 #    direct invocation during backlog sweeps. Prefer opencode + skill route.

--- a/_b00t_/hermes.agent.toml
+++ b/_b00t_/hermes.agent.toml
@@ -18,6 +18,13 @@ pid = "hermes-001"
 skills = ["chat", "tools", "mcp", "gateway"]
 role = "specialist"
 
+[b00t.agent.inference]
+endpoint = "http://127.0.0.1:8001/v1"   # OpenAI-compatible base
+health   = "http://127.0.0.1:8001/health"
+model    = "qwen36-local/ch0nky"
+protocol = "openai"                      # openai | acp | rpc
+required = true                          # false ⇒ Claude-backed / stub ⇒ doctor SKIPs
+
 [b00t.agent.ipc]
 # 🤓 hermes MCP server is stdio-transport only (no port flags) — see hermes.mcp.toml
 protocol = "mcp+stdio"

--- a/_b00t_/mece-analyzer.agent.toml
+++ b/_b00t_/mece-analyzer.agent.toml
@@ -19,6 +19,13 @@ tools = ["codebase-memory.mcp", "b00t-mcp.mcp"]
 skills = ["multi-framework-code-review"]
 # 🤓 multi-framework-code-review skill routes to MECE phase when loaded by this agent
 
+[b00t.agent.inference]
+endpoint = "http://127.0.0.1:8001/v1"   # OpenAI-compatible base
+health   = "http://127.0.0.1:8001/health"
+model    = "qwen36-local/ch0nky"
+protocol = "openai"                      # openai | acp | rpc
+required = true                          # false ⇒ Claude-backed / stub ⇒ doctor SKIPs
+
 [b00t.agent.crew]
 role = "specialist"
 captain = false

--- a/_b00t_/moltis.agent.toml
+++ b/_b00t_/moltis.agent.toml
@@ -29,6 +29,13 @@ personality = "pragmatic"
 humor = "low"
 role = "specialist"
 
+[b00t.agent.inference]
+endpoint = "http://127.0.0.1:8001/v1"   # OpenAI-compatible base
+health   = "http://127.0.0.1:8001/health"
+model    = "ch0nky"
+protocol = "openai"                      # openai | acp | rpc
+required = true                          # false ⇒ Claude-backed / stub ⇒ doctor SKIPs
+
 [b00t.agent.executor]
 # 🤓 binary is built from submodule; not on global PATH until installed
 cli_path = "vendor/moltis-b00t/target/release/moltis"

--- a/_b00t_/opencode.agent.toml
+++ b/_b00t_/opencode.agent.toml
@@ -25,6 +25,13 @@ personality = "pragmatic"
 humor = "low"
 role = "specialist"
 
+[b00t.agent.inference]
+endpoint = "http://127.0.0.1:8001/v1"   # OpenAI-compatible base
+health   = "http://127.0.0.1:8001/health"
+model    = "qwen36-local/ch0nky"
+protocol = "openai"                      # openai | acp | rpc
+required = true                          # false ⇒ Claude-backed / stub ⇒ doctor SKIPs
+
 [b00t.agent.ipc]
 # 🤓 opencode ACP server listens on HTTP :3000; tasks submitted via opencode run --attach or HTTP
 socket = "/tmp/b00t/agents/opencode.sock"
@@ -74,7 +81,7 @@ service_type = "simple"
 restart = "on-failure"
 restart_sec = "10s"
 timeout_start_sec = "60"
-after = ["network.target", "b00t-hive-inference-qwen36-27b.service"]
+after = ["network.target", "b00t-hive-inference-qwen36-27b-mtp-podman.service"]
 environment = [
   "PATH=/home/brianh/.opencode/bin:/home/brianh/.bun/bin:/home/brianh/.local/bin:/home/brianh/.nvm/versions/node/v22.15.1/bin:/usr/local/bin:/usr/bin:/bin",
   "OPENCODE_CONFIG=/home/brianh/.config/opencode/opencode.json",

--- a/_b00t_/pi.agent.toml
+++ b/_b00t_/pi.agent.toml
@@ -32,6 +32,13 @@ personality = "pragmatic"
 humor = "low"
 role = "specialist"
 
+[b00t.agent.inference]
+endpoint = "http://127.0.0.1:8001/v1"   # OpenAI-compatible base
+health   = "http://127.0.0.1:8001/health"
+model    = "ch0nky"
+protocol = "openai"                      # openai | acp | rpc
+required = true                          # false ⇒ Claude-backed / stub ⇒ doctor SKIPs
+
 [b00t.agent.executor]
 # 🤓 cli_path must be on PATH; pi --mode rpc is the persistent path; this is one-shot fallback via handle_invoke
 cli_path = "pi"

--- a/_b00t_/sm3lly-acp.agent.toml
+++ b/_b00t_/sm3lly-acp.agent.toml
@@ -17,6 +17,13 @@ skills = ["compile", "test", "install", "long-session", "ch0nky-code", "nats-acp
 personality = "laconic"
 role = "specialist"
 
+[b00t.agent.inference]
+endpoint = "http://127.0.0.1:8001/v1"   # OpenAI-compatible base
+health   = "http://127.0.0.1:8001/health"
+model    = "qwen36/ch0nky"
+protocol = "openai"                      # openai | acp | rpc
+required = true                          # false ⇒ Claude-backed / stub ⇒ doctor SKIPs
+
 [b00t.agent.ipc]
 protocol = "nats+acp"
 pubsub = true

--- a/_b00t_/synthesis-agent.agent.toml
+++ b/_b00t_/synthesis-agent.agent.toml
@@ -20,6 +20,13 @@ tools = ["b00t-mcp.mcp", "github.mcp"]
 skills = ["multi-framework-code-review"]
 # 🤓 multi-framework-code-review skill routes to Synthesis phase when loaded by this agent
 
+[b00t.agent.inference]
+endpoint = "http://127.0.0.1:8001/v1"   # OpenAI-compatible base
+health   = "http://127.0.0.1:8001/health"
+model    = "qwen36-local/ch0nky"
+protocol = "openai"                      # openai | acp | rpc
+required = true                          # false ⇒ Claude-backed / stub ⇒ doctor SKIPs
+
 [b00t.agent.crew]
 role = "specialist"
 captain = false

--- a/_b00t_/triz-analyzer.agent.toml
+++ b/_b00t_/triz-analyzer.agent.toml
@@ -19,6 +19,13 @@ tools = ["codebase-memory.mcp", "context7.mcp"]
 skills = ["systematic-debugging", "multi-framework-code-review"]
 # 🤓 multi-framework-code-review skill routes to TRIZ phase when loaded by this agent
 
+[b00t.agent.inference]
+endpoint = "http://127.0.0.1:8001/v1"   # OpenAI-compatible base
+health   = "http://127.0.0.1:8001/health"
+model    = "qwen36-local/ch0nky"
+protocol = "openai"                      # openai | acp | rpc
+required = true                          # false ⇒ Claude-backed / stub ⇒ doctor SKIPs
+
 [b00t.agent.crew]
 role = "specialist"
 captain = false

--- a/scripts/b00t-agent-doctor.py
+++ b/scripts/b00t-agent-doctor.py
@@ -1,13 +1,45 @@
 #!/usr/bin/env python3
-"""b00t-agent-doctor — census of _b00t_/*.agent.toml agents, health-check local ones."""
-import argparse, json, pathlib, re, sys, tomllib, urllib.request
+"""b00t-agent-doctor — census of _b00t_/*.agent.toml agents, health-check
+local ones, and (optionally) fix + register them.
+
+BD-001 (census)  : classify each agent local/claude/stub, print PASS|FAIL|SKIP.
+BD-002 (probe)   : prefer the structured [b00t.agent.inference] block when an
+                   agent declares one — GET health + POST a 1-token completion.
+BD-003 (fix)     : --fix injects the standard inference block into agents that
+                   classify as local-inference but lack one, and rewrites the
+                   stale `inference-qwen36-27b.service` unit name.
+BD-004 (register): --register nats-pubs a presence message for each PASS agent.
+"""
+import argparse
+import datetime as dt
+import json
+import os
+import pathlib
+import re
+import shutil
+import subprocess
+import sys
+import tomllib
+import urllib.request
 
 HEALTH_URL = "http://127.0.0.1:8001/health"
-TIMEOUT = 2  # seconds
+TIMEOUT = 2  # seconds, GET
+COMPLETION_TIMEOUT = 3  # seconds, POST
+
+STALE_SERVICE = "inference-qwen36-27b.service"
+STALE_SERVICE_FIXED = "inference-qwen36-27b-mtp-podman.service"
+STALE_SERVICE_RE = re.compile(re.escape(STALE_SERVICE))
+
+NATS_SUBJECT = "b00t.hive.mesh.discovery.presence"
+NATS_SECRETS_FILE = pathlib.Path.home() / ".b00t" / "secrets" / "hive-nats.env"
 
 
 def classify(text: str, name: str) -> str:
-    """Classify an agent as local, claude, or stub from its TOML text."""
+    """Classify an agent as local, claude, or stub from its TOML text.
+
+    This is the BD-001 heuristic — kept as the fallback path for agents that
+    do not (yet) declare a [b00t.agent.inference] block (see BD-003 --fix).
+    """
     # local: ch0nky or qwen anywhere, or hive_profile starts with inference-,
     # or a model= line containing local/ch0nky or local/sm0l
     if "ch0nky" in text or "qwen" in text:
@@ -23,18 +55,257 @@ def classify(text: str, name: str) -> str:
     return "stub"
 
 
-def health_check() -> str:
+def get_inference_block(data: dict):
+    """Return the [b00t.agent.inference] table if present, else None."""
+    return data.get("b00t", {}).get("agent", {}).get("inference")
+
+
+def http_get_ok(url: str, timeout: float = TIMEOUT) -> bool:
+    if not url:
+        return False
     try:
-        resp = urllib.request.urlopen(HEALTH_URL, timeout=TIMEOUT)
-        return "PASS" if resp.status == 200 else "FAIL"
+        resp = urllib.request.urlopen(url, timeout=timeout)
+        return resp.status == 200
     except Exception:
-        return "FAIL"
+        return False
+
+
+def health_check(url: str = HEALTH_URL) -> str:
+    return "PASS" if http_get_ok(url) else "FAIL"
+
+
+def probe_completion(endpoint: str, model: str, protocol: str, timeout: float = COMPLETION_TIMEOUT) -> bool:
+    """POST a 1-token completion request. True on a 2xx response.
+
+    Only `protocol = "openai"` is implemented against the real
+    /chat/completions wire contract. acp/rpc agents have no documented
+    minimal-completion shape yet, so their completion probe is a no-op
+    (verdict then rests on the health GET alone) rather than a guess.
+    """
+    if not endpoint:
+        return False
+    if protocol != "openai":
+        return True
+    url = endpoint.rstrip("/") + "/chat/completions"
+    body = json.dumps(
+        {
+            "model": model or "unknown",
+            "messages": [{"role": "user", "content": "ping"}],
+            "max_tokens": 1,
+        }
+    ).encode("utf-8")
+    req = urllib.request.Request(
+        url, data=body, headers={"Content-Type": "application/json"}, method="POST"
+    )
+    try:
+        resp = urllib.request.urlopen(req, timeout=timeout)
+        return 200 <= resp.status < 300
+    except Exception:
+        return False
+
+
+def pick_model(text: str) -> str:
+    """Reuse an existing top-level model = "..." line, else the default local slot."""
+    m = re.search(r'^\s*model\s*=\s*"([^"]+)"', text, re.MULTILINE)
+    if m:
+        return m.group(1)
+    return "qwen36-local/ch0nky"
+
+
+def inject_inference_block(text: str, model: str) -> str:
+    """Insert the standard [b00t.agent.inference] block right after [b00t.agent],
+    before whatever table follows it (mirrors the phi5-shacl.agent.toml convention).
+    Falls back to inserting before the tail-map comment, else EOF, when there is
+    no [b00t.agent] table to anchor on.
+    """
+    had_trailing_newline = text.endswith("\n")
+    lines = text.splitlines()
+
+    block = [
+        "[b00t.agent.inference]",
+        'endpoint = "http://127.0.0.1:8001/v1"   # OpenAI-compatible base',
+        'health   = "http://127.0.0.1:8001/health"',
+        f'model    = "{model}"',
+        'protocol = "openai"                      # openai | acp | rpc',
+        "required = true                          # false ⇒ Claude-backed / stub ⇒ doctor SKIPs",
+    ]
+
+    header_idx = None
+    for i, line in enumerate(lines):
+        if line.strip() == "[b00t.agent]":
+            header_idx = i
+            break
+
+    if header_idx is not None:
+        insert_at = len(lines)
+        for i in range(header_idx + 1, len(lines)):
+            if re.match(r"^\[\S", lines[i]):
+                insert_at = i
+                break
+    else:
+        insert_at = len(lines)
+        for i, line in enumerate(lines):
+            if line.strip() == "# b00t:map v1":
+                insert_at = i
+                break
+
+    prefix = lines[:insert_at]
+    while prefix and prefix[-1].strip() == "":
+        prefix.pop()
+    suffix = lines[insert_at:]
+
+    new_lines = prefix + [""] + block + [""] + suffix
+    out = "\n".join(new_lines)
+    return out + "\n" if had_trailing_newline else out
+
+
+def fix_stale_service(text: str):
+    """Rewrite the stale inference-qwen36-27b.service ref inside an
+    after = [...] line. Returns the new text, or None if nothing matched."""
+    lines = text.splitlines()
+    changed = False
+    for i, line in enumerate(lines):
+        if re.match(r"^\s*after\s*=", line) and STALE_SERVICE_RE.search(line):
+            lines[i] = STALE_SERVICE_RE.sub(STALE_SERVICE_FIXED, line)
+            changed = True
+    if not changed:
+        return None
+    had_trailing_newline = text.endswith("\n")
+    out = "\n".join(lines)
+    return out + "\n" if had_trailing_newline else out
+
+
+def apply_patch(fpath: pathlib.Path, content: str) -> bool:
+    """Write content to fpath via `b00t-cli patch apply <file> - --yes`
+    (never sed/direct write for datum files — see repo CLAUDE.md)."""
+    try:
+        proc = subprocess.run(
+            ["b00t-cli", "patch", "apply", str(fpath), "-", "--yes"],
+            input=content,
+            text=True,
+            capture_output=True,
+            timeout=15,
+        )
+    except FileNotFoundError:
+        print(f"FIX-SKIP {fpath.name}: b00t-cli not found on PATH", file=sys.stderr)
+        return False
+    except Exception as e:
+        print(f"FIX-FAIL {fpath.name}: {e}", file=sys.stderr)
+        return False
+    if proc.returncode != 0:
+        print(f"FIX-FAIL {fpath.name}: {proc.stderr.strip() or proc.stdout.strip()}", file=sys.stderr)
+        return False
+    print(f"FIXED {fpath.name}")
+    return True
+
+
+def run_fix(agents: list[pathlib.Path]) -> None:
+    for fpath in agents:
+        text = fpath.read_text()
+        try:
+            data = tomllib.loads(text)
+        except Exception as e:
+            print(f"FIX-SKIP {fpath.name}: TOML parse error: {e}", file=sys.stderr)
+            continue
+
+        name = data.get("b00t", {}).get("name", fpath.stem.replace(".agent", ""))
+        working = text
+        touched = False
+
+        # 1. inject the standard inference block into local-inference agents that lack one
+        if get_inference_block(data) is None and classify(text, name) == "local":
+            model = pick_model(text)
+            candidate = inject_inference_block(working, model)
+            try:
+                tomllib.loads(candidate)
+            except Exception as e:
+                print(f"FIX-SKIP {fpath.name}: injected block would break TOML: {e}", file=sys.stderr)
+            else:
+                working = candidate
+                touched = True
+
+        # 2. rewrite the stale inference-qwen36-27b.service unit reference
+        stale_fixed = fix_stale_service(working)
+        if stale_fixed is not None:
+            working = stale_fixed
+            touched = True
+
+        if touched:
+            apply_patch(fpath, working)
+
+
+def load_nats_creds():
+    """B00T_HIVE_NATS_USER / B00T_HIVE_NATS_PASSWORD from the environment,
+    optionally sourced from ~/.b00t/secrets/hive-nats.env first. Never a
+    hardcoded fallback."""
+    user = os.environ.get("B00T_HIVE_NATS_USER")
+    password = os.environ.get("B00T_HIVE_NATS_PASSWORD")
+    if user and password:
+        return user, password
+
+    if NATS_SECRETS_FILE.exists():
+        env = {}
+        try:
+            for line in NATS_SECRETS_FILE.read_text().splitlines():
+                line = line.strip()
+                if not line or line.startswith("#") or "=" not in line:
+                    continue
+                k, _, v = line.partition("=")
+                env[k.strip()] = v.strip().strip('"').strip("'")
+        except Exception:
+            env = {}
+        user = user or env.get("B00T_HIVE_NATS_USER")
+        password = password or env.get("B00T_HIVE_NATS_PASSWORD")
+
+    return user, password
+
+
+def run_register(results: list[dict]) -> None:
+    if shutil.which("nats") is None:
+        print("SKIP register: `nats` CLI not found on PATH", file=sys.stderr)
+        return
+
+    user, password = load_nats_creds()
+    if not user or not password:
+        print(
+            "SKIP register: B00T_HIVE_NATS_USER/B00T_HIVE_NATS_PASSWORD not set "
+            "(env or ~/.b00t/secrets/hive-nats.env)",
+            file=sys.stderr,
+        )
+        return
+
+    for r in results:
+        if r["verdict"] != "PASS":
+            continue
+        payload = {
+            "agent_id": r["name"],
+            "endpoint": r.get("endpoint"),
+            "model": r.get("model"),
+            "ts": dt.datetime.now(dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        }
+        cmd = [
+            "nats",
+            "--user", user,
+            "--password", password,
+            "pub", NATS_SUBJECT, json.dumps(payload),
+        ]
+        try:
+            proc = subprocess.run(cmd, capture_output=True, text=True, timeout=5)
+        except Exception as e:
+            print(f"REGISTER-SKIP {r['name']}: nats pub failed to run: {e}", file=sys.stderr)
+            continue
+        if proc.returncode != 0:
+            print(f"REGISTER-SKIP {r['name']}: {proc.stderr.strip() or proc.stdout.strip()}", file=sys.stderr)
+        else:
+            print(f"REGISTERED {r['name']}")
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Agent-Doctor census")
+    parser = argparse.ArgumentParser(description="Agent-Doctor census + probe + fix + register")
     parser.add_argument("--check", action="store_true", default=True, help="Run health checks (default)")
     parser.add_argument("--json", action="store_true", help="Emit JSON array instead of TSV")
+    parser.add_argument("--fix", action="store_true", help="Inject missing [b00t.agent.inference] blocks + fix stale service refs")
+    parser.add_argument("--register", action="store_true", help="nats-pub presence for every PASS agent")
     args = parser.parse_args()
 
     base = pathlib.Path(__file__).resolve().parent.parent / "_b00t_"
@@ -43,6 +314,10 @@ def main():
         print("No .agent.toml files found.", file=sys.stderr)
         sys.exit(0)
 
+    if args.fix:
+        run_fix(agents)
+        agents = sorted(base.glob("*.agent.toml"))
+
     results = []
     any_fail = False
     for fpath in agents:
@@ -50,21 +325,53 @@ def main():
         data = tomllib.loads(text)
         name = data.get("b00t", {}).get("name", fpath.stem.replace(".agent", ""))
         cls = classify(text, name)
+        inf = get_inference_block(data)
+        endpoint = None
+        model = None
 
-        if cls == "local":
-            verdict = health_check()
-            if verdict == "FAIL":
-                any_fail = True
+        if inf is not None:
+            source = "block"
+            required = inf.get("required", True)
+            if not required:
+                verdict = "SKIP"
+            else:
+                endpoint = inf.get("endpoint")
+                health = inf.get("health")
+                model = inf.get("model")
+                protocol = inf.get("protocol", "openai")
+                ok = http_get_ok(health) and probe_completion(endpoint, model, protocol)
+                verdict = "PASS" if ok else "FAIL"
+                if verdict == "FAIL":
+                    any_fail = True
         else:
-            verdict = "SKIP"
+            source = "heuristic"
+            if cls == "local":
+                verdict = health_check()
+                endpoint = "http://127.0.0.1:8001/v1"
+                if verdict == "FAIL":
+                    any_fail = True
+            else:
+                verdict = "SKIP"
 
-        results.append({"name": name, "class": cls, "verdict": verdict})
+        results.append(
+            {
+                "name": name,
+                "class": cls,
+                "verdict": verdict,
+                "source": source,
+                "endpoint": endpoint,
+                "model": model,
+            }
+        )
+
+    if args.register:
+        run_register(results)
 
     if args.json:
         print(json.dumps(results))
     else:
         for r in results:
-            print(f"{r['name']}\t{r['class']}\t{r['verdict']}")
+            print(f"{r['name']}\t{r['class']}\t{r['verdict']}\t{r['source']}")
 
     sys.exit(1 if any_fail else 0)
 


### PR DESCRIPTION
Completes deliverable B of the hive-resilience wiki (`docs/hive-resilience-wiki/Agent-Doctor.md`). BD-001 (census/`--check` table) shipped on main via #1253.

## What shipped

**BD-002 (Probe)**: `--check` now reads `[b00t.agent.inference]` directly when present (endpoint/health/model/protocol/required) and does a real GET on `health` + POST of a 1-token `/chat/completions` request for `protocol="openai"`. `required=false` → SKIP unconditionally. Falls back to the old text-heuristic classifier only when no block exists.

**BD-003 (Fix)**: `--fix` injects the standard `[b00t.agent.inference]` block (via `b00t-cli patch apply <file> - --yes`) into any agent classified `local` but lacking a block, reusing an existing `model = "..."` line when present. Also rewrites the stale `inference-qwen36-27b.service` string in `after = [...]` arrays to `...-mtp-podman.service`.

**BD-004 (Register)**: `--register` nats-pubs `{agent_id, endpoint, model, ts}` to `b00t.hive.mesh.discovery.presence` for every PASS agent, reading creds from `B00T_HIVE_NATS_USER`/`B00T_HIVE_NATS_PASSWORD` env (optionally sourced from `~/.b00t/secrets/hive-nats.env`) — never hardcoded. Missing `nats` binary / missing creds / unreachable broker all degrade to a clean per-agent SKIP.

**BD-005 (Wire)**: added `agent-doctor`, `agent-doctor-fix`, `agent-register` recipes to `_b00t_/b00t.just` as thin command surfaces.

Diff: `scripts/b00t-agent-doctor.py` 73→380 lines; 11 `_b00t_/*.agent.toml` files gained an inference block; `_b00t_/b00t.just` +13 lines.

## Verification

Real endpoint at :8001 in the dev sandbox: baseline `--check` (11 PASS via old GET-only path) → `--fix --check` (11 files FIXED, all flip to `source=block` and PASS via the new GET+POST probe) → re-running `--fix` is a no-op (idempotent) → `tomllib` re-parses all 20 `.agent.toml` files clean → `b00t-cli datum validate --graph` valid → `just b00t agent-doctor`/`agent-doctor-fix` both exit 0.

`--register` verified structurally (no creds / no `nats` binary / unreachable broker) — each degrades cleanly to SKIP without crashing; not verified against the live shared NATS bus per instructions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)