### PR TITLE
datum: register SysML-v2-Release / sysml-v2-parser / Eclipse SysON + refresh kr0ki.repo

### DIFF
--- a/_b00t_/eclipse-syson.repo.toml
+++ b/_b00t_/eclipse-syson.repo.toml
@@ -1,0 +1,59 @@
+# b00t Repo Datum — eclipse-syson/syson (Eclipse SysON)
+# 🤓 Web-based open-source SysML v2 modeler built on Eclipse Sirius Web. EPL-2.0.
+#    Java 21 / Spring Boot backend, React/TS frontend, PostgreSQL. Co-led by Obeo
+#    (product/UX) + CEA List (spec compliance, OMG representation). CalVer, ~2-monthly
+#    releases, very active.
+# 🤓 Renders the FOUR standard SysML v2 ViewDefinitions — General, Interconnection,
+#    Action Flow, State Transition — plus a Requirements Table. Graphical (React Flow +
+#    client-side elkjs layout) AND a growing subset of textual notation (via Sensmetry
+#    SySIDE). Image export is client-side (html-to-image) — there is NO headless render
+#    API; a headless render needs a real browser (Playwright).
+# 🤓 Partial OMG Systems Modeling API at /api/rest/ (read-mostly). Does NOT support the
+#    SysML v2 Standard JSON serialization for import/export.
+# 🤓 kr0ki's posture (kr0ki docs/EVAL-syson.md): SysON is (a) a REFERENCE ORACLE — the
+#    best OSS impl of standard v2 notation, CEA-backed — validate kr0ki output against
+#    its structure, not its pixels (client-side ELK makes visual parity hard); and
+#    (b) an OPTIONAL upstream authoring front-end via the textual / partial-REST path.
+#    It is NOT a competitor for kr0ki's headless-cached-artifact role. Its
+#    ViewUsage.exposedElement model is useful view-scoping input. Reusable JVM libs:
+#    syson-sysml-metamodel / -import / -export / -validation.
+
+[b00t]
+name = "eclipse-syson"
+type = "repo"
+type_tags = ["reference"]
+hint = "Eclipse SysON — web-based open-source SysML v2 modeler on Sirius Web (EPL-2.0, Obeo + CEA List). Four standard ViewDefinitions + Requirements Table; partial OMG REST API; no headless render API. kr0ki's reference oracle + optional authoring front-end (not a competitor)."
+keywords = ["sysml", "sysml2", "kerml", "mbse", "modeler", "sirius-web", "eclipse", "obeo", "cea", "viewpoint"]
+
+[b00t.source]
+url = "https://github.com/eclipse-syson/syson"
+
+[b00t.repo]
+description = "A web-based graphical + textual SysML v2 authoring environment built on Eclipse Sirius Web. Reference implementation of the standard SysML v2 view definitions; the b00tyverse's SysML v2 notation oracle and an optional upstream authoring front-end for kr0ki."
+license = "EPL-2.0"
+topics = ["sysml", "sysml-v2", "kerml", "mbse", "sirius-web", "eclipse", "modeling-tool"]
+# ⚠️ verify: latest ~v2026.7.4 (2026-09-03). Docker image eclipsesyson/syson + Postgres.
+#    Multi-arch images from v2026.9.0. No Helm chart in-repo.
+
+[[b00t.references]]
+name = "kr0ki EVAL-syson — the client/oracle assessment"
+url = "https://github.com/PromptExecution/kr0ki/blob/main/docs/EVAL-syson.md"
+
+[[b00t.references]]
+name = "SysON site + user manual"
+url = "https://mbse-syson.org"
+
+[[b00t.references]]
+name = "Eclipse project page"
+url = "https://projects.eclipse.org/projects/modeling.syson"
+
+[[b00t.references]]
+name = "OMG Systems Modeling API and Services"
+url = "https://www.omg.org/spec/SystemsModelingAPI/"
+
+# b00t:map v1
+# summary: Eclipse SysON — web SysML v2 modeler on Sirius Web (EPL-2.0); 4 standard ViewDefinitions; partial OMG REST API, no headless render; kr0ki's notation oracle + optional authoring front-end
+# tags: reference, sysml, sysml-v2, kerml, mbse, sirius-web, eclipse, viewpoint
+# tier: sm0l
+# cmds: b00t-cli datum show eclipse-syson.repo
+# complexity: 3

