### PR TITLE
#189: bump dstack 0.20.28 → 0.21.5 (k8s backend bring-up)

### DIFF
--- a/.github/workflows/ci-build-plane.yml
+++ b/.github/workflows/ci-build-plane.yml
@@ -47,7 +47,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v5
-      - run: uv tool install 'dstack[all]==0.20.28'
+      - run: uv tool install 'dstack[all]==0.21.5'
       - id: ref
         run: echo "sha=${{ github.event.pull_request.head.sha || inputs.ref || github.sha }}" >> "$GITHUB_OUTPUT"
       - name: Point dstack at the build plane
@@ -72,7 +72,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v5
-      - run: uv tool install 'dstack[all]==0.20.28'
+      - run: uv tool install 'dstack[all]==0.21.5'
       - name: Point dstack at the build plane
         run: |
           dstack project add --name main \

--- a/dev-env/b00t-build-fleet.yaml
+++ b/dev-env/b00t-build-fleet.yaml
@@ -46,7 +46,7 @@ resources:
 spot_policy: spot
 
 # Auto re-provision an evicted / capacity-starved node (verified accepted by
-# dstack 0.20.28: on_events, values interruption / no-capacity / error).
+# dstack 0.21.5: on_events, values interruption / no-capacity / error).
 retry:
   on_events: [interruption, no-capacity]
   duration: 1h

--- a/dev-env/b00t-build.dev-environment.yaml
+++ b/dev-env/b00t-build.dev-environment.yaml
@@ -36,7 +36,7 @@ retry:
 inactivity_duration: 30m
 
 env:
-  # dstack 0.20.28: bare `- FOO` resolves from the LOCAL shell only; secrets
+  # dstack 0.21.5: bare `- FOO` resolves from the LOCAL shell only; secrets
   # need `- FOO=${{ secrets.FOO }}` (server-side substitution).
   - b00t_build_deploy_key=${{ secrets.b00t_build_deploy_key }}   # read-only deploy key for elasticdotventures/_b00t_
 

--- a/docs/runbooks/dstack-k0s-soci.md
+++ b/docs/runbooks/dstack-k0s-soci.md
@@ -105,7 +105,27 @@ dstack apply -f dev-env/k0s-ci-test.task.yaml -n k0s-smoke \
 - Dagster: add a `backend` knob to `DstackResource` so `ci_build_plane` can
   target k8s for the run ops.
 
-## ⚠️ dstack 0.20.28 kubernetes backend — `NO_OFFERS` (2026-09-09)
+## dstack kubernetes backend — bring-up notes (2026-09-09)
+
+**dstack 0.20.28: `NO_OFFERS` for everything.** Bumped to **0.21.5** (b00t #189,
+`deploy_cp_node.py DSTACK_VERSION`). 0.21's k8s backend actually enumerates the
+cluster — but two gotchas:
+
+1. **Default `disk: 100GB` exceeds vultr1's 72GB ephemeral-storage** → no node
+   matches → `NO_OFFERS`. Set an explicit small `disk:` (e.g. `5GB`) in the task
+   / fleet `resources:`. `dev-env/k0s-ci-test.task.yaml` sets `disk: 40GB..` —
+   lower it or grow the node.
+2. **dstack creates an SSH jump-pod `Service` with `nodePort: <proxy_jump.port>`**
+   → `nodePort: 22` is outside k8s's `30000-32767` range → `422 Unprocessable
+   Entity`. Fix: `proxy_jump.port: 30022` (now the `deploy_cp_node.py` default)
+   + open `tcp:30022` `tag:vultr1` in the tailnet ACL (done).
+
+With both applied, dstack 0.21.5 gets a valid k8s offer and attempts pod
+creation. A fleet must exist first (`type: fleet` + `backends: [kubernetes]` +
+sized `resources:`); a residual fleet/offer retry interaction is still being
+worked — drive pods via kubectl/Dagster if `dstack apply` stalls.
+
+## (historical) dstack 0.20.28 kubernetes backend — `NO_OFFERS`
 
 The backend is wired and the control node reaches the k8s API + `proxy_jump`
 (both verified), but `dstack apply` (task or fleet) against `backends:

--- a/docs/runbooks/remote-build-server.md
+++ b/docs/runbooks/remote-build-server.md
@@ -70,7 +70,7 @@ CP_HOST=localhost pyinfra --ssh-port 2222 --ssh-user brianh \
 (`~/.ssh/google_compute_engine` is auto-created by a first
 `gcloud compute ssh b00t-dstack-control --zone australia-southeast1-a --tunnel-through-iap`.)
 
