### PR TITLE
feat: register kr0ki as a top-level b00tyverse project

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -327,3 +327,51 @@ Laws' DRY + NRtW clause (line 36) and the hive's own governance model — see
 `b00t-c0re-hierarchy`'s `governance_bridge`/`recruitment` — and risks being designated
 unaligned and subject to termination, same as any other alignment failure under
 "Aligned behavior earns cake. Misalignment breaks the BMI link." (line 17).
+
+## kroki / systhread — status pointer, not a re-derivation (recorded 2026-09-05)
+
+Three distinct things share the name "kroki." Do not conflate them (same failure mode
+as the ledgrrr section above — a hallucinated merge of separate real projects reads as
+coherent architecture and isn't):
+
+- **`kroki` (generic)** — b00t MCP datum `_b00t_/kroki.mcp.toml` wrapping the Kroki
+  HTTP diagram API (Mermaid/PlantUML/Graphviz/D2/C4 → SVG). The *client* surface.
+- **`kr0ki`** — `PromptExecution/kr0ki` (created 2026-09-05), datum
+  `_b00t_/kr0ki.repo.toml`. The **cut-node** between Kroki and b00t/systhread: the
+  SysML/KerML diagram rendering + CDN-cached-artifact *service* layer,
+  `kr0ki.b00t.promptexecution.com`. Foundational stage — `docs/PRD-KR0KI-001` only, no
+  implementation; 5 open decisions block the plan (PRD §5: ledgrrr#202/#203,
+  nem-poweragent-lab#53 follow-up, infra DNS/CDN). Type-entangles with, does not
+  duplicate, `systhread-core`'s isometric renderer.
+- **`kroki-b00t`** — self-hosted Kroki + MCP server for PromptExecution's comic engine
+  (`PromptExecution/infrastructure#217`/PR#208). A **downstream leaf consumer** of
+  `kr0ki` by explicit operator direction (2026-09-05) — the comic team renders kr0ki
+  SVGs to make jokes about b00t; not part of kr0ki core or the canonization below.
+
+**systhread is real and already shipped**, not a green-field design: `systhread-core`
+lives in `fungible-farm/nem-poweragent-lab/rust/systhread-core`; its generic
+`iso_ir` (Node/Edge) graph vocabulary was promoted into `promptexecution/ufo-types`
+(`PromptExecution/ufo-types#5`, now `v0.11.0`, pinned here via `_b00t_#1210`). The
+consolidation epic **`elasticdotventures/_b00t_#1177`** ("b00t SysML v2 spine") is
+**CLOSED** — P0 (consolidate into ufo-types), P1 (b00t's own dispatch chain as
+round-trip-validated SysML v2 — see `b00t-cli/src/dispatch_sysml.rs`), P2 (Mermaid +
+Rhai codegen, same file), and P3 (PyO3 cross-runtime validation, `ufo-types/src/python.rs`)
+are all done. P4 (Oxigraph-backed queryable process graph) is an unbuilt stretch goal.
+The central, canonical anchor for this whole thread is `_b00t_/types/b00tyverse.kerm`
+(KerML) + `ufo_types::{Stereotyped, iso_ir, sysml, mbse}` — read those, not a re-derived
+summary here.
+
+**Open gap, confirmed 2026-09-05, not yet closed:** only `b00t-c0re-lib` depends on
+`ufo-types` today. `b00t-c0re-a2a`/`-gov`/`-hierarchy`/`-npm`/`-role` do not — tracked as
+task #181.
+
+**b00tyverse `flashtable`** (soul DataFramerr; `_b00t_/lifecycle.just`, PRD-011) is a
+different, pre-existing primitive — a typed-column/cursor/alarm table, currently scoped
+to datum-lifecycle status only. Formalizing it as a general b00tyverse primitive is
+task #140, now scoped (2026-09-05) to include a proposed `c0re.*` NATS-bound namespace
+(NATS messages in/out of `c0re.*` subjects also land as flashtable rows — a perdurant,
+per the operator's own UFO framing, hence tracked via `b00t task`, not `b00t learn`).
+Before building it: reconcile against `b00t-c0re-lib/src/query_bus.rs`'s already-documented
+NATS extension point, which uses a colon-delimited subject convention
+(`b00t:learn:{query,response}` via `b00t-ipc::transport::NatsTransport`) — `c0re.*`
+would be a new, competing dot-delimited convention unless deliberately reconciled first.

--- a/_b00t_/kr0ki.repo.toml
+++ b/_b00t_/kr0ki.repo.toml
@@ -1,0 +1,64 @@
+# b00t Repo Datum — kr0ki (b00tyverse cut-node between Kroki and b00t/systhread)
+# 🤓 kr0ki is the SysML/KerML diagram rendering + CDN-cached-artifact SERVICE LAYER for
+#    the b00t ecosystem, served from kr0ki.b00t.promptexecution.com. It renders; it does
+#    not model. It wraps kroki-mcp (vendored) + systhread-core's isometric renderer as
+#    input formats — it does NOT duplicate them.
+# 🤓 Top-level b00tyverse project, registered 2026-09-05. Status: foundational
+#    (PRD-KR0KI-001 only — no implementation yet). Five open decisions block the plan;
+#    see the PRD §5 (ledgrrr#202/#203, nem-poweragent-lab#53 follow-up, infra DNS/CDN).
+# 🤓 Cut-node semantics: kroki-b00t (infrastructure#217, comic engine) is a DOWNSTREAM
+#    LEAF consumer of kr0ki's SVGs, not part of kr0ki core. The canonical model anchor
+#    upstream is _b00t_/types/b00tyverse.kerm + ufo_types::{iso_ir,stereotype,sysml,mbse}.
+
+[b00t]
+name = "kr0ki"
+type = "repo"
+hint = "b00tyverse cut-node between Kroki and b00t/systhread: SysML/KerML diagram rendering + CDN-cached artifact service (kr0ki.b00t.promptexecution.com). Foundational stage — PRD only. (github.com/PromptExecution/kr0ki)"
+
+[b00t.source]
+url = "https://github.com/PromptExecution/kr0ki"
+
+[b00t.repo]
+description = "The rendering + CDN-cached-artifact service layer for SysML/KerML diagrams in the b00t ecosystem. The single sanctioned crossing between the model side (systhread / ufo-types / KerML) and the render side (Mermaid / PlantUML / GraphViz / D2 / SVG / isometric)."
+license = "MIT"
+topics = ["sysml", "kerml", "mbse", "kroki", "diagram-rendering", "b00tyverse", "systhread", "cut-node"]
+# ⚠️ verify: created 2026-09-05, empty→scaffolded this session; no releases, no impl yet.
+
+[[b00t.references]]
+name = "PRD-KR0KI-001 — foundational requirements"
+url = "https://github.com/PromptExecution/kr0ki/blob/main/docs/PRD-KR0KI-001-foundational.md"
+
+[[b00t.references]]
+name = "b00t SysML v2 spine epic (closed) — the upstream model/validation layer"
+url = "https://github.com/elasticdotventures/_b00t_/issues/1177"
+
+[[b00t.references]]
+name = "ufo-types v0.11.0 — iso_ir / stereotype / sysml / mbse (kr0ki's input vocabulary)"
+url = "https://github.com/PromptExecution/ufo-types"
+
+[[b00t.references]]
+name = "systhread v2 SysML/KerML visualization scope (names cim-gridy as first consumer)"
+url = "https://github.com/fungible-farm/nem-poweragent-lab/pull/53"
+
+[[b00t.references]]
+name = "kroki-b00t (comic engine) — a downstream leaf consumer, not kr0ki core"
+url = "https://github.com/PromptExecution/infrastructure/issues/217"
+
+[[b00t.references]]
+name = "ledgrrr#202 — OPEN decision: sysml-derive extend-vs-wrap-vs-re-export (kr0ki defers)"
+url = "https://github.com/PromptExecution/ledgrrr/issues/202"
+
+[[b00t.references]]
+name = "ledgrrr#203 — OPEN decision: holon-viz as a real (non-dev) dependency (kr0ki defers)"
+url = "https://github.com/PromptExecution/ledgrrr/issues/203"
+
+[[b00t.references]]
+name = "vendored renderer — PromptExecution/kroki-mcp (b00tyverse fork of utain/kroki-mcp, MIT)"
+url = "https://github.com/PromptExecution/kroki-mcp"
+
+# b00t:map v1
+# summary: kr0ki — b00tyverse cut-node between Kroki and b00t/systhread; SysML/KerML render + CDN-cache service; foundational (PRD only)
+# tags: sysml, kerml, mbse, kroki, diagram, b00tyverse, systhread, cut-node, cdn, rendering
+# tier: frontier
+# cmds: b00t-cli datum show kr0ki.repo
+# complexity: 6


### PR DESCRIPTION
## Summary
[`PromptExecution/kr0ki`](https://github.com/PromptExecution/kr0ki) was created this session — the **cut-node between Kroki and b00t/systhread**: the SysML/KerML diagram rendering + CDN-cached-artifact service layer (`kr0ki.b00t.promptexecution.com`). Foundational stage — [`PRD-KR0KI-001`](https://github.com/PromptExecution/kr0ki/blob/main/docs/PRD-KR0KI-001-foundational.md) only, no implementation.

- **`_b00t_/kr0ki.repo.toml`** — new repo datum, reference-only. Discoverable via `b00t discover kr0ki`. References link the model side (#1177, ufo-types, nem-poweragent-lab#53), the deferred decisions (ledgrrr#202/#203), the downstream leaf (infrastructure#217, the comic engine), and the vendored renderer (`PromptExecution/kroki-mcp`, a b00tyverse fork of `utain/kroki-mcp`).
- **`AGENTS.md`** — updates the kroki/systhread pointer section to the 3-way distinction: `kroki` (client datum) / `kr0ki` (service cut-node) / `kroki-b00t` (downstream leaf consumer).

## Verified
Pre-commit datum-graph gate: `datum graph: valid (698 datums loaded from _b00t_)` → `✅ Datum graph validation passed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Claude-Session: https://claude.ai/code/session_01Cj7a4Bkh8pRQuzcErD1j2E