--- a/_b00t_/kr0ki.repo.toml
+++ b/_b00t_/kr0ki.repo.toml
@@ -3,17 +3,24 @@
 #    the b00t ecosystem, served from kr0ki.b00t.promptexecution.com. It renders; it does
 #    not model. It wraps kroki-mcp (vendored) + systhread-core's isometric renderer as
 #    input formats — it does NOT duplicate them.
-# 🤓 Top-level b00tyverse project, registered 2026-09-05. Status: foundational
-#    (PRD-KR0KI-001 only — no implementation yet). Five open decisions block the plan;
-#    see the PRD §5 (ledgrrr#202/#203, nem-poweragent-lab#53 follow-up, infra DNS/CDN).
+# 🤓 Top-level b00tyverse project. Registered 2026-09-05; substantially built out the
+#    same day. Status: P0 render loop + SysML-v2-Release conformance harness +
+#    kr0ki-sysmlv2-client all SHIPPED on main. The SysML-model ingestion path
+#    (FR1/FR3/FR4) is planned in PLAN-KR0KI-002 and blocked on the UFO semantic-graph
+#    layer landing in ufo-types + at least one pattern recognizer.
 # 🤓 Cut-node semantics: kroki-b00t (infrastructure#217, comic engine) is a DOWNSTREAM
 #    LEAF consumer of kr0ki's SVGs, not part of kr0ki core. The canonical model anchor
-#    upstream is _b00t_/types/b00tyverse.kerm + ufo_types::{iso_ir,stereotype,sysml,mbse}.
+#    upstream is _b00t_/types/b00tyverse.kerm + ufo_types::{iso_ir, stereotype, sysml,
+#    mbse, sysml_model, ontology, view}.
+# 🤓 Five-box ingestion pipeline (PLAN-KR0KI-002 §2): source (k8s / Rust / SysML-v2)
+#    → canonical UFO-typed semantic graph (ufo_types) → pattern recognizers
+#    → SysML v2 viewpoints (ufo_types::sysml_model) → kr0ki renderer adapters.
+#    kr0ki MUST NOT infer architecture from diagram syntax or raw iso_ir strings.
 
 [b00t]
 name = "kr0ki"
 type = "repo"
-hint = "b00tyverse cut-node between Kroki and b00t/systhread: SysML/KerML diagram rendering + CDN-cached artifact service (kr0ki.b00t.promptexecution.com). Foundational stage — PRD only. (github.com/PromptExecution/kr0ki)"
+hint = "b00tyverse cut-node between Kroki and b00t/systhread: SysML/KerML diagram rendering + CDN-cached artifact service (kr0ki.b00t.promptexecution.com). P0 render loop + conformance harness + OMG-SysML-v2-API client shipped; model-ingestion path planned (PLAN-KR0KI-002). (github.com/PromptExecution/kr0ki)"
 
 [b00t.source]
 url = "https://github.com/PromptExecution/kr0ki"
@@ -21,19 +28,38 @@ url = "https://github.com/PromptExecution/kr0ki"
 [b00t.repo]
 description = "The rendering + CDN-cached-artifact service layer for SysML/KerML diagrams in the b00t ecosystem. The single sanctioned crossing between the model side (systhread / ufo-types / KerML) and the render side (Mermaid / PlantUML / GraphViz / D2 / SVG / isometric)."
 license = "MIT"
