### PR TITLE
fix(build-plane): test-runtime parity — bake just + nats-server + ts-rs dir into b00t-build

### DIFF
--- a/containers/b00t-build/Containerfile
+++ b/containers/b00t-build/Containerfile
@@ -38,6 +38,32 @@ RUN curl -fsSL "https://github.com/mozilla/sccache/releases/download/v${SCCACHE_
     && rm -rf /tmp/sccache-* /tmp/cargo-nextest \
     && sccache --version && cargo-nextest --version
 
+# Test-runtime deps the build-plane RUN stage (dev-env/ci-test.task.yaml)
+# needs but that are NOT compile deps — kept in lockstep with the same
+# installs in .github/workflows/ci.yml's `test` job (b00t #202):
+#   just >= 1.13  -> b00t-cli::{datum_justfile,just_ast} (`just --dump` json)
+#   nats-server   -> capability-forge::e2e_local_nats (spawns a real server)
+#   z3            -> already in the apt block above
+ARG JUST_VERSION=1.36.0
+ARG NATS_VERSION=2.14.5
+RUN curl -fsSL "https://github.com/casey/just/releases/download/${JUST_VERSION}/just-${JUST_VERSION}-x86_64-unknown-linux-musl.tar.gz" \
+      | tar xz -C /usr/local/bin just \
+    && just --version \
+    && curl -fsSL "https://github.com/nats-io/nats-server/releases/download/v${NATS_VERSION}/nats-server-v${NATS_VERSION}-linux-amd64.tar.gz" \
+      | tar xz -C /tmp \
+    && install -m0755 "/tmp/nats-server-v${NATS_VERSION}-linux-amd64/nats-server" /usr/local/bin/nats-server \
+    && rm -rf /tmp/nats-server-* \
+    && nats-server --version
+
+# b00t-c0re-lib/src/b00t_config.rs hardcodes #[ts(export_to = "/home/brianh/
+# promptexecution/infrastructure/b00t-website/dashboard/src/types/")] on 10+
+# types. ts-rs emits an export_bindings_* #[test] per type that WRITES there
+# (a compile-time-constant path, so --workspace-remap does not touch it), so
+# the dir must exist for those tests to pass off the maintainer's box. This
+# mirrors ci.yml's "Prepare ts-rs export target dir" step. Real fix = drop
+# the hardcoded path (#919).
+RUN mkdir -p /home/brianh/promptexecution/infrastructure/b00t-website/dashboard/src/types
+
 # gcsfuse (for the cache mount; needs privileged at run time for /dev/fuse)
 RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt gcsfuse-noble main" \
       > /etc/apt/sources.list.d/gcsfuse.list \

--- a/dev-env/ci-test.task.yaml
+++ b/dev-env/ci-test.task.yaml
@@ -34,6 +34,14 @@ env:
 commands:
   - set -eu
   - . "$HOME/.cargo/env"
+
+  # Test-runtime parity with ci.yml's `test` job (b00t #202). just / nats-server
+  # / z3 are baked into the b00t-build image (containers/b00t-build/Containerfile);
+  # this is a fail-fast guard if a stale image is in play, plus a runtime
+  # fallback for the ts-rs export dir that b00t-c0re-lib hardcodes.
+  - mkdir -p /home/brianh/promptexecution/infrastructure/b00t-website/dashboard/src/types
+  - 'for b in just nats-server z3; do command -v "$b" >/dev/null || { echo "MISSING $b in b00t-build image — rebuild containers/b00t-build (b00t #202)"; exit 1; }; done'
+
   - mkdir -p /data/src
 
   # gcs-obj.sh needs no repo — fetch just that one script over raw git is


### PR DESCRIPTION
b00t task **#202**. `ci-build-plane.yml` run [34428356633](https://github.com/elasticdotventures/_b00t_/actions/runs/34428356633): **build succeeded** (GCP fleet fix worked) but **all 4 compile-free test partitions failed** — the same tests pass 4/4 on `ci.yml`'s GitHub runners.

Root cause: `ci.yml`'s `test` job installs native test deps as explicit steps; the prebaked `b00t-build` image only had `z3`.

## `containers/b00t-build/Containerfile`

| Added | Why |
|---|---|
| `just` 1.36.0 (pinned musl binary) | `b00t-cli::{datum_justfile,just_ast}` shell out to `just --dump --dump-format json` (needs ≥ 1.13.0) |
| `nats-server` 2.14.5 (same pin as `ci.yml`) | `capability-forge::e2e_local_nats` spawns a real `nats-server` via PATH |
| `mkdir -p /home/brianh/…/dashboard/src/types` | `b00t-c0re-lib/src/b00t_config.rs` hardcodes `#[ts(export_to = "/home/brianh/…")]` on 10+ types → an `export_bindings_*` test per type writes there. Compile-time-constant path, so `--workspace-remap` doesn't touch it. These spread across all 4 partitions → **total failure**. Mirrors `ci.yml`'s "Prepare ts-rs export target dir" step. Real fix = drop the hardcoded path (#919). |

## `dev-env/ci-test.task.yaml`

Fail-fast guard (`command -v just nats-server z3`) + runtime `mkdir` fallback for a stale image.

## Rollout

Verified the `just` / `nats-server` release URLs + tar layout. Image rebuilds via `b00t-build-image.yml` on **merge to main** (`paths: containers/b00t-build/**`); the next `ci-build-plane.yml` run then picks up `:latest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cj7a4Bkh8pRQuzcErD1j2E