### PR TITLE
fix(b00t-mcp): soul_table_create silently dropped columns; soul_row_insert schema mismatch

### DIFF
--- a/b00t-cli/src/commands/soul.rs
+++ b/b00t-cli/src/commands/soul.rs
@@ -1730,4 +1730,106 @@ mod shard_tests {
         // Deleting again is a no-op, not an error.
         df_shard_delete(&scope).unwrap();
     }
+
+    /// End-to-end regression test for the reported `soul table-create` /
+    /// `soul frame-insert` bug (surfaced via the b00t-mcp `soul_table_create`
+    /// tool creating zero-column tables): a table created with a
+    /// multi-column spec must register EVERY declared column (not zero), and
+    /// rows inserted afterwards must persist and round-trip EVERY inserted
+    /// field (not just the auto `id`/`created_at`). Exercises the exact
+    /// command-handler functions the CLI dispatches to (`df_table_create`,
+    /// `df_frame_insert`) with the same table/column/field shapes from the
+    /// original bug report, going through real TOML save+reload — not just
+    /// the lower-level `SoulDataFramerr` struct (which already had its own
+    /// unit tests and was never the bug).
+    #[test]
+    fn table_create_with_columns_then_frame_insert_roundtrips_all_fields() {
+        let _home = TempHome::new();
+        let scope = SoulScope::new(ShardKind::Agent, "provider-rank-repro");
+
+        let column_specs = [
+            "task:text",
+            "provider:text",
+            "model:text",
+            "rank:int?",
+            "status:text",
+            "evidence:text",
+            "recorded_at:timestamp",
+        ];
+        df_table_create(
+            "provider_task_rank",
+            &column_specs.iter().map(|s| s.to_string()).collect::<Vec<_>>(),
+            Some(scope.clone()),
+        )
+        .unwrap();
+
+        // Bug 1: table-create must register ALL declared columns, not zero.
+        let doc = load_soul_doc_scoped(Some(&scope)).unwrap();
+        let reg = load_registry(&doc).unwrap();
+        let table = reg.tables.get("provider_task_rank").unwrap();
+        assert_eq!(
+            table.columns.len(),
+            column_specs.len(),
+            "all declared columns must be registered — got: {:?}",
+            table.columns
+        );
+        let names: Vec<&str> = table.columns.iter().map(|c| c.name.as_str()).collect();
+        assert_eq!(
+            names,
+            vec!["task", "provider", "model", "rank", "status", "evidence", "recorded_at"]
+        );
+
+        // Insert 5 rows, mirroring the original bug report's repro shape.
+        for i in 0..5 {
+            let model = if i % 2 == 0 {
+                "apac.amazon.nova-pro-v1:0"
+            } else {
+                "apac.amazon.nova-lite-v1:0"
+            };
+            df_frame_insert(
+                "provider_task_rank",
+                &[
+                    "task=rust_codegen".to_string(),
+                    "provider=bedrock".to_string(),
+                    format!("model={model}"),
+                    "rank=0".to_string(),
+                    "status=flopped".to_string(),
+                    format!("evidence=run-{i}"),
+                    "recorded_at=2026-09-05T12:46:00Z".to_string(),
+                ],
+                Some(scope.clone()),
+            )
+            .unwrap();
+        }
+
+        // Bug 2: every inserted field must persist and round-trip — not just
+        // id/created_at. This is downstream of bug 1: frame-dump renders
+        // columns from `df.columns`, so it only ever showed anything once
+        // that list stopped being empty.
+        let doc = load_soul_doc_scoped(Some(&scope)).unwrap();
+        let reg = load_registry(&doc).unwrap();
+        let table = reg.tables.get("provider_task_rank").unwrap();
+        assert_eq!(table.rows.len(), 5);
+        assert_eq!(table.columns.len(), column_specs.len());
+
+        let row = &table.rows[0];
+        assert_eq!(row.id, 1);
+        assert_eq!(row.fields.get("task"), Some(&SoulValue::Text("rust_codegen".into())));
+        assert_eq!(row.fields.get("provider"), Some(&SoulValue::Text("bedrock".into())));
+        assert_eq!(
+            row.fields.get("model"),
+            Some(&SoulValue::Text("apac.amazon.nova-pro-v1:0".into()))
+        );
+        assert_eq!(row.fields.get("rank"), Some(&SoulValue::Int(0)));
+        assert_eq!(row.fields.get("status"), Some(&SoulValue::Text("flopped".into())));
+        assert_eq!(row.fields.get("evidence"), Some(&SoulValue::Text("run-0".into())));
+        assert_eq!(
+            row.fields.get("recorded_at"),
+            Some(&SoulValue::Text("2026-09-05T12:46:00Z".into()))
+        );
+
+        // frame-get iterates row.fields directly, so it must also see them.
+        let last_row = df_frame_get("provider_task_rank", 5, Some(scope.clone()));
+        assert!(last_row.is_ok());
+    }
 }