-topics = ["sysml", "kerml", "mbse", "kroki", "diagram-rendering", "b00tyverse", "systhread", "cut-node"]
-# ⚠️ verify: created 2026-09-05, empty→scaffolded this session; no releases, no impl yet.
+topics = ["sysml", "kerml", "mbse", "kroki", "diagram-rendering", "b00tyverse", "systhread", "cut-node", "sysml-v2-api"]
+# ⚠️ verify: created 2026-09-05. As of 2026-09-05: crates kr0ki-core (P0 render loop),
+#    kr0ki-server (axum HTTP), kr0ki-sysmlv2-client (OMG Systems Modeling API client);
+#    SysML-v2-Release conformance harness pinned at tag 2026-07 via sysml-v2-parser 0.55.
+#    No tagged release yet; not deployed.
 
 [[b00t.references]]
 name = "PRD-KR0KI-001 — foundational requirements"
 url = "https://github.com/PromptExecution/kr0ki/blob/main/docs/PRD-KR0KI-001-foundational.md"
 
 [[b00t.references]]
-name = "b00t SysML v2 spine epic (closed) — the upstream model/validation layer"
-url = "https://github.com/elasticdotventures/_b00t_/issues/1177"
+name = "PLAN-KR0KI-002 — the SysML-model ingestion path (five-box pipeline; D3 operator-resolved)"
+url = "https://github.com/PromptExecution/kr0ki/blob/main/docs/PLAN-KR0KI-002.md"
 
 [[b00t.references]]
-name = "ufo-types v0.11.0 — iso_ir / stereotype / sysml / mbse (kr0ki's input vocabulary)"
+name = "DESIGN-NOTE — typed model layer (SysML v2 / KerML only; v1 DiagramKind rejected)"
+url = "https://github.com/PromptExecution/kr0ki/blob/main/docs/DESIGN-NOTE-typed-model-layer.md"
+
+[[b00t.references]]
+name = "PATTERNS-kubernetes — first pattern recognizer: UFO 4-category bridge + 25 canonical relations"
+url = "https://github.com/PromptExecution/kr0ki/blob/main/docs/PATTERNS-kubernetes.md"
+
+[[b00t.references]]
+name = "EVAL-flexo — Open-MBEE Flexo MMS as the primary OMG-SysML-v2-API model server"
+url = "https://github.com/PromptExecution/kr0ki/blob/main/docs/EVAL-flexo.md"
+
+[[b00t.references]]
+name = "EVAL-syson — Eclipse SysON as reference oracle + optional authoring front-end"
+url = "https://github.com/PromptExecution/kr0ki/blob/main/docs/EVAL-syson.md"
+
+[[b00t.references]]
+name = "ufo-types — iso_ir / stereotype / sysml / mbse + sysml_model (ElementKind, Relation) + ontology (UfoRelation, OntologicalEdge) + view (SysmlViewKind)"
 url = "https://github.com/PromptExecution/ufo-types"
 
 [[b00t.references]]
@@ -45,20 +71,24 @@ name = "kroki-b00t (comic engine) — a downstream leaf consumer, not kr0ki core
 url = "https://github.com/PromptExecution/infrastructure/issues/217"
 
 [[b00t.references]]
-name = "ledgrrr#202 — OPEN decision: sysml-derive extend-vs-wrap-vs-re-export (kr0ki defers)"
+name = "ledgrrr#202 — OPEN decision D1: sysml-derive extend-vs-wrap-vs-re-export (only gates the authoring path)"
 url = "https://github.com/PromptExecution/ledgrrr/issues/202"
 
 [[b00t.references]]
-name = "ledgrrr#203 — OPEN decision: holon-viz as a real (non-dev) dependency (kr0ki defers)"
+name = "ledgrrr#203 — OPEN decision D2: holon-viz as a real (non-dev) dependency"
 url = "https://github.com/PromptExecution/ledgrrr/issues/203"
 
 [[b00t.references]]
 name = "vendored renderer — PromptExecution/kroki-mcp (b00tyverse fork of utain/kroki-mcp, MIT)"
 url = "https://github.com/PromptExecution/kroki-mcp"
 
+[[b00t.references]]
+name = "SysML-v2-Release — the conformance corpus (see sysml-v2-release datum)"
+url = "https://github.com/Systems-Modeling/SysML-v2-Release"
+
 # b00t:map v1
