### PR TITLE
ci(build-plane): join the tailnet before reaching the control plane

### DIFF
--- a/.github/workflows/ci-build-plane.yml
+++ b/.github/workflows/ci-build-plane.yml
@@ -10,11 +10,29 @@
 # always-on fast path. Opt-in: `workflow_dispatch` or a PR labeled
 # `build-plane-ci`.
 #
+# --- TAILNET INGRESS (Phase 2.75) ----------------------------------------
+# The control node is tailnet-only: no external IP, and the Cloud Run pingap
+# waker was destroyed by `network_mode = "tailnet"`. A GitHub-hosted runner
+# therefore CANNOT reach the build plane until it joins the tailnet, which is
+# what the "Join the tailnet" step below does (b00t #196).
+#
 # Repo settings required (Settings -> Secrets and variables -> Actions):
-#   variable DSTACK_URL          = the waker URL
-#                                  (`cd b00t-tf && tofu output -raw gcp_control_node_endpoint`)
+#   secret   TS_OAUTH_CLIENT_ID  \ Tailscale OAuth client, scope `auth_keys`,
+#   secret   TS_OAUTH_SECRET     / allowed to issue `tag:ci-runner`
 #   secret   DSTACK_ADMIN_TOKEN  = the `token:` from ~/.dstack/server/config.yml
+#   variable DSTACK_URL          = the TAILNET waker address:
+#                                  `cd b00t-tf && tofu output -raw gcp_control_node_endpoint`
+#                                  in network_mode=tailnet -> http://100.109.101.1:8088
+#                                  (vultr1 k0s-pod waker — powers the
+#                                  scaled-to-zero control node on first call,
+#                                  ~90s, then proxies to dstack :3000).
 #   ( enrol repos with: just remote-enroll [--label] owner/repo … )
+#
+# Tailnet ACL (operator, one-time): own `tag:ci-runner` and grant it
+#   tcp:3000 -> tag:b00t-control-plane   (dstack API via the waker/proxy)
+#   tcp:8088 -> tag:vultr1               (the waker itself, cold-start)
+# An `authkey:`-based join also works — swap `oauth-client-id`/`oauth-secret`
+# for `authkey: ${{ secrets.TS_AUTHKEY }}` (ephemeral, preauthorized, tagged).
 name: ci-build-plane
 
 on:
@@ -50,11 +68,31 @@ jobs:
       - run: uv tool install 'dstack[all]==0.21.5'
       - id: ref
         run: echo "sha=${{ github.event.pull_request.head.sha || inputs.ref || github.sha }}" >> "$GITHUB_OUTPUT"
-      - name: Point dstack at the build plane
+      - name: Join the tailnet
+        uses: tailscale/github-action@v4
+        with:
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+          tags: tag:ci-runner
+          hostname: ci-build-plane-build-${{ github.run_id }}
+      - name: Wake + point dstack at the build plane
+        env:
+          DSTACK_URL: ${{ vars.DSTACK_URL }}
+          DSTACK_ADMIN_TOKEN: ${{ secrets.DSTACK_ADMIN_TOKEN }}
         run: |
-          dstack project add --name main \
-            --url "${{ vars.DSTACK_URL }}" \
-            --token "${{ secrets.DSTACK_ADMIN_TOKEN }}"
+          # $DSTACK_URL is the tailnet waker (see header). Poke it first so the
+          # scaled-to-zero control node powers on, then retry `project add`
+          # while it finishes booting (~90s) and dstack :3000 comes up.
+          curl -fsS -m 240 --retry 8 --retry-all-errors -o /dev/null \
+            "$DSTACK_URL/api/projects" || true
+          ok=""
+          for i in $(seq 1 12); do
+            if dstack project add --name main --url "$DSTACK_URL" --token "$DSTACK_ADMIN_TOKEN"; then
+              ok=1; break
+            fi
+            echo "project add not ready yet (attempt $i) — sleeping 15s"; sleep 15
+          done
+          [ -n "$ok" ] || { echo "::error::control plane unreachable via $DSTACK_URL after retries"; exit 1; }
       - name: Build + archive (1 VM, 1 compile)
         run: |
           dstack apply -f dev-env/ci-build.task.yaml -n "ci-build-${GITHUB_RUN_ID}" \
@@ -73,11 +111,30 @@ jobs:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v5
       - run: uv tool install 'dstack[all]==0.21.5'
-      - name: Point dstack at the build plane
+      - name: Join the tailnet
+        uses: tailscale/github-action@v4
+        with:
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+          tags: tag:ci-runner
+          hostname: ci-build-plane-test-${{ github.run_id }}-p${{ strategy.job-index }}
+      - name: Wake + point dstack at the build plane
+        env:
+          DSTACK_URL: ${{ vars.DSTACK_URL }}
+          DSTACK_ADMIN_TOKEN: ${{ secrets.DSTACK_ADMIN_TOKEN }}
         run: |
