### PR TITLE
fix(waker): hostNetwork so the tailnet control-plane waker is reachable

### DIFF
--- a/deploy/k0s-waker/waker.yaml
+++ b/deploy/k0s-waker/waker.yaml
@@ -1,5 +1,6 @@
 # Tailnet control-plane waker — Phase 2.75. Runs on vultr1's k0s (always-on),
-# reachable at http://100.109.101.1:8088 over the tailnet. On any request it
+# reachable at http://100.109.101.1:8088 over the tailnet (hostNetwork — the
+# k0s CNI ignores the container hostPort). On any request it
 # starts the GCP control node (if TERMINATED) then reverse-proxies to
 # dstack-server at the control node's tailnet IP:3000. Replaces the public
 # Cloud Run waker so network_mode="tailnet" (no external IP) is viable.
@@ -37,9 +38,17 @@ metadata: { name: b00t-cp-waker, namespace: b00t-ci, labels: { app: b00t-cp-wake
 spec:
   replicas: 1
   selector: { matchLabels: { app: b00t-cp-waker } }
+  # hostNetwork singleton: a rolling update can't surge a 2nd pod onto the
+  # one node (host :8088 conflict) -> Recreate.
+  strategy: { type: Recreate }
   template:
     metadata: { labels: { app: b00t-cp-waker, b00t.plane: build } }
     spec:
+      # kube-router (k0s default CNI) does not chain the portmap plugin, so
+      # the container `hostPort` directive is a silent no-op here — run on the
+      # node's own netns so :8088 is bound on vultr1 for the tailnet.
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       serviceAccountName: b00t-ci
       containers:
         - name: spiffe-helper
@@ -62,7 +71,7 @@ spec:
             - { name: PORT, value: "8088" }
             - { name: START_DEADLINE_SECONDS, value: "150" }
             - { name: GOOGLE_APPLICATION_CREDENTIALS, value: /cfg/credential-configuration.json }
-          ports: [{ containerPort: 8088, hostPort: 8088 }]
+          ports: [{ containerPort: 8088 }]
           volumeMounts:
             - { name: src, mountPath: /app }
             - { name: svid, mountPath: /svid, readOnly: true }


### PR DESCRIPTION
Part of unblocking CI-on-the-build-plane (b00t #196, alongside #1284).

## Problem

`DSTACK_URL` for `ci-build-plane.yml` should be the tailnet waker `http://100.109.101.1:8088`, but that endpoint **times out** — nothing is bound to `:8088` on vultr1.

Root cause: `deploy/k0s-waker/waker.yaml` declares `hostPort: 8088`, but k0s's default **kube-router CNI does not chain the `portmap` plugin**, so `hostPort` is silently ignored. (`/opt/cni/bin/portmap` exists on the node but isn't in the CNI conflist.) The waker pod itself is healthy — just unreachable from outside the cluster.

## Fix

- `hostNetwork: true` + `dnsPolicy: ClusterFirstWithHostNet` — bind the node's own `:8088`; drop the dead `hostPort`.
- `strategy: Recreate` — a `RollingUpdate` can't surge a second hostNetwork pod onto the single node (host `:8088` conflict → `Pending` forever).

## Applied live + verified

```
$ ssh root@100.109.101.1
$ k0s kubectl -n b00t-ci patch deploy b00t-cp-waker …   # hostNetwork + Recreate
deployment.apps/b00t-cp-waker patched
$ ss -ltnp | grep 8088
LISTEN 0 5 0.0.0.0:8088  users:(("python3",pid=100302))

$ curl http://100.109.101.1:8088/_waker/health        # over the tailnet
200  (t=0.076s)
$ curl http://100.109.101.1:8088/api/projects
404 {"detail":"Not Found"}     # dstack-server's own 404 → proxy path works end-to-end
```

Waker log confirms the wake+proxy flow: `instance status = RUNNING` → `dstack ready (200) at http://100.92.193.0:3000/` → proxied.

Mergeable now (manifest matches the live state). After merge, re-apply is a no-op:
`kubectl kustomize deploy/k0s-waker | sed "s/CONTROL_TS_IP/100.92.193.0/" | kubectl apply -f -`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cj7a4Bkh8pRQuzcErD1j2E