-# summary: kr0ki — b00tyverse cut-node between Kroki and b00t/systhread; SysML/KerML render + CDN-cache service; foundational (PRD only)
-# tags: sysml, kerml, mbse, kroki, diagram, b00tyverse, systhread, cut-node, cdn, rendering
+# summary: kr0ki — b00tyverse cut-node between Kroki and b00t/systhread; SysML/KerML render + CDN-cache service; P0 + conformance + OMG-API client shipped, model-ingestion path planned (PLAN-KR0KI-002)
+# tags: sysml, kerml, mbse, kroki, diagram, b00tyverse, systhread, cut-node, cdn, rendering, sysml-v2-api
 # tier: frontier
 # cmds: b00t-cli datum show kr0ki.repo
 # complexity: 6

--- a/_b00t_/sysml-v2-parser.repo.toml
+++ b/_b00t_/sysml-v2-parser.repo.toml
@@ -1,0 +1,60 @@
+# b00t Repo Datum — elan8/sysml-v2-parser
+# 🤓 Pure-Rust (nom-8 parser-combinator, NO Java/Xtext) parser for the SysML v2 textual
+#    notation. MIT. Two entry points: parse() strict / all-or-nothing, and
+#    parse_for_editor() resilient (partial AST + diagnostics, never panics).
+#    ufo_types::sysml::validate_sysml_v2 wraps it as the b00tyverse SysML v2 SYNTAX GATE.
+# 🤓 elan8 is (per a 2026-09-05 survey) plausibly the elastic.ventures account — treat as
+#    an in-house / fork-fix-forward crate, not a third-party black box.
+# 🤓 Self-contained conformance rig: docs/conformance-target pins a SysML-v2-Release tag,
+#    scripts/fetch-sysml-v2-release.sh pulls the tarball, build.rs recomputes an FNV-1a
+#    hash of the two textual BNF files and FAILS the build on drift from the pin.
+#    Conformance layers (docs/CONFORMANCE.md): L1 BNF production coverage, L2 full
+#    sysml.library parse, L2.5 roundtrip parse→emit→reparse on the validation corpus
+#    (ROUNDTRIP_PASS ratchet). L3 semantics explicitly NOT claimed.
+# 🤓 Consumers: kr0ki-core dev-depends on "0.55" for its phase-1 conformance harness
+#    (crates/kr0ki-core/tests/conformance.rs). Version MUST be pinned in lockstep with
+#    ufo-types (a parser-version skew means the two disagree on "valid SysML v2").
+# 🚩 known (sysml-v2-parser 0.55): the recursive-descent parser stack-overflows
+#    (SIGABRT) on a few deeply-nested example models with the default 2 MiB thread
+#    stack. kr0ki contains it with a 256 MiB worker thread; worth an upstream issue +
+#    b00t task.
+
+[b00t]
+name = "sysml-v2-parser"
+type = "repo"
+type_tags = ["reference"]
+hint = "Pure-Rust (nom-8, no Java) SysML v2 textual-notation parser. MIT. strict parse() + resilient parse_for_editor(); wrapped by ufo_types::sysml::validate_sysml_v2 as the b00tyverse SysML v2 syntax gate. Tag-pinned conformance rig against SysML-v2-Release. crates.io: sysml-v2-parser (0.55.0)."
+keywords = ["sysml", "sysml2", "kerml", "parser", "rust", "nom", "syntax-validation", "conformance"]
+
+[b00t.source]
+url = "https://github.com/elan8/sysml-v2-parser"
+
+[b00t.repo]
+description = "A hand-written nom parser-combinator implementation of the SysML v2 textual grammar in Rust — no JVM, no Xtext. The syntax-validation layer for the b00tyverse SysML v2 stack, with a self-contained tag-pinned conformance harness against the OMG SysML-v2-Release corpus."
+license = "MIT"
+topics = ["sysml", "sysml-v2", "kerml", "parser", "rust", "nom", "conformance"]
+# ⚠️ verify: crates.io sysml-v2-parser 0.55.0 (2026-08-27), repository elan8/sysml-v2-parser.
+#    Rapid cadence (0.44→0.55 in ~5 weeks). deps: nom 8, nom_locate, memchr, stacker.
+
+[[b00t.references]]
+name = "crates.io — sysml-v2-parser"
+url = "https://crates.io/crates/sysml-v2-parser"
+
+[[b00t.references]]
+name = "SysML-v2-Release — the corpus this crate's conformance rig pins (see that datum)"
+url = "https://github.com/Systems-Modeling/SysML-v2-Release"
+
+[[b00t.references]]
+name = "ufo-types — ufo_types::sysml::validate_sysml_v2 wraps this crate"
+url = "https://github.com/PromptExecution/ufo-types"
+
+[[b00t.references]]
+name = "kr0ki — dev-depends on it for the phase-1 conformance harness"
+url = "https://github.com/PromptExecution/kr0ki/blob/main/docs/CONFORMANCE.md"
+
+# b00t:map v1
+# summary: pure-Rust (nom-8, no Java) SysML v2 textual parser; the b00tyverse SysML v2 syntax gate (wrapped by ufo_types::sysml::validate_sysml_v2); tag-pinned conformance rig; crates.io 0.55.0
+# tags: reference, sysml, sysml-v2, kerml, parser, rust, nom, conformance
+# tier: ch0nky
+# cmds: b00t-cli datum show sysml-v2-parser.repo
+# complexity: 4