-          dstack project add --name main \
-            --url "${{ vars.DSTACK_URL }}" \
-            --token "${{ secrets.DSTACK_ADMIN_TOKEN }}"
+          # The build job already woke the control node; the retry covers the
+          # case where the idle-reaper scaled it back down between stages.
+          curl -fsS -m 240 --retry 8 --retry-all-errors -o /dev/null \
+            "$DSTACK_URL/api/projects" || true
+          ok=""
+          for i in $(seq 1 12); do
+            if dstack project add --name main --url "$DSTACK_URL" --token "$DSTACK_ADMIN_TOKEN"; then
+              ok=1; break
+            fi
+            echo "project add not ready yet (attempt $i) — sleeping 15s"; sleep 15
+          done
+          [ -n "$ok" ] || { echo "::error::control plane unreachable via $DSTACK_URL after retries"; exit 1; }
       - name: Run partition ${{ matrix.partition }} from the archive (no compile)
         run: |
           NAME="ci-test-${GITHUB_RUN_ID}-p$(echo '${{ matrix.partition }}' | tr / -)"

--- a/.github/workflows/ci-build-plane.yml
+++ b/.github/workflows/ci-build-plane.yml
@@ -16,9 +16,11 @@
 # therefore CANNOT reach the build plane until it joins the tailnet, which is
 # what the "Join the tailnet" step below does (b00t #196).
 #
-# Repo settings required (Settings -> Secrets and variables -> Actions):
-#   secret   TS_OAUTH_CLIENT_ID  \ Tailscale OAuth client, scope `auth_keys`,
-#   secret   TS_OAUTH_SECRET     / allowed to issue `tag:ci-runner`
+# Repo settings required (Settings -> Secrets and variables -> Actions).
+# Only true credentials are secrets; everything else is a variable:
+#   variable TS_OAUTH_CLIENT_ID  = Tailscale OAuth client id (not sensitive),
+#                                  scope `auth_keys`, may issue `tag:ci-runner`
+#   secret   TS_OAUTH_SECRET     = that client's secret
 #   secret   DSTACK_ADMIN_TOKEN  = the `token:` from ~/.dstack/server/config.yml
 #   variable DSTACK_URL          = the TAILNET waker address:
 #                                  `cd b00t-tf && tofu output -raw gcp_control_node_endpoint`
@@ -71,7 +73,7 @@ jobs:
       - name: Join the tailnet
         uses: tailscale/github-action@v4
         with:
-          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-client-id: ${{ vars.TS_OAUTH_CLIENT_ID }}
           oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
           tags: tag:ci-runner
           hostname: ci-build-plane-build-${{ github.run_id }}
@@ -114,7 +116,7 @@ jobs:
       - name: Join the tailnet
         uses: tailscale/github-action@v4
         with:
-          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-client-id: ${{ vars.TS_OAUTH_CLIENT_ID }}
           oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
           tags: tag:ci-runner
           hostname: ci-build-plane-test-${{ github.run_id }}-p${{ strategy.job-index }}


### PR DESCRIPTION
**Draft — blocked on operator inputs (b00t #196). Do not merge until the vars/secret + ACL grant exist.**

## Why

Phase 2.75 made the control node tailnet-only — no external IP, Cloud Run pingap waker destroyed (`gcloud run services list` is empty). A GitHub-hosted runner can't reach the build plane anymore. Confirmed by dispatching `ci-build-plane.yml` run 34415089204: the `build` job failed in 14s at `dstack project add` -> `404 on .../api/projects/main/get`.

## What this changes (code only)

- Both `build` and `test` jobs run `tailscale/github-action@v4` (OAuth client, `tag:ci-runner`, ephemeral node) **before** any `dstack` call.
- "Point dstack at the build plane" -> "**Wake + point**": pokes `$DSTACK_URL` (the tailnet waker) to power the scaled-to-zero control node, then retries `dstack project add` for ~3 min while it boots. Secrets via `env:`, not inline `${{ }}`.
- `actionlint` clean.

## Operator prerequisites before this can run

Only real credentials are secrets; the rest are repo variables:

| Kind | Name | Value |
|---|---|---|
| **variable** | `TS_OAUTH_CLIENT_ID` | Tailscale OAuth client id (not sensitive), scope `auth_keys`, may issue `tag:ci-runner` |
| **secret** | `TS_OAUTH_SECRET` | that client's secret |
| **variable** | `DSTACK_URL` | the tailnet waker — `http://100.109.101.1:8088` (`cd b00t-tf && tofu output -raw gcp_control_node_endpoint`) |
| secret | `DSTACK_ADMIN_TOKEN` | already set |
| ACL | — | done — `tag:ci-runner` owned + granted `tcp:3000 -> tag:b00t-control-plane`, `tcp:8088 -> tag:vultr1` |

Depends on **#1285** (waker `hostNetwork` fix — without it `http://100.109.101.1:8088` doesn't listen). An `authkey:` join is a one-line swap if preferred over OAuth.

Once vars/secret are set: mark ready, merge, `workflow_dispatch ci-build-plane.yml` -> real build time, per-partition compile-free times, sccache / CARGO_HOME hit rates (step 1 of #195).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cj7a4Bkh8pRQuzcErD1j2E
