### PR TITLE
fix(container): include pgduck in CLI workspace build stages

### DIFF
--- a/Dockerfile.b00t-cli
+++ b/Dockerfile.b00t-cli
@@ -182,6 +182,9 @@ FROM scratch AS b00t-resources
 # Copy _b00t_ configuration files and resources (datums, scripts, templates)
 # Includes: *.toml datums, scripts/, learn/, datum directories (bash.🐚, docker.🐳, etc.)
 COPY _b00t_/ /opt/b00t/config/
+# _b00t_/AGENT.md points at ../AGENTS.md; package its target alongside the
+# config tree so the symlink remains usable in the runtime image.
+COPY AGENTS.md /opt/b00t/AGENTS.md
 
 # ================================
 # Stage 5: b00t-cli Distribution Layer

--- a/Dockerfile.b00t-cli
+++ b/Dockerfile.b00t-cli
@@ -71,6 +71,7 @@ COPY b00t-lsp/ ./b00t-lsp/
 COPY b00t-mcp/ ./b00t-mcp/
 COPY b00t-mcp-npm/ ./b00t-mcp-npm/
 COPY b00t-mermaid-wasm/ ./b00t-mermaid-wasm/
+COPY b00t-pgduck/ ./b00t-pgduck/
 COPY b00t-pyverse/ ./b00t-pyverse/
 COPY b00t-stt-serve/ ./b00t-stt-serve/
 COPY b00t-ui-wasm/ ./b00t-ui-wasm/
@@ -147,6 +148,7 @@ COPY b00t-lsp/ ./b00t-lsp/
 COPY b00t-mcp/ ./b00t-mcp/
 COPY b00t-mcp-npm/ ./b00t-mcp-npm/
 COPY b00t-mermaid-wasm/ ./b00t-mermaid-wasm/
+COPY b00t-pgduck/ ./b00t-pgduck/
 COPY b00t-pyverse/ ./b00t-pyverse/
 COPY b00t-stt-serve/ ./b00t-stt-serve/
 COPY b00t-ui-wasm/ ./b00t-ui-wasm/


### PR DESCRIPTION
The b00t-cli container build fails in `cargo chef prepare` because the workspace now includes `b00t-pgduck`, but neither source-copy stage includes its manifest. Copy that member into both the planner and builder stages.

Reproduced from main's failed [container publication run](https://github.com/elasticdotventures/_b00t_/actions/runs/33931200158): `failed to read /build/b00t-pgduck/Cargo.toml`.

Validation:
- Before the fix, checking both stage COPY lists against Cargo.toml identifies b00t-pgduck as the sole missing member.
- After the fix: `PASS: planner copies all 35 workspace members` and `PASS: rust-builder copies all 35 workspace members`.
- `git diff --check` and commit hook passed (`14/14 rules passed`).
- Full container compilation/publication has not been rerun. Kept draft pending that validation; the existing published image remains pinned on the WSL workstation.