--- a/_b00t_/sysml-v2-release.repo.toml
+++ b/_b00t_/sysml-v2-release.repo.toml
@@ -1,0 +1,67 @@
+# b00t Repo Datum — Systems-Modeling/SysML-v2-Release
+# 🤓 The OMG's canonical incremental release of the SysML v2 language: spec PDFs, the
+#    textual/graphical BNF grammar, the normative standard library (sysml.library —
+#    Kernel / Domain / Systems libraries), curated validation models, training models,
+#    KerML + SysML examples, and the Jupyter kernel installer. EPL-2.0 (repo-level
+#    LICENSE covers all models + the standard library; spec PDFs under doc/ are
+#    OMG-copyright — do NOT redistribute those).
+# 🤓 Monthly tags, format YYYY-MM. Tracks the formally adopted (30 June 2025) KerML 1.0 /
+#    SysML 2.0 / Systems Modeling API & Services 1.0 baseline.
+# 🤓 This is the b00tyverse's SysML v2 CONFORMANCE GROUND TRUTH. Consumed as a pinned,
+#    fetched-not-vendored corpus:
+#      - kr0ki: docs/conformance-target.toml pins tag 2026-07; scripts/fetch-sysml-v2-
+#        release.sh extracts only sysml/src/{validation,examples}, kerml/src/examples,
+#        sysml.library, bnf. Gated: validation corpus 56/56, standard library 94/94
+#        (via sysml-v2-parser 0.55 — see the sysml-v2-parser datum).
+#      - sysml-v2-parser (elan8): its own docs/conformance-target pins a tag and
+#        gates BNF coverage + roundtrip against the same tree.
+# 🤓 The repo tarball is ~1.9 GB extracted (XMI blobs + PDFs). Fetch via
+#    github.com/Systems-Modeling/SysML-v2-Release/archive/refs/tags/<TAG>.tar.gz and
+#    extract only the textual paths (~1.85 MB of .sysml/.kerml). No expected-ERROR
+#    corpus exists here (positive fixtures only); the negative suite is in the OMG
+#    Pilot Implementation's Xtext-coupled *.xt xpect tests.
+
+[b00t]
+name = "sysml-v2-release"
+type = "repo"
+type_tags = ["reference"]
+hint = "OMG canonical SysML v2 release: spec + BNF grammar + normative standard library + validation/training/example models + Jupyter kernel. The b00tyverse SysML v2 conformance ground truth (EPL-2.0, monthly YYYY-MM tags, currently pinned at 2026-07)."
+keywords = ["sysml", "sysml2", "kerml", "omg-spec", "conformance", "standard-library", "bnf-grammar", "systems-modeling", "validation-corpus"]
+
+[b00t.source]
+url = "https://github.com/Systems-Modeling/SysML-v2-Release"
+
+[b00t.repo]
+description = "The OMG's monthly incremental release of the SysML v2 / KerML language: specifications, textual + graphical BNF, the normative model library, curated validation models, and the Jupyter kernel. Purpose: the pinned corpus every b00tyverse SysML v2 tool validates against."
+license = "EPL-2.0"
+topics = ["sysml", "sysml-v2", "kerml", "omg", "modeling-language", "standard-library", "conformance"]
+# ⚠️ verify: latest tag 2026-07 (published 2026-08-27). b00tyverse pin: 2026-07.
+#    Bump procedure lives in kr0ki docs/CONFORMANCE.md (edit conformance-target.toml,
+#    re-run, adjust the ratcheting baselines) — keep in lockstep with sysml-v2-parser.
+
+[[b00t.references]]
+name = "kr0ki conformance harness — docs/CONFORMANCE.md (phase 1: consume sysml-v2-parser)"
+url = "https://github.com/PromptExecution/kr0ki/blob/main/docs/CONFORMANCE.md"
+
+[[b00t.references]]
+name = "sysml-v2-parser (elan8) — the pure-Rust nom parser that exercises this corpus"
+url = "https://github.com/elan8/sysml-v2-parser"
+
+[[b00t.references]]
+name = "OMG SysML v2 spec"
+url = "https://www.omg.org/spec/SysML/2.0/"
+
+[[b00t.references]]
+name = "OMG Pilot Implementation (Java/Xtext) — holds the expected-error xpect suite"
+url = "https://github.com/Systems-Modeling/SysML-v2-Pilot-Implementation"
+
+[[b00t.references]]
+name = "sysml-v2-docs — the vendored spec markdown corpus (companion; agent-authored .sysml)"
+url = "https://github.com/PromptExecution/ufo-types"
+
+# b00t:map v1
+# summary: OMG canonical SysML v2 release — spec + BNF + normative standard library + validation corpus; the b00tyverse SysML v2 conformance ground truth (EPL-2.0, tag 2026-07)
+# tags: reference, sysml, sysml-v2, kerml, omg-spec, conformance, standard-library, bnf
+# tier: sm0l
+# cmds: b00t-cli datum show sysml-v2-release.repo
+# complexity: 3


