### PR TITLE
fix(container): include AGENTS.md in Docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,7 @@
 .git/
 .github/
 *.md
+!AGENTS.md
 !README.md
 
 # Build artifacts


### PR DESCRIPTION
The previous container fix added `COPY AGENTS.md`, but `.dockerignore` excludes `*.md`, causing the post-merge build to fail with `/AGENTS.md not found`. Add the explicit negation so the tracked root identity file is available to BuildKit.\n\nValidation: commit hook 14/14; build workflow failure reproduced from run 33936044670. Awaiting CI.