--- a/b00t-mcp/src/clap_reflection.rs
+++ b/b00t-mcp/src/clap_reflection.rs
@@ -13,6 +13,20 @@ pub trait McpReflection: CommandFactory {
     /// Get the full command path (e.g., ["mcp", "list"])
     fn command_path() -> Vec<String>;
 
+    /// Optional per-argument schema override, keyed by the arg's normalized
+    /// (underscored) name. Returning `Some(schema)` replaces whatever
+    /// `generate_json_schema()` would otherwise infer from the CLAP `Arg`
+    /// for that name — use this ONLY when a tool's MCP-facing contract is
+    /// deliberately different from its raw CLAP shape (e.g. a `Vec<String>`
+    /// "key=value" CLAP arg that the MCP tool exposes as a JSON object for
+    /// ergonomics — see `SoulRowInsertCommand`). Everything else should rely
+    /// on the generic inference below, which is driven by the actual CLAP
+    /// arg metadata (positional/flag, multi-valued, required, default,
+    /// help) and stays correct automatically as commands evolve.
+    fn schema_override(_arg_name: &str) -> Option<Map<String, Value>> {
+        None
+    }
+
     /// Generate MCP tool from this command structure
     fn to_mcp_tool() -> Tool {
         let cmd = Self::command();
@@ -41,11 +55,34 @@ pub trait McpReflection: CommandFactory {
 
         // Process arguments and options
         for arg in cmd.get_arguments() {
-            let arg_name = arg.get_id().as_str();
+            let arg_name = arg.get_id().as_str().replace('-', "_");
+
+            if let Some(arg_schema) = Self::schema_override(&arg_name) {
+                properties.insert(arg_name.clone(), Value::Object(arg_schema));
+                if arg.is_required_set() {
+                    required.push(arg_name);
+                }
+                continue;
+            }
+
             let mut arg_schema = Map::new();
 
-            // Determine type based on CLAP value type
-            let arg_type = if arg.is_positional() {
+            // A CLAP arg that accepts more than one value (e.g. a `Vec<String>`
+            // positional or `--flag`, action `Append`, `num_args` max > 1) is a
+            // JSON array, not a scalar string — regardless of whether it's
+            // positional or a flag. Checking `num_args` (not just
+            // `is_positional`/`takes_values`) is what makes this generic: it
+            // reflects the actual CLAP arity instead of guessing from arg kind,
+            // so any current or future multi-value arg is described correctly
+            // without per-tool patching.
+            let is_multi = arg
+                .get_num_args()
+                .map(|range| range.max_values() > 1)
+                .unwrap_or(false);
+
+            let arg_type = if is_multi {
+                "array"
+            } else if arg.is_positional() {
                 "string"
             } else if arg.get_action().takes_values() {
                 "string"
@@ -54,6 +91,9 @@ pub trait McpReflection: CommandFactory {
             };
 
             arg_schema.insert("type".to_string(), json!(arg_type));
+            if is_multi {
+                arg_schema.insert("items".to_string(), json!({"type": "string"}));
+            }
 
             if let Some(help) = arg.get_help() {
                 arg_schema.insert("description".to_string(), json!(help.to_string()));
@@ -63,10 +103,10 @@ pub trait McpReflection: CommandFactory {
                 arg_schema.insert("default".to_string(), json!(default.to_string_lossy()));
             }
 
-            properties.insert(arg_name.replace('-', "_"), Value::Object(arg_schema));
+            properties.insert(arg_name.clone(), Value::Object(arg_schema));
 
             if arg.is_required_set() {
-                required.push(arg_name.replace('-', "_"));
+                required.push(arg_name);
             }
         }
 
@@ -425,5 +465,94 @@ mod tests {
         let tools = registry.get_tools();
         assert_eq!(tools.len(), 1);
         assert_eq!(tools[0].name.as_ref(), "b00t_test");
+    }
+
+    // Regression test for the b00t-mcp soul_table_create / soul_row_insert
+    // schema bug: a positional `Vec<String>` arg (clap action `Append`,
+    // `num_args` max > 1) was always described as a scalar `"type": "string"`,
+    // never `"array"`, because `generate_json_schema()` only looked at
+    // `is_positional()` / `takes_values()` and never checked arity.
+    #[derive(Parser)]
+    struct MultiValueCommand {
+        #[arg(help = "Single scalar positional")]
+        name: String,
+
+        #[arg(help = "Multi-value positional (e.g. \"name:type\" column defs)")]
+        columns: Vec<String>,
+    }
+
+    impl McpReflection for MultiValueCommand {
+        fn mcp_tool_name() -> String {
+            "b00t_test_multi".to_string()
+        }
+
+        fn command_path() -> Vec<String> {
+            vec!["test".to_string(), "multi".to_string()]
+        }
+    }
+
+    impl McpExecutor for MultiValueCommand {
+        fn execute_mcp_call(_params: &HashMap<String, Value>) -> Result<String> {
+            Ok("ok".to_string())
+        }
+    }
+
+    #[test]
+    fn multi_value_arg_is_described_as_array_not_string() {
+        let schema = MultiValueCommand::generate_json_schema();
+        let properties = schema["properties"].as_object().unwrap();
+
+        // Single-value positional stays a scalar string.
+        assert_eq!(properties["name"]["type"], json!("string"));
+
+        // Multi-value positional (Vec<String>) must be an array of strings,
+        // not the scalar "string" the old code always emitted.
+        assert_eq!(properties["columns"]["type"], json!("array"));
+        assert_eq!(properties["columns"]["items"]["type"], json!("string"));
+    }
+
+    // A tool may deliberately expose a `Vec<String>` "key=value" CLAP arg as
+    // a JSON object (nicer ergonomics for MCP clients) — `schema_override`
+    // is the sanctioned, generic escape hatch for that, distinct from (and
+    // not undermining) the generic array inference above.
+    #[derive(Parser)]
+    struct ObjectOverrideCommand {
+        #[arg(help = "key=value pairs, exposed as an object")]
+        fields: Vec<String>,
+    }
+
+    impl McpReflection for ObjectOverrideCommand {
+        fn mcp_tool_name() -> String {
+            "b00t_test_object_override".to_string()
+        }
+
+        fn command_path() -> Vec<String> {
+            vec!["test".to_string(), "object-override".to_string()]
+        }
+
+        fn schema_override(arg_name: &str) -> Option<Map<String, Value>> {
+            if arg_name == "fields" {
+                let mut m = Map::new();
+                m.insert("type".to_string(), json!("object"));
+                m.insert("additionalProperties".to_string(), json!(true));
+                Some(m)
+            } else {
+                None
+            }
+        }
+    }
+
+    impl McpExecutor for ObjectOverrideCommand {
+        fn execute_mcp_call(_params: &HashMap<String, Value>) -> Result<String> {
+            Ok("ok".to_string())
+        }
+    }
+
+    #[test]
+    fn schema_override_replaces_generic_inference() {
+        let schema = ObjectOverrideCommand::generate_json_schema();
+        let properties = schema["properties"].as_object().unwrap();
+        assert_eq!(properties["fields"]["type"], json!("object"));
+        assert_eq!(properties["fields"]["additionalProperties"], json!(true));
     }
 }

--- a/b00t-mcp/src/soul_dataframerr_tools.rs
+++ b/b00t-mcp/src/soul_dataframerr_tools.rs
@@ -5,7 +5,7 @@
 use crate::clap_reflection::{McpExecutor, McpReflection};
 use anyhow::Result;
 use clap::Parser;
-use serde_json::Value;
+use serde_json::{Map, Value, json};
 use std::collections::HashMap;
 
 // ── helpers ───────────────────────────────────────────────────────────────────
@@ -65,18 +65,46 @@ impl McpReflection for SoulTableCreateCommand {
     }
 }
 
+impl SoulTableCreateCommand {
+    /// Extract `columns` from MCP params as a `Vec<String>` of "name:type"
+    /// shorthand entries.
+    ///
+    /// Bug fix: the previous implementation used
+    /// `.and_then(|v| v.as_array()).unwrap_or_default()`, which SILENTLY
+    /// turned any non-array `columns` value (e.g. a plain string — exactly
+    /// what a caller following the tool's old, incorrectly-declared
+    /// `"type": "string"` schema would send) into an empty `Vec`. That made
+    /// `soul_table_create` report success while creating a table with zero
+    /// columns, which then made every subsequent `frame-insert`'s fields
+    /// invisible in `frame-dump` (its column list is empty). Now a
+    /// non-array, non-null `columns` value is a hard error instead of a
+    /// silent no-op; omitting `columns` entirely still yields an empty
+    /// (schemaless) table, unchanged from before.
+    fn columns_from_params(params: &HashMap<String, Value>) -> Result<Vec<String>> {
+        match params.get("columns") {
+            None | Some(Value::Null) => Ok(Vec::new()),
+            Some(Value::Array(arr)) => arr
+                .iter()
+                .map(|v| {
+                    v.as_str().map(String::from).ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "soul_table_create: columns[] entries must be strings \
+                             ('name:type' or 'name:type?'), got: {v}"
+                        )
+                    })
+                })
+                .collect(),
+            Some(other) => Err(anyhow::anyhow!(
+                "soul_table_create requires columns: array of \"name:type\" strings, got: {other}"
+            )),
+        }
+    }
+}
+
 impl McpExecutor for SoulTableCreateCommand {
     fn execute_mcp_call(params: &HashMap<String, Value>) -> Result<String> {
         let name = str_param(params, "name")?;
-        let columns: Vec<String> = params
-            .get("columns")
-            .and_then(|v| v.as_array())
-            .map(|arr| {
-                arr.iter()
-                    .filter_map(|v| v.as_str().map(String::from))
-                    .collect()
-            })
-            .unwrap_or_default();
+        let columns = Self::columns_from_params(params)?;
         let mut args: Vec<&str> = vec!["table-create", name];
         let col_refs: Vec<&str> = columns.iter().map(|s| s.as_str()).collect();
         args.extend(col_refs.iter());
@@ -141,17 +169,46 @@ impl McpReflection for SoulRowInsertCommand {
     fn command_path() -> Vec<String> {
         vec!["soul".into(), "frame-insert".into()]
     }
+
+    /// `fields` is a `Vec<String>` of "key=value" tokens at the CLAP layer,
+    /// which the generic reflection in `McpReflection::generate_json_schema`
+    /// would (after the generic array-inference fix) correctly describe as `"type":
+    /// "array"` of strings — but PRD-DATAFRAMERR §4 deliberately specifies
+    /// `soul_row_insert(table: str, fields: dict, ...)`: a JSON object is a
+    /// much nicer MCP-client ergonomic than an array of pre-formatted
+    /// "key=value" strings, and `execute_mcp_call` below has always parsed
+    /// it as one. Before this fix the schema still said `"type": "string"`
+    /// (the pre-fix generic bug), which matched neither the array the
+    /// generic rule would now infer nor the object the executor actually
+    /// requires — this override makes the declared schema match the real
+    /// contract exactly.
+    fn schema_override(arg_name: &str) -> Option<Map<String, Value>> {
+        if arg_name == "fields" {
+            let mut m = Map::new();
+            m.insert("type".to_string(), json!("object"));
+            m.insert(
+                "description".to_string(),
+                json!(
+                    "Field key=value pairs, e.g. {\"task\": \"rust_codegen\", \"rank\": 0}"
+                ),
+            );
+            m.insert("additionalProperties".to_string(), json!(true));
+            Some(m)
+        } else {
+            None
+        }
+    }
 }
 
-impl McpExecutor for SoulRowInsertCommand {
-    fn execute_mcp_call(params: &HashMap<String, Value>) -> Result<String> {
-        let table = str_param(params, "table")?;
+impl SoulRowInsertCommand {
+    /// Extract `fields` from MCP params (a JSON object) as "key=value"
+    /// CLAP argv tokens for `frame-insert`.
+    fn fields_from_params(params: &HashMap<String, Value>) -> Result<Vec<String>> {
         let fields_obj = params
             .get("fields")
             .and_then(|v| v.as_object())
             .ok_or_else(|| anyhow::anyhow!("soul_row_insert requires fields: object"))?;
-        // Build "key=value" pairs
-        let pairs: Vec<String> = fields_obj
+        Ok(fields_obj
             .iter()
             .map(|(k, v)| {
                 let val = match v {
@@ -162,7 +219,14 @@ impl McpExecutor for SoulRowInsertCommand {
                 };
                 format!("{k}={val}")
             })
-            .collect();
+            .collect())
+    }
+}
+
+impl McpExecutor for SoulRowInsertCommand {
+    fn execute_mcp_call(params: &HashMap<String, Value>) -> Result<String> {
+        let table = str_param(params, "table")?;
+        let pairs = Self::fields_from_params(params)?;
         let mut args: Vec<&str> = vec!["frame-insert", table];
         let pair_refs: Vec<&str> = pairs.iter().map(|s| s.as_str()).collect();
         args.extend(pair_refs.iter());
@@ -480,4 +544,112 @@ pub fn register_dataframerr_tools(builder: &mut crate::clap_reflection::McpComma
         .register::<SoulAlarmCheckCommand>()
         .register::<SoulTokenEncodeCommand>()
         .register::<SoulTokenDecodeCommand>();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    // ── schema shape ────────────────────────────────────────────────────────
+
+    #[test]
+    fn table_create_columns_schema_is_array_of_strings() {
+        // Regression test: this was declared as "type": "string" before the
+        // generic clap_reflection fix, which is what led a compliant MCP
+        // client to send a plain string for `columns` — silently producing
+        // a zero-column table (see columns_from_params tests below).
+        let tool = SoulTableCreateCommand::to_mcp_tool();
+        let props = tool.input_schema["properties"].as_object().unwrap();
+        assert_eq!(props["columns"]["type"], json!("array"));
+        assert_eq!(props["columns"]["items"]["type"], json!("string"));
+    }
+
+    #[test]
+    fn row_insert_fields_schema_is_object() {
+        // Regression test for the reported MCP-layer mismatch: schema said
+        // "string", runtime demanded "object". PRD-DATAFRAMERR §4 specifies
+        // `fields: dict`, so the corrected schema must say "object" — not
+        // "array" (what the generic Vec<String> rule alone would infer) or
+        // "string" (the old, wrong value).
+        let tool = SoulRowInsertCommand::to_mcp_tool();
+        let props = tool.input_schema["properties"].as_object().unwrap();
+        assert_eq!(props["fields"]["type"], json!("object"));
+    }
+
+    // ── SoulTableCreateCommand::columns_from_params ─────────────────────────
+
+    #[test]
+    fn columns_from_params_accepts_proper_array() {
+        let mut params = HashMap::new();
+        params.insert(
+            "columns".to_string(),
+            json!(["task:text", "provider:text", "rank:int?"]),
+        );
+        let cols = SoulTableCreateCommand::columns_from_params(&params).unwrap();
+        assert_eq!(cols, vec!["task:text", "provider:text", "rank:int?"]);
+    }
+
+    #[test]
+    fn columns_from_params_missing_is_empty_table() {
+        let params = HashMap::new();
+        let cols = SoulTableCreateCommand::columns_from_params(&params).unwrap();
+        assert!(cols.is_empty());
+    }
+
+    #[test]
+    fn columns_from_params_rejects_plain_string_instead_of_silently_dropping() {
+        // Repro: a caller following the (pre-fix) "type": "string"
+        // schema would send `columns` as one comma-separated string. The old
+        // code turned that into an EMPTY Vec via `.unwrap_or_default()`,
+        // silently creating a zero-column table and reporting success. It
+        // must now be a clear error instead.
+        let mut params = HashMap::new();
+        params.insert(
+            "columns".to_string(),
+            json!("task:text, provider:text, model:text"),
+        );
+        let err = SoulTableCreateCommand::columns_from_params(&params).unwrap_err();
+        assert!(
+            err.to_string().contains("array"),
+            "error should explain columns must be an array, got: {err}"
+        );
+    }
+
+    #[test]
+    fn columns_from_params_rejects_non_string_array_entries() {
+        let mut params = HashMap::new();
+        params.insert("columns".to_string(), json!(["task:text", 42]));
+        let err = SoulTableCreateCommand::columns_from_params(&params).unwrap_err();
+        assert!(err.to_string().contains("must be strings"));
+    }
+
+    // ── SoulRowInsertCommand::fields_from_params ────────────────────────────
+
+    #[test]
+    fn fields_from_params_converts_object_to_key_value_pairs() {
+        let mut params = HashMap::new();
+        params.insert(
+            "fields".to_string(),
+            json!({"task": "rust_codegen", "rank": 0, "flopped": true}),
+        );
+        let mut pairs = SoulRowInsertCommand::fields_from_params(&params).unwrap();
+        pairs.sort();
+        assert_eq!(
+            pairs,
+            vec![
+                "flopped=true".to_string(),
+                "rank=0".to_string(),
+                "task=rust_codegen".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn fields_from_params_rejects_non_object() {
+        let mut params = HashMap::new();
+        params.insert("fields".to_string(), json!("task=rust_codegen"));
+        let err = SoulRowInsertCommand::fields_from_params(&params).unwrap_err();
+        assert!(err.to_string().contains("object"));
+    }
 }


### PR DESCRIPTION
## What

Fixes two MCP-layer bugs in the soul DataFramerr tools (`b00t-mcp/src/soul_dataframerr_tools.rs`) that together made the standard "create a table with columns, then insert rows" flow silently produce a table that renders empty.

### Bug 1 — `soul_table_create` silently discarded the column spec

`execute_mcp_call` built the column list with:

```rust
params.get("columns").and_then(|v| v.as_array()).unwrap_or_default()
```

Any non-array `columns` value — e.g. the plain string a caller gets when following the tool's *own* schema, which incorrectly declared `columns` as `"type": "string"` (see Bug 3 root cause) — was silently coerced to an empty `Vec`. The tool then reported success while creating a **zero-column table**. Every subsequent `frame-insert` persisted fine, but `frame-dump` / `table-show` render strictly from the declared column list, so the rows looked empty.

Now `columns_from_params` hard-errors on a non-array / non-string-element value. Omitting `columns` entirely still yields an empty (schemaless) table — unchanged.

### Bug 2 — `soul_row_insert` schema said `string`, executor demanded `object`

Declared schema: `fields: "string"`. Runtime: `fields` must be a JSON object (`PRD-DATAFRAMERR §4: fields: dict`), and `execute_mcp_call` has always parsed it that way. Callers got `soul_row_insert requires fields: object` despite sending what the schema asked for.

Added a `schema_override(arg_name) -> Option<Map>` hook to the `McpReflection` trait and used it to declare `fields` as `"type": "object"`, matching the real contract.

### Root cause of the wrong schemas — generic CLAP→JSON-Schema inference ignored arity

`McpReflection::generate_json_schema` decided arg type from `is_positional()` / `takes_values()` only, never CLAP arity. So a `Vec<String>` positional (clap action `Append`, `num_args` max > 1) was always described as a scalar `"string"`. Fixed generically:

```rust
let is_multi = arg.get_num_args().map(|r| r.max_values() > 1).unwrap_or(false);
```

→ emits `"type": "array"` + `"items": {"type": "string"}`. This corrects `columns` for free and any future multi-value arg. `schema_override` is the sanctioned escape hatch for the handful of tools (like `fields` here) whose MCP contract is deliberately a *different* shape than the raw CLAP arg.

## Not fixed here (follow-up)

The schemaless-table display path itself: `df_frame_dump` / `df_table_show` in `b00t-cli/src/commands/soul.rs` render only declared columns, so a genuinely schemaless table (no `columns` given) still shows nothing even though `frame-get` and the persisted TOML have the data. Left focused out of this PR; noted for a follow-up that derives the display column set from the union of `row.fields` keys when `df.columns` is empty.

## Verification

- **No data was ever lost.** The 5 rows from the original repro were fully intact in `SOUL.tomllm` (every field present) — only column registration + rendering were broken.
- `cargo test -p b00t-mcp --lib` → **86 passed / 0 failed** (10 new tests: `columns_from_params` array / missing / non-array / non-string-entry; `fields_from_params` object / non-object; declared-schema shape for both tools; generic array inference; `schema_override` escape hatch).
- `cargo test -p b00t-cli --lib soul` → **18 passed / 0 failed** (1 new end-to-end: `table-create` with 7 columns + 5 `frame-insert`s round-trips every column and field through real TOML save/reload).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013REztLAsGz4oLyFGK8KzmX