### PR DESCRIPTION
Datum-only. Registers the three external SysML-v2 surfaces that `kr0ki` now depends on, and brings `kr0ki.repo.toml` up to date with the work merged today (`kr0ki` PRs #1/#3/#4/#5/#7, `ufo-types` #20/#21).

## New datums
- **`sysml-v2-release.repo.toml`** — `Systems-Modeling/SysML-v2-Release` (EPL-2.0). The b00tyverse SysML v2 **conformance ground truth**: spec + BNF + normative standard library + validation corpus. Pinned at tag `2026-07` by both `kr0ki` (`docs/conformance-target.toml`) and `sysml-v2-parser`.
- **`sysml-v2-parser.repo.toml`** — `elan8/sysml-v2-parser` (MIT, pure-Rust nom, crates.io 0.55.0). Wrapped by `ufo_types::sysml::validate_sysml_v2` as the SysML v2 **syntax gate**; `kr0ki-core` dev-depends on it for the phase-1 conformance harness. Flags the known 0.55 deep-nesting stack-overflow.
- **`eclipse-syson.repo.toml`** — `eclipse-syson/syson` (EPL-2.0, Obeo + CEA List). kr0ki's SysML v2 **notation oracle** + optional authoring front-end; not a competitor (no headless render API). Per `kr0ki` `docs/EVAL-syson.md`.

(Flexo is already covered by the existing `flexo-mms-layer1-mcp` / `flexo-mms-sysmlv2-mcp` datums; SysML v2 spec docs + LSP by `sysml-v2-docs` / `sysml-v2-lsp`.)

## Updated
- **`kr0ki.repo.toml`** — status was stale ("no implementation yet"). Now: P0 render loop + conformance harness + `kr0ki-sysmlv2-client` shipped; the five-box ingestion pipeline; references to `PLAN-KR0KI-002`, `DESIGN-NOTE-typed-model-layer`, `PATTERNS-kubernetes`, `EVAL-flexo/syson`, and the new `ufo-types` `sysml_model` / `ontology` / `view` modules.

All four carry a `b00t:map v1` tail-map. No code, no schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)