### PR TITLE
fix(build-plane): idle-reaper ignores terminated kubernetes-backend fleets

### DIFF
--- a/_b00t_/learn/dstack.md
+++ b/_b00t_/learn/dstack.md
@@ -1,2 +1,5 @@
 ---
 architecture: dstack is compute orchestration above RunPod/AWS/k8s. Install: uv tool install 'dstack[all]'. Not compatible with HF Jobs — wire as ORCHESTRATOR=dstack separate from ORCHESTRATOR=hf.
+
+---
+dstack 0.21.5 kubernetes backend has NO pod-spec injection: compute.py _create_job_pod exposes only resources (cpu/mem/gpu/shm_size), privileged:true, and volumes: mounts that resolve to a dstack-managed PVC (KubernetesVolumeConfiguration) or a hostPath (InstanceMountPoint). No init containers, no inline CSI (csi.spiffe.io), no configMap volume, no serviceAccountName override, no raw pod_spec/patch. Pods that need SPIRE SVID delivery (csi.spiffe.io + spiffe-helper init + ADC ConfigMap + custom SA) MUST be applied via kubectl/Dagster, not dstack apply. Plain identity-free tasks run fine through dstack apply on backends:[kubernetes] once an unconstrained fleet (no resources: block) exists.

--- a/nats/pyinfra/files/b00t-cp-idle-reaper.sh
+++ b/nats/pyinfra/files/b00t-cp-idle-reaper.sh
@@ -44,11 +44,22 @@ if printf '%s\n' "$runs" | grep -qiE 'provisioning|pending|running|terminating';
   stay "dstack has a non-terminal run"
 fi
 
-# --- 4. dstack fleet not empty ----------------------------------------------
+# --- 4. dstack fleet has a LIVE instance ----------------------------------
+#   0.21.x prints one row per fleet plus an `instance=N` row per node. A
+#   `kubernetes`-backend fleet (kept up as a standing prereq for k8s runs)
+#   shows its instance `terminated` forever — it provisions no VM and costs
+#   nothing, so it must NOT pin the control node up. Only an instance in a
+#   live state counts. Fail-safe: a query error, or fleet rows present with
+#   no recognizable `instance=` line, => stay up.
 fleet="$("$DSTACK" fleet 2>/dev/null)" || stay "dstack fleet query failed (fail-safe)"
-# Header line always prints; a data row means an instance exists.
 if [ "$(printf '%s\n' "$fleet" | sed '1d' | grep -c .)" -gt 0 ]; then
-  stay "dstack fleet non-empty"
+  inst_rows="$(printf '%s\n' "$fleet" | grep -cE '^[[:space:]]+instance=')"
+  live_rows="$(printf '%s\n' "$fleet" | grep -E '^[[:space:]]+instance=' \
+                | grep -cviE 'terminated|failed')"
+  if [ "$inst_rows" -eq 0 ] || [ "$live_rows" -gt 0 ]; then
+    stay "dstack fleet has a live (or unrecognized) instance"
+  fi
+  log "fleet present but all ${inst_rows} instance row(s) terminated/failed — not a hold"
 fi
 
 # --- nothing holding it — power off --------------------------------------


### PR DESCRIPTION
## Problem

The GCP dstack control node (`b00t-dstack-control`) stopped scaling to zero after PR #1282 landed the standing `k0s` `kubernetes`-backend fleet.

`b00t-cp-idle-reaper.sh` step 4 treated **any** `dstack fleet` data row as a live instance:

```sh
if [ "$(printf '%s\n' "$fleet" | sed '1d' | grep -c .)" -gt 0 ]; then
  stay "dstack fleet non-empty"
fi
```

dstack 0.21.x's `kubernetes` backend has no `create_instance`, so the `k0s` fleet's instance sits at `terminated` **forever** (by design — idle Pods are meaningless). The reaper read that as activity and held the node up. Observed: 7h+ idle, every 5-min tick logging `HOLD: dstack fleet non-empty`.

## Fix

Step 4 now holds only for an `instance=` row **not** in `terminated`/`failed` state. Fail-safe preserved — a query error, or fleet rows with no recognizable `instance=` line, still keeps the node up.

## Verification

Hot-patched on `b00t-dstack-control` and dry-ran the logic against live state:

```
rows=2 inst_rows=1 live_rows=0
VERDICT: not-a-hold -> proceeds to other checks / POWEROFF
no hold file / keepalive stale / :3000 idle / no non-terminal run
```

Repo source (`nats/pyinfra/files/b00t-cp-idle-reaper.sh`) matches the hot-patched node copy (`md5 3d7a23fe…`). `bash -n` clean.

Also folds in the `_b00t_/learn/dstack.md` note that dstack 0.21.5's k8s backend has no pod-spec injection (from the #1282 follow-up).

b00t task #194

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cj7a4Bkh8pRQuzcErD1j2E