### PR TITLE
fix(build-plane): Spot capacity fallback + reaper no longer kills retrying runs

### DIFF
--- a/dev-env/ci-build.task.yaml
+++ b/dev-env/ci-build.task.yaml
@@ -17,7 +17,10 @@ resources:
   disk: 200GB..
   gpu: 0
 
-spot_policy: spot
+# spot first, fall back to on-demand in-region: a Spot capacity gap in
+# australia-southeast1 must not wedge CI (observed 2026-09-10, run
+# 34419799571: `No matching instance offers`).
+spot_policy: auto
 retry:
   on_events: [no-capacity, interruption]
   duration: 20m

--- a/dev-env/ci-test.task.yaml
+++ b/dev-env/ci-test.task.yaml
@@ -14,7 +14,10 @@ resources:
   disk: 60GB..
   gpu: 0
 
-spot_policy: spot
+# spot first, fall back to on-demand in-region: a Spot capacity gap in
+# australia-southeast1 must not wedge CI (observed 2026-09-10, run
+# 34419799571: `No matching instance offers`).
+spot_policy: auto
 retry:
   on_events: [no-capacity, interruption]
   duration: 20m

--- a/nats/pyinfra/files/b00t-cp-idle-reaper.sh
+++ b/nats/pyinfra/files/b00t-cp-idle-reaper.sh
@@ -37,11 +37,14 @@ if ss -Htn state established '( sport = :3000 )' 2>/dev/null | grep -q .; then
 fi
 
 # --- 3. dstack has active runs -------------------------------------------
-#   `dstack ps -a` on 0.21.5 prints a table; --project comes from
-#   $DSTACK_PROJECT. Fail-safe: a non-zero exit => stay up.
-runs="$("$DSTACK" ps -a 2>/dev/null)" || stay "dstack ps failed (fail-safe)"
-if printf '%s\n' "$runs" | grep -qiE 'provisioning|pending|running|terminating'; then
-  stay "dstack has a non-terminal run"
+#   `dstack ps` (WITHOUT -a) lists only runs dstack still considers
+#   non-terminal, INCLUDING one inside its no-capacity retry window. The
+#   old `-a` + status-word allow-list missed that state and powered the
+#   node off mid-`dstack apply` (2026-09-10 run 34419799571 -> CLI 503).
+#   Any data row here => a run is live. Fail-safe: non-zero exit => stay up.
+runs="$("$DSTACK" ps 2>/dev/null)" || stay "dstack ps failed (fail-safe)"
+if [ "$(printf '%s\n' "$runs" | sed '1d' | grep -cvE '^[[:space:]]*$')" -gt 0 ]; then
+  stay "dstack has a live run"
 fi
 
 # --- 4. dstack fleet has a LIVE instance ----------------------------------


### PR DESCRIPTION
Surfaced by the first end-to-end `ci-build-plane.yml` measurement run ([34419799571](https://github.com/elasticdotventures/_b00t_/actions/runs/34419799571)) — the tailnet ingress worked (Tailscale join → waker → `dstack project add` → task planned), then two `_b00t_`-side issues bit:

## 1. No Spot offer → wedged

`dev-env/ci-build.task.yaml` (`cpu: 8.. / memory: 32GB.. / disk: 200GB..`, `spot_policy: spot`) against the gcp backend pinned to `australia-southeast1` only → `No matching instance offers available` → 20 min retry → fail.

→ `spot_policy: auto` on both build-plane tasks (spot first, on-demand fallback **in-region** — no cross-region image pull / egress).

## 2. Reaper killed the control node mid-`dstack apply`

`b00t-cp-idle-reaper.sh` step 3 held only on statuses `provisioning|pending|running|terminating`. A run inside its no-capacity retry window is none of those, so at 00:14:50 the reaper logged `POWEROFF … no runs` and powered off — the CLI then got `503` from the waker (upstream gone).

→ Step 3 now uses `dstack ps` (**without `-a`**): that lists exactly the runs dstack still considers non-terminal, retry-window included. Any data row → HOLD.

## Verification

Reaper hot-patched on `b00t-dstack-control`; `dstack ps | wc -l` currently reports 1 live row (the stuck retrying run) → reaper correctly HOLDs (previously it would have reaped).

Part of unblocking #195 step-1 measurement (b00t #196). After this + #1284 + #1285 land, re-dispatch `ci-build-plane.yml` for the real timings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cj7a4Bkh8pRQuzcErD1j2E