### PR TITLE
fix(build-plane): pin gcp backend + on-demand (au-southeast1 has no Spot quota)

### DIFF
--- a/.github/workflows/ci-build-plane.yml
+++ b/.github/workflows/ci-build-plane.yml
@@ -95,6 +95,8 @@ jobs:
             echo "project add not ready yet (attempt $i) — sleeping 15s"; sleep 15
           done
           [ -n "$ok" ] || { echo "::error::control plane unreachable via $DSTACK_URL after retries"; exit 1; }
+      - name: Ensure the elastic GCP fleet exists
+        run: dstack apply -f dev-env/gcp-ci-fleet.yaml -y
       - name: Build + archive (1 VM, 1 compile)
         run: |
           dstack apply -f dev-env/ci-build.task.yaml -n "ci-build-${GITHUB_RUN_ID}" \
@@ -137,6 +139,8 @@ jobs:
             echo "project add not ready yet (attempt $i) — sleeping 15s"; sleep 15
           done
           [ -n "$ok" ] || { echo "::error::control plane unreachable via $DSTACK_URL after retries"; exit 1; }
+      - name: Ensure the elastic GCP fleet exists
+        run: dstack apply -f dev-env/gcp-ci-fleet.yaml -y
       - name: Run partition ${{ matrix.partition }} from the archive (no compile)
         run: |
           NAME="ci-test-${GITHUB_RUN_ID}-p$(echo '${{ matrix.partition }}' | tr / -)"

--- a/dev-env/ci-build.task.yaml
+++ b/dev-env/ci-build.task.yaml
@@ -17,10 +17,13 @@ resources:
   disk: 200GB..
   gpu: 0
 
-# spot first, fall back to on-demand in-region: a Spot capacity gap in
-# australia-southeast1 must not wedge CI (observed 2026-09-10, run
-# 34419799571: `No matching instance offers`).
-spot_policy: auto
+# australia-southeast1 has PREEMPTIBLE_CPUS quota = 0 (verified 2026-09-10),
+# so Spot can never provision here. On-demand only until that quota is
+# raised. `backends: [gcp]` pins cloud-provisioning to GCP so dstack 0.21.5
+# does not try to place this on the `k0s` kubernetes fleet
+# (`No offers matching the run requirements in fleet 'k0s'`).
+backends: [gcp]
+spot_policy: on-demand
 retry:
   on_events: [no-capacity, interruption]
   duration: 20m

--- a/dev-env/ci-test.task.yaml
+++ b/dev-env/ci-test.task.yaml
@@ -14,10 +14,11 @@ resources:
   disk: 60GB..
   gpu: 0
 
-# spot first, fall back to on-demand in-region: a Spot capacity gap in
-# australia-southeast1 must not wedge CI (observed 2026-09-10, run
-# 34419799571: `No matching instance offers`).
-spot_policy: auto
+# On-demand only (australia-southeast1 PREEMPTIBLE_CPUS quota = 0) and
+# pinned to the gcp backend so dstack 0.21.5 doesn't route these at the
+# `k0s` kubernetes fleet.
+backends: [gcp]
+spot_policy: on-demand
 retry:
   on_events: [no-capacity, interruption]
   duration: 20m

--- a/dev-env/gcp-ci-fleet.yaml
+++ b/dev-env/gcp-ci-fleet.yaml
@@ -1,0 +1,23 @@
+# Elastic GCP cloud fleet for the build plane (plan gleaming-jingling-nygaard).
+#
+# dstack 0.21.x assigns every run to a fleet. `ci-build.task.yaml` /
+# `ci-test.task.yaml` (backends: [gcp]) have nowhere to land without this —
+# a bare `dstack apply` falls through to the only other fleet (`k0s`,
+# kubernetes-only) and fails `No offers matching … in fleet 'k0s'`.
+# Verified 2026-09-10: with this fleet, cpu=8/mem=32GB/disk=200GB → 113 GCP
+# offers (e2-standard-8 on-demand @ ~$0.38/hr, australia-southeast1).
+#
+# nodes: 0..2 → zero idle cost; dstack provisions a node sized to each run and
+# tears it down after `idle_duration`. on-demand because australia-southeast1
+# PREEMPTIBLE_CPUS quota = 0 (request that quota to restore Spot pricing).
+#
+# NO `resources:` block — dstack intersects the fleet's resources with each
+# run's, and a disjoint range raises "Cannot combine fleet requirements".
+# Unconstrained combines with both the 8-vCPU build and the 4-vCPU test tasks.
+#
+#   dstack apply -f dev-env/gcp-ci-fleet.yaml -y      # once per run; cheap
+type: fleet
+name: gcp-ci
+nodes: 0..2
+backends: [gcp]
+spot_policy: on-demand


### PR DESCRIPTION
Third measurement run ([34424111402](https://github.com/elasticdotventures/_b00t_/actions/runs/34424111402)) got past every earlier blocker (tailnet join, waker, `dstack project add`) then failed at `dstack apply`:

```
No matching instance offers available
… 20m retry …
No offers matching the run requirements in fleet 'k0s'
```

## Causes

1. **`australia-southeast1` `PREEMPTIBLE_CPUS` quota = 0** (`gcloud compute regions describe`). Spot can never provision there; `spot_policy: auto` didn't fall through cleanly. → `spot_policy: on-demand` (regular `CPUS` quota is 100).
2. **No `backends:` set** + only the `k0s` kubernetes fleet exists → dstack 0.21.5 tried to place the 8-vCPU/32 GB build on the 2-vCPU k0s node. → `backends: [gcp]` on both tasks.

## Follow-up (operator)

Request `PREEMPTIBLE_CPUS` quota for `australia-southeast1` to restore the Spot cost model (~4× cheaper compile-minutes). On-demand e2-standard-8 for a ~20 min build ≈ $0.19 — fine for now / for the measurement.

Dispatching `ci-build-plane.yml` from this branch to verify before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cj7a4Bkh8pRQuzcErD1j2E