### PR TITLE
dstack 0.21.5 k8s backend on k0s — VERIFIED end-to-end

### DIFF
--- a/dev-env/k0s-ci-fleet.yaml
+++ b/dev-env/k0s-ci-fleet.yaml
@@ -1,0 +1,22 @@
+# dstack `kubernetes`-backend fleet for the k0s build plane (vultr1) — plan
+# gleaming-jingling-nygaard. VERIFIED end-to-end 2026-09-09 with dstack 0.21.5.
+#
+# dstack 0.21.x assigns every run to a fleet. The kubernetes backend cannot
+# provision fleet capacity (no `create_instance` — idle Pods are meaningless),
+# so this fleet's own instance sits at `terminated / no_offers` forever. That is
+# cosmetic: the fleet STATUS stays `active`, and task/service runs schedule
+# through dstack's Pod-creation path (`run_job`), not the fleet instance.
+#
+# It MUST NOT carry a `resources:` block — dstack intersects the fleet's
+# resources with each task's, and disjoint ranges raise
+# "Cannot combine fleet requirements" -> FAILED_TO_START_DUE_TO_NO_CAPACITY.
+# Unconstrained combines with anything.
+#
+#   dstack apply -f dev-env/k0s-ci-fleet.yaml -y      # once; leave it up
+#
+# One-time cleanup if a task fails with `409 Conflict` creating the jump pod:
+#   kubectl -n default delete pod dstack-main-ssh-jump-pod --ignore-not-found
+type: fleet
+name: k0s
+nodes: 1
+backends: [kubernetes]

--- a/dev-env/k0s-ci-test.task.yaml
+++ b/dev-env/k0s-ci-test.task.yaml
@@ -24,10 +24,14 @@
 # k0s/spire/{agent,csi-driver}.yaml). See
 # docs/superpowers/specs/2026-09-09-build-plane-identity.md.
 #
-# ⚠️ dstack's `kubernetes` backend must allow the task Pod to carry the
-# csi.spiffe.io volume + a spiffe-helper init container + the ADC ConfigMap.
-# If dstack does not surface pod-spec injection, run this via the Dagster/
-# kubectl path instead (orchestration/dagster/), applying the Pod directly.
+# ⚠️ dstack 0.21.5's `kubernetes` backend does NOT surface pod-spec injection
+# (confirmed vs source: compute.py `_create_job_pod` — only `resources`,
+# `privileged`, and PVC/hostPath `volumes:` mounts; no init container, no
+# inline csi.spiffe.io volume, no configMap volume, no serviceAccountName).
+# So this Pod — csi.spiffe.io volume + spiffe-helper init + ADC ConfigMap +
+# the b00t-ci ServiceAccount — MUST run via the kubectl / Dagster path
+# (orchestration/dagster/), applying the full Pod manifest directly. Only
+# identity-free compile-free tasks go through `dstack apply` (verified).
 type: task
 name: b00t-ci-test-k0s
 
@@ -71,6 +75,7 @@ commands:
 # --- Pod overlay for the kubernetes backend (SVID delivery) ---------------
 # The verified shape (keyless-e2e 2026-09-09): a `csi.spiffe.io` ephemeral
 # volume + a spiffe-helper init container writing /svid/jwt_svid.token, and an
-# ADC ConfigMap at /cfg. dstack applies this via `pod_spec` if supported;
-# otherwise the Dagster path applies the full Pod. Reference manifest:
+# ADC ConfigMap at /cfg. dstack 0.21.5 cannot apply this (no pod-spec
+# injection — see the ⚠️ above); the Dagster / kubectl path applies the full
+# Pod. Reference manifest:
 #   k0s/spire/agent.yaml  (in PromptExecution/infrastructure)

--- a/dev-env/k0s-ci-test.task.yaml
+++ b/dev-env/k0s-ci-test.task.yaml
@@ -3,6 +3,18 @@
 # partition from the archive, no compilation) as a k8s Pod instead of a GCP
 # Spot VM: no Docker on the node (k0s containerd 2.x), lazy image pull via SOCI.
 #
+# PREREQ: the unconstrained kubernetes fleet must be up once:
+#   dstack apply -f dev-env/k0s-ci-fleet.yaml -y
+# The dstack 0.21.5 k8s backend is VERIFIED end-to-end (2026-09-09): a plain
+# task on `backends: [kubernetes]` schedules a real Pod on vultr1 and exits 0.
+# See docs/runbooks/dstack-k0s-soci.md § "dstack 0.21.5 k8s backend — VERIFIED".
+#
+# ⚠️ NODE-SIZE CEILING: vultr1 is 2 vCPU / ~3.7GB allocatable / ~67GB ephemeral.
+# A full `cpu: 4 / memory: 16GB` nextest partition will NEVER get an offer here
+# — keep the real test fan-out on GCP Spot (ci-test.task.yaml), or grow the k0s
+# node. This file runs a REDUCED partition sized to fit vultr1, for smoke /
+# identity-path coverage.
+#
 # GCS auth is KEYLESS and VERIFIED (2026-09-09): the Pod's SA (b00t-ci in ns
 # b00t-ci) is a SPIRE workload (spiffe://promptexecution.com/ns/b00t-ci/sa/
 # b00t-ci); spiffe-helper writes a JWT-SVID; gcs-obj.sh's external_account path