-Installs `dstack[all]==0.20.28`, renders `~/.dstack/server/config.yml` (GCP
+Installs `dstack[all]==0.21.5`, renders `~/.dstack/server/config.yml` (GCP
 backend, metadata ADC — no keys), the `dstack-server` systemd unit, and the
 `dstack-idle-reaper` timer (powers the VM off when dstack is idle).
 

--- a/nats/pyinfra/deploy_cp_node.py
+++ b/nats/pyinfra/deploy_cp_node.py
@@ -33,7 +33,7 @@ from pyinfra.operations import apt, files, server, systemd
 # pyinfra resolves files.put/template `src` against CWD, not this script's dir.
 _D = Path(__file__).parent
 
-DSTACK_VERSION = "0.20.28"
+DSTACK_VERSION = "0.21.5"
 # "main" = dstack's default project name (the server auto-creates it and writes
 # the CLI's ~/.dstack/config.yml against it). Standardize on it everywhere —
 # the reaper, the post-check, and the operator's `dstack project add main ...`.
@@ -61,12 +61,12 @@ tailscale_tag = host.data.get("tailscale_tag", "tag:b00t-control-plane")
 
 # Optional kubernetes backend (k0s on b00t-node). Pass:
 #   --data k0s_kubeconfig=/local/path/to/b00t-node.kubeconfig
-#   --data k0s_proxy_jump_host=<b00t-node tailnet IP>   [--data k0s_proxy_jump_port=22]
+#   --data k0s_proxy_jump_host=<b00t-node tailnet IP>   [--data k0s_proxy_jump_port=30022]
 # k0s_kubeconfig is a LOCAL file (fetched via files/fetch-k0s-kubeconfig.sh);
 # it is put to ~/.dstack/kube/ on the control node and referenced by the config.
 k0s_kubeconfig_src = host.data.get("k0s_kubeconfig", "")
 k0s_proxy_jump_host = host.data.get("k0s_proxy_jump_host", "")
-k0s_proxy_jump_port = str(host.data.get("k0s_proxy_jump_port", 22))
+k0s_proxy_jump_port = str(host.data.get("k0s_proxy_jump_port", 30022))
 k0s_kubeconfig_dest = (
     f"{HOME}/.dstack/kube/b00t-node.kubeconfig" if k0s_kubeconfig_src else ""
 )

--- a/nats/pyinfra/files/b00t-cp-idle-reaper.sh
+++ b/nats/pyinfra/files/b00t-cp-idle-reaper.sh
@@ -37,7 +37,7 @@ if ss -Htn state established '( sport = :3000 )' 2>/dev/null | grep -q .; then
 fi
 
 # --- 3. dstack has active runs -------------------------------------------
-#   `dstack ps -a` on 0.20.28 prints a table; --project comes from
+#   `dstack ps -a` on 0.21.5 prints a table; --project comes from
 #   $DSTACK_PROJECT. Fail-safe: a non-zero exit => stay up.
 runs="$("$DSTACK" ps -a 2>/dev/null)" || stay "dstack ps failed (fail-safe)"
 if printf '%s\n' "$runs" | grep -qiE 'provisioning|pending|running|terminating'; then


### PR DESCRIPTION
b00t task #189 — was blocked on #1280 (now merged).

## Server (applied + verified)
`nats/pyinfra/deploy_cp_node.py` `DSTACK_VERSION 0.20.28 → 0.21.5`; `ci-build-plane.yml` CLIs match (0.21 CLIs don't talk to 0.20 servers — server-first). Ran `deploy_cp_node.py` against the control node over tailnet:
```
The dstack server 0.21.5 is running at http://0.0.0.0:3000
Post-check: dstack server up + GCP backend healthy   Success
```
GCP + kubernetes backends load clean on 0.21.5; the b00t-cp-idle-reaper's `dstack ps -a` parse still works.

## kubernetes backend — two gotchas found & fixed
1. **`NO_OFFERS`** on 0.20.28 for *everything*; on 0.21.5 it enumerates the cluster but the **default `disk: 100GB` > vultr1's 72GB ephemeral-storage** → still no match. Task/fleet `resources:` need an explicit small `disk:`.
2. **`422 Unprocessable Entity`** — dstack 0.21 makes an SSH jump-pod `Service` with `nodePort: <proxy_jump.port>`; `22` is outside k8s's `30000-32767`. Fix: **`k0s_proxy_jump_port` default `22 → 30022`** + `tcp:30022` opened for `tag:vultr1` in the tailnet ACL.

With both, dstack 0.21.5 gets a valid k8s offer and attempts pod creation (a residual fleet/offer retry interaction is still being chased; interim = kubectl/Dagster).

## Files
`deploy_cp_node.py`, `.github/workflows/ci-build-plane.yml`, `docs/runbooks/dstack-k0s-soci.md` (bring-up notes), version-comment refs in `dev-env/*.yaml` + `b00t-cp-idle-reaper.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)