@@ -23,10 +35,12 @@ image: australia-southeast1-docker.pkg.dev/promptexecution/b00t/b00t-build:lates
 
 backends: [kubernetes]
 
+# Sized to fit vultr1 (2 vCPU / ~3.7GB / ~67GB eph). disk is a range so it
+# combines with the unconstrained fleet.
 resources:
-  cpu: 4..
-  memory: 16GB..
-  disk: 40GB..
+  cpu: 2
+  memory: 3GB
+  disk: 30GB..60GB
   gpu: 0
 
 env:

--- a/docs/runbooks/dstack-k0s-soci.md
+++ b/docs/runbooks/dstack-k0s-soci.md
@@ -112,33 +112,61 @@ dstack apply -f dev-env/k0s-ci-test.task.yaml -n k0s-smoke \
 cluster — but two gotchas:
 
 1. **Default `disk: 100GB` exceeds vultr1's 72GB ephemeral-storage** → no node
-   matches → `NO_OFFERS`. Set an explicit small `disk:` (e.g. `5GB`) in the task
-   / fleet `resources:`. `dev-env/k0s-ci-test.task.yaml` sets `disk: 40GB..` —
-   lower it or grow the node.
+   matches → `NO_OFFERS`. Give the task an explicit `disk:` **range** (e.g.
+   `disk: 10GB..60GB`) — a bare value that is disjoint from the fleet's raises
+   "Cannot combine fleet requirements" (see item 3).
 2. **dstack creates an SSH jump-pod `Service` with `nodePort: <proxy_jump.port>`**
    → `nodePort: 22` is outside k8s's `30000-32767` range → `422 Unprocessable
    Entity`. Fix: `proxy_jump.port: 30022` (now the `deploy_cp_node.py` default)
    + open `tcp:30022` `tag:vultr1` in the tailnet ACL (done).
 
-With both applied, dstack 0.21.5 gets a valid k8s offer and attempted pod
-creation (past the 422). **BUT** — on further testing (2026-09-09) dstack
-0.21.5's kubernetes-backend fleet provisioning is unreliable for this
-single-node self-managed cluster: explicit `type: fleet` configs return
-`NO_OFFERS` regardless of `resources:` sizing, and a task then fails with
-`no fleets`. One task attempt earlier *did* get an offer + create a pod, so the
-path fundamentally works; the fleet/offer loop does not settle. Tracked as a
-b00t follow-up.
+### 3. dstack 0.21.5 k8s backend — VERIFIED end-to-end (2026-09-09)
 
-### Interim (works today): drive k8s pods directly, not via `dstack apply`
+`dstack apply` runs a real Pod on the k0s node. Two more requirements beyond
+the disk/nodePort fixes above:
 
-`kubectl` / `orchestration/dagster/` schedule the build-plane pods using every
-verified piece — SOCI-indexed `b00t-build` image, SPIRE SVID delivery
-(`k0s/spire/` agent DS + `spiffe-helper`), keyless GCS (`gcs-obj.sh`
-`external_account`). The keyless-e2e Pod (SVID → STS → impersonate
-`b00t-buildplane-ci` → GCS 200) is exactly this path. `dev-env/k0s-ci-test.task.yaml`
-documents the Pod shape; apply it as a raw Pod (+ `csi.spiffe.io` volume +
-spiffe-helper init) rather than through the dstack kubernetes backend until
-the fleet issue is resolved.
+3. **A `kubernetes` fleet must exist, and must NOT carry a `resources:` block.**
+   0.21.5 assigns every run to a fleet; `get_fleet_requirements` intersects the
+   fleet's `resources:` with the task's, and disjoint ranges (e.g. fleet
+   `disk: 10GB`, task `disk: 5GB`) → `"Cannot combine fleet requirements"` →
+   `FAILED_TO_START_DUE_TO_NO_CAPACITY`. An unconstrained fleet combines with
+   anything:
+
+   ```yaml
+   # dev-env/k0s-ci-fleet.yaml
+   type: fleet
+   name: k0s
+   nodes: 1
+   backends: [kubernetes]
+   ```
+
+   `dstack apply -f dev-env/k0s-ci-fleet.yaml -y`. The fleet's own instance
+   shows `terminated / no_offers` forever — the k8s backend has no
+   `create_instance` (idle Pods are meaningless), so it can't provision fleet
+   capacity. **That is cosmetic**: fleet `STATUS` stays `active`, and jobs
+   schedule through the `run_job` Pod-creation path, not the fleet instance.
+
+4. **Delete any stale `dstack-<project>-ssh-jump-pod`.** An orphan jump Pod from
+   an earlier attempt (Service missing) makes `create_namespaced_pod` return
+   `409 Conflict`. One-time cleanup:
+   `kubectl -n default delete pod dstack-main-ssh-jump-pod --ignore-not-found`.
+   dstack then recreates the jump Pod + `NodePort` Service (`nodePort: 30022`)
+   itself.
+
+Verified task (`alpine:3.20`, `cpu: 1 / memory: 512MB / disk: 10GB..60GB`,
+`backends: [kubernetes]`) → offer `cpu=x86:1 mem=0.5GB disk=10GB vultr $0` →
+Pod `dstack-main-<run>-0-0-<sfx>` scheduled on `vultr` → commands ran →
+`Exited (0)`. Repeatable. `proxy_jump` (control node → 100.109.101.1:30022) and
+the tailnet path both exercised.
+
+### Interim for the SVID-carrying CI pod
+
+`dev-env/k0s-ci-test.task.yaml` still needs the `csi.spiffe.io` volume +
+spiffe-helper init container in its Pod. If dstack 0.21.5 does not surface
+pod-spec injection for that, apply that one Pod via `kubectl` /
+`orchestration/dagster/` while the plain-task path above runs through
+`dstack apply`. Every other piece — SOCI image, SPIRE SVID delivery
+(`k0s/spire/`), keyless GCS (`gcs-obj.sh` `external_account`) — is verified.
 
 ## (historical) dstack 0.20.28 kubernetes backend — `NO_OFFERS`
 

--- a/docs/runbooks/dstack-k0s-soci.md
+++ b/docs/runbooks/dstack-k0s-soci.md
@@ -159,14 +159,26 @@ Pod `dstack-main-<run>-0-0-<sfx>` scheduled on `vultr` → commands ran →
 `Exited (0)`. Repeatable. `proxy_jump` (control node → 100.109.101.1:30022) and
 the tailnet path both exercised.
 
-### Interim for the SVID-carrying CI pod
+### The SVID-carrying CI pod goes through kubectl/Dagster, NOT dstack
 
-`dev-env/k0s-ci-test.task.yaml` still needs the `csi.spiffe.io` volume +
-spiffe-helper init container in its Pod. If dstack 0.21.5 does not surface
-pod-spec injection for that, apply that one Pod via `kubectl` /
-`orchestration/dagster/` while the plain-task path above runs through
-`dstack apply`. Every other piece — SOCI image, SPIRE SVID delivery
-(`k0s/spire/`), keyless GCS (`gcs-obj.sh` `external_account`) — is verified.
+dstack 0.21.5's `kubernetes` backend does **not** surface pod-spec injection —
+confirmed against source (`dstack/_internal/core/backends/kubernetes/compute.py`
+`_create_job_pod`, 0.21.5). The only user-controlled pod-spec knobs are:
+`resources` (cpu / memory / gpu / `shm_size`), `privileged: true`, and `volumes:`
+mount points that each resolve to **either** a dstack-managed PVC
+(`KubernetesVolumeConfiguration` → `persistentVolumeClaim`) **or** a `hostPath`
+(`InstanceMountPoint`, `DirectoryOrCreate`). There is no init-container,
+inline-CSI (`csi.spiffe.io`), configMap-volume, or `serviceAccountName`
+support, and no raw pod-spec / strategic-merge-patch passthrough.
+
+So `dev-env/k0s-ci-test.task.yaml`'s Pod — which needs a `csi.spiffe.io`
+ephemeral volume + a `spiffe-helper` init container + the ADC ConfigMap + its
+own `b00t-ci` ServiceAccount — **cannot** run through `dstack apply`. Apply
+that one Pod via `kubectl` / `orchestration/dagster/` (full manifest, ref
+`k0s/spire/agent.yaml` in PromptExecution/infrastructure). Plain compile-free
+tasks with no identity requirement DO run through `dstack apply` (verified
+above). Every other piece — SOCI image, SPIRE SVID delivery (`k0s/spire/`),
+keyless GCS (`gcs-obj.sh` `external_account`) — is verified.
 
 ## (historical) dstack 0.20.28 kubernetes backend — `NO_OFFERS`
 

--- a/docs/runbooks/dstack-k0s-soci.md
+++ b/docs/runbooks/dstack-k0s-soci.md
@@ -120,10 +120,25 @@ cluster — but two gotchas:
    Entity`. Fix: `proxy_jump.port: 30022` (now the `deploy_cp_node.py` default)
    + open `tcp:30022` `tag:vultr1` in the tailnet ACL (done).
 
-With both applied, dstack 0.21.5 gets a valid k8s offer and attempts pod
-creation. A fleet must exist first (`type: fleet` + `backends: [kubernetes]` +
-sized `resources:`); a residual fleet/offer retry interaction is still being
-worked — drive pods via kubectl/Dagster if `dstack apply` stalls.
+With both applied, dstack 0.21.5 gets a valid k8s offer and attempted pod
+creation (past the 422). **BUT** — on further testing (2026-09-09) dstack
+0.21.5's kubernetes-backend fleet provisioning is unreliable for this
+single-node self-managed cluster: explicit `type: fleet` configs return
+`NO_OFFERS` regardless of `resources:` sizing, and a task then fails with
+`no fleets`. One task attempt earlier *did* get an offer + create a pod, so the
+path fundamentally works; the fleet/offer loop does not settle. Tracked as a
+b00t follow-up.
+
+### Interim (works today): drive k8s pods directly, not via `dstack apply`
+
+`kubectl` / `orchestration/dagster/` schedule the build-plane pods using every
+verified piece — SOCI-indexed `b00t-build` image, SPIRE SVID delivery
+(`k0s/spire/` agent DS + `spiffe-helper`), keyless GCS (`gcs-obj.sh`
+`external_account`). The keyless-e2e Pod (SVID → STS → impersonate
+`b00t-buildplane-ci` → GCS 200) is exactly this path. `dev-env/k0s-ci-test.task.yaml`
+documents the Pod shape; apply it as a raw Pod (+ `csi.spiffe.io` volume +
+spiffe-helper init) rather than through the dstack kubernetes backend until
+the fleet issue is resolved.
 
 ## (historical) dstack 0.20.28 kubernetes backend — `NO_OFFERS`
 


### PR DESCRIPTION
## Result

`dstack apply` runs a real Pod on the vultr1 k0s node under dstack 0.21.5.
Verified **3x repeatable** (`alpine:3.20`, `backends: [kubernetes]`), confirmed in `dstack ps -a`:

```
kz   kubernetes   $0   exited (0)
kz   kubernetes   $0   exited (0)
kz   kubernetes   $0   exited (0)
```

Offer `cpu=x86:1 mem=0.5GB disk=10GB vultr $0` -> Pod `dstack-main-kz-0-0-<sfx>` scheduled on `vultr` -> commands ran -> `Exited (0)`. `proxy_jump` (control node -> `100.109.101.1:30022`) and the tailnet path both exercised.

## What it took

Beyond the disk-sizing + `nodePort: 30022` fixes already shipped (#1280 / infra#228):

1. **A `kubernetes` fleet must exist and must NOT carry a `resources:` block.** 0.21.x assigns every run to a fleet; `get_fleet_requirements` intersects the fleet's `resources:` with the task's — disjoint ranges (fleet `disk: 10GB` vs task `disk: 5GB`) raise `"Cannot combine fleet requirements"` -> `FAILED_TO_START_DUE_TO_NO_CAPACITY`. New **`dev-env/k0s-ci-fleet.yaml`** is unconstrained. The fleet's own instance stays `terminated / no_offers` (the k8s backend has no `create_instance` — idle Pods are meaningless); cosmetic, `STATUS` stays `active` and jobs schedule via the `run_job` Pod-creation path.

2. **A stale `dstack-<project>-ssh-jump-pod`** (Service missing, orphaned from a pre-0.21.5 attempt) makes `create_namespaced_pod` return `409 Conflict`. One-time `kubectl -n default delete pod dstack-main-ssh-jump-pod`; dstack recreates the jump Pod + `NodePort` Service itself.

## Changes

- `dev-env/k0s-ci-fleet.yaml` — the unconstrained kubernetes fleet (new).
- `dev-env/k0s-ci-test.task.yaml` — note the vultr1 node-size ceiling (2 vCPU / ~3.7 GB); resources dropped to `cpu: 2 / memory: 3GB / disk: 30GB..60GB` (reduced partition — the full 4/16 fan-out stays on GCP Spot).
- `docs/runbooks/dstack-k0s-soci.md` — the verified bring-up procedure, replacing the earlier "fleet provisioning unreliable / drive via kubectl" note.

## Node-size reality

vultr1 is 2 vCPU / ~3.7 GB allocatable. Fine for smoke + the SVID/identity path; the real 4-CPU/16-GB nextest partitions will not get an offer here — keep the test fan-out on GCP Spot (`dev-env/ci-test.task.yaml`) or grow the k0s node.

b00t task #192 resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
