### PR TITLE
feat(build-plane): k0s CI test Job with SPIRE workload identity (#193)

### DIFF
--- a/deploy/k0s-ci-test/README.md
+++ b/deploy/k0s-ci-test/README.md
@@ -1,0 +1,50 @@
+# k0s CI test Job — SPIRE-identity, keyless GCS
+
+`dev-env/k0s-ci-test.task.yaml` documents this shape as a dstack task, but
+dstack 0.21.5's `kubernetes` backend has **no pod-spec injection** — it can't
+add the `csi.spiffe.io` volume, the `spiffe-helper` sidecar, the ADC
+ConfigMap, or `serviceAccountName`. So the identity-carrying variant runs as
+a plain k8s Job instead (b00t task #193). Plain, identity-free compile-free
+partitions still go through `dstack apply -f dev-env/ci-test.task.yaml`.
+
+## What it proves
+
+```
+Pod (SA b00t-ci, ns b00t-ci)
+  └─ spiffe-csi-driver mounts the Workload API socket
+  └─ spiffe-helper (native sidecar) fetches a JWT-SVID  -> /svid/jwt_svid.token
+        aud //iam.googleapis.com/projects/308167228204/…/providers/spire-provider
+  └─ run: gcs-obj.sh (external_account) -> STS token exchange
+        -> impersonate b00t-buildplane-ci  (roles/storage.objectViewer on the bucket)
+        -> KEYLESS GET gs://b00t-buildcache-promptexecution/<archive>
+  └─ cargo nextest run --archive-file … --partition …   (no rustc)
+```
+
+No SA key, no GCE metadata server. Identity + WIF binding live in
+`PromptExecution/infrastructure` (`terraform/google/google-oidc-spire-buildplane.tf`,
+`k0s/spire/`). Prereqs already on the cluster: the `spire-agent` +
+`spiffe-csi-driver` DaemonSets in ns `spire`, the `b00t-ci` SA in ns
+`b00t-ci`, and the SPIRE registration entry
+`spiffe://promptexecution.com/ns/b00t-ci/sa/b00t-ci` (selectors `k8s:ns:b00t-ci`
++ `k8s:sa:b00t-ci`).
+
+## Run
+
+```sh
+# CI_ARCHIVE_KEY is what ci-build.task.yaml published, e.g.:
+deploy/k0s-ci-test/run.sh ci-archives/34428356633-1 1/16
+```
+
+`run.sh` applies the ConfigMap + a `$`-substituted Job, waits, streams logs,
+prints the Job condition. Sized for vultr1 (2 vCPU / ~3.7 GiB / ~67 GiB eph)
+— keep the partition fraction small (`1/16` default); the full test fan-out
+belongs on GCP Spot (`ci-build-plane.yml`). `kubectl` is reached over the
+tailnet (`ssh root@100.109.101.1 k0s kubectl`); set `KUBECTL="k0s kubectl"`
+to run on the node.
+
+## Dagster
+
+`orchestration/dagster/` currently drives `dstack apply` only. A
+`KubernetesJobResource` op that shells this `run.sh` is the natural follow-up
+so `ci_build_plane` can route the identity-bearing partition through k0s
+while the rest stay on Spot.

--- a/deploy/k0s-ci-test/configmap.yaml
+++ b/deploy/k0s-ci-test/configmap.yaml
@@ -1,0 +1,23 @@
+# SPIRE JWT-SVID -> GCP external_account (WIF) wiring for the k0s CI test Job.
+# Identical audience / impersonated SA to deploy/k0s-waker (the same
+# spiffe://promptexecution.com/ns/b00t-ci/sa/b00t-ci workload identity), kept
+# as a SEPARATE ConfigMap so the Job doesn't couple to the waker's lifecycle.
+# b00t task #193. See PromptExecution/infrastructure
+# terraform/google/google-oidc-spire-buildplane.tf + k0s/spire/.
+apiVersion: v1
+kind: ConfigMap
+metadata: { name: b00t-ci-test-src, namespace: b00t-ci }
+data:
+  helper.conf: |
+    agent_address = "/spiffe-workload-api/spire-agent.sock"
+    daemon_mode = true
+    jwt_svids = [{ jwt_audience = "//iam.googleapis.com/projects/308167228204/locations/global/workloadIdentityPools/spire-pool/providers/spire-provider", jwt_svid_file_name = "/svid/jwt_svid.token" }]
+  credential-configuration.json: |
+    {
+      "type": "external_account",
+      "audience": "//iam.googleapis.com/projects/308167228204/locations/global/workloadIdentityPools/spire-pool/providers/spire-provider",
+      "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+      "token_url": "https://sts.googleapis.com/v1/token",
+      "credential_source": { "file": "/svid/jwt_svid.token", "format": { "type": "text" } },
+      "service_account_impersonation_url": "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/b00t-buildplane-ci@promptexecution.iam.gserviceaccount.com:generateAccessToken"
+    }

--- a/deploy/k0s-ci-test/job.yaml
+++ b/deploy/k0s-ci-test/job.yaml
@@ -1,0 +1,90 @@
+# One compile-free nextest partition as a k0s Job that carries the SPIRE
+# workload identity — the piece dstack 0.21.5's kubernetes backend cannot
+# express (no pod-spec injection: no init/sidecar container, no csi.spiffe.io
+# inline volume, no serviceAccountName). b00t task #193.
+#
+# What it proves: pod (SA b00t-ci) -> spiffe-csi-driver -> spiffe-helper
+# JWT-SVID -> external_account STS exchange -> impersonate b00t-buildplane-ci
+# -> KEYLESS read of gs://b00t-buildcache-promptexecution -> run tests from
+# the prebuilt nextest archive. No SA key, no GCE metadata.
+#
+# Per-run values are $-substituted (see run.sh):
+#   CI_ARCHIVE_KEY     e.g. ci-archives/<run>-<attempt>  (from ci-build.task.yaml)
+#   NEXTEST_PARTITION  e.g. 1/16   (small — vultr1 is 2 vCPU / ~3.7Gi / ~67Gi eph)
+#   JOB_SUFFIX         unique per apply
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: b00t-ci-test-${JOB_SUFFIX}
+  namespace: b00t-ci
+  labels: { app: b00t-ci-test, b00t.plane: build }
+spec:
+  backoffLimit: 0
+  ttlSecondsAfterFinished: 3600
+  activeDeadlineSeconds: 2400
+  template:
+    metadata: { labels: { app: b00t-ci-test, b00t.plane: build } }
+    spec:
+      serviceAccountName: b00t-ci
+      restartPolicy: Never
+      initContainers:
+        # Native sidecar (k8s >= 1.28): starts before `run`, keeps the
+        # JWT-SVID fresh for the whole Job, does not block completion.
+        - name: spiffe-helper
+          image: ghcr.io/spiffe/spiffe-helper:0.11.0
+          args: ["-config", "/cfg/helper.conf"]
+          restartPolicy: Always
+          securityContext: { runAsUser: 0 }
+          # No probe: ghcr.io/spiffe/spiffe-helper is distroless (no shell,
+          # no `test`) so an exec probe errors forever. As a native sidecar it
+          # is "started" once its container runs; the `run` script below polls
+          # for the first SVID write (it lands in ~1s).
+          volumeMounts:
+            - { name: spiffe, mountPath: /spiffe-workload-api, readOnly: true }
+            - { name: svid, mountPath: /svid }
+            - { name: cfg, mountPath: /cfg, readOnly: true }
+      containers:
+        - name: run
+          image: australia-southeast1-docker.pkg.dev/promptexecution/b00t/b00t-build:latest
+          command: ["bash", "-c"]
+          args:
+            - |
+              set -euo pipefail
+              . "$HOME/.cargo/env"
+              test -s /cfg/credential-configuration.json
+              for i in $(seq 1 60); do [ -s /svid/jwt_svid.token ] && break; sleep 1; done
+              test -s /svid/jwt_svid.token
+              echo "SVID present ($(wc -c </svid/jwt_svid.token) bytes) after ${i}s"
+              mkdir -p /data/src
+              echo "--- keyless GCS fetch (external_account -> STS -> impersonate b00t-buildplane-ci) ---"
+              gcs-obj.sh get "$BUILDCACHE_BUCKET" "$CI_ARCHIVE_KEY/src.tar.zst"     /data/src.tar.zst
+              gcs-obj.sh get "$BUILDCACHE_BUCKET" "$CI_ARCHIVE_KEY/nextest.tar.zst" /data/nextest.tar.zst
+              tar -I zstd -xf /data/src.tar.zst -C /data/src
+              du -sh /data/src /data/nextest.tar.zst
+              # b00t-c0re-lib hardcodes a ts-rs export_to path (see #202)
+              mkdir -p /home/brianh/promptexecution/infrastructure/b00t-website/dashboard/src/types
+              echo "--- nextest run (partition ${NEXTEST_PARTITION}) ---"
+              exec cargo nextest run \
+                --archive-file /data/nextest.tar.zst \
+                --workspace-remap /data/src \
+                --partition "count:${NEXTEST_PARTITION}" \
+                --test-threads 2 --no-fail-fast
+          env:
+            - { name: BUILDCACHE_BUCKET, value: b00t-buildcache-promptexecution }
+            - { name: GOOGLE_APPLICATION_CREDENTIALS, value: /cfg/credential-configuration.json }
+            - { name: GCP_WIF_AUDIENCE, value: "//iam.googleapis.com/projects/308167228204/locations/global/workloadIdentityPools/spire-pool/providers/spire-provider" }
+            - { name: CI_ARCHIVE_KEY, value: "${CI_ARCHIVE_KEY}" }
+            - { name: NEXTEST_PARTITION, value: "${NEXTEST_PARTITION}" }
+            - { name: CARGO_TERM_COLOR, value: never }
+          resources:
+            requests: { cpu: "1", memory: "1200Mi", ephemeral-storage: "8Gi" }
+            limits:   { cpu: "2", memory: "3Gi",    ephemeral-storage: "45Gi" }
+          volumeMounts:
+            - { name: svid, mountPath: /svid, readOnly: true }
+            - { name: cfg, mountPath: /cfg, readOnly: true }
+            - { name: data, mountPath: /data }
+      volumes:
+        - { name: spiffe, csi: { driver: csi.spiffe.io, readOnly: true } }
+        - { name: svid, emptyDir: {} }
+        - { name: cfg, configMap: { name: b00t-ci-test-src } }
+        - { name: data, emptyDir: {} }

--- a/deploy/k0s-ci-test/kustomization.yaml
+++ b/deploy/k0s-ci-test/kustomization.yaml
@@ -1,0 +1,7 @@
+# `kubectl apply -k deploy/k0s-ci-test` applies only the ConfigMap. The Job
+# is per-run and $-substituted — apply it with deploy/k0s-ci-test/run.sh.
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: b00t-ci
+resources:
+  - configmap.yaml

--- a/deploy/k0s-ci-test/run.sh
+++ b/deploy/k0s-ci-test/run.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Run one compile-free nextest partition on k0s (vultr1) with the SPIRE
+# workload identity — the keyless-GCS path dstack's kubernetes backend can't
+# carry (b00t task #193). Apply, wait, stream logs, report the Job's result.
+#
+#   deploy/k0s-ci-test/run.sh <CI_ARCHIVE_KEY> [NEXTEST_PARTITION]
+#
+#   CI_ARCHIVE_KEY     ci-archives/<run>-<attempt>  (published by ci-build.task.yaml)
+#   NEXTEST_PARTITION  default 1/16  (vultr1 is small)
+#
+# kubectl is reached via the tailnet: `ssh root@100.109.101.1 'k0s kubectl …'`.
+# Override with KUBECTL="k0s kubectl" when run on the node itself.
+set -euo pipefail
+
+CI_ARCHIVE_KEY="${1:?usage: run.sh <CI_ARCHIVE_KEY> [NEXTEST_PARTITION]}"
+NEXTEST_PARTITION="${2:-1/16}"
+JOB_SUFFIX="$(date -u +%Y%m%d%H%M%S)-$RANDOM"
+KUBECTL="${KUBECTL:-ssh -o ConnectTimeout=12 root@100.109.101.1 k0s kubectl}"
+here="$(cd "$(dirname "$0")" && pwd)"
+
+echo "archive=$CI_ARCHIVE_KEY partition=$NEXTEST_PARTITION job=b00t-ci-test-$JOB_SUFFIX"
+
+$KUBECTL apply -f - < "$here/configmap.yaml"
+
+export CI_ARCHIVE_KEY NEXTEST_PARTITION JOB_SUFFIX
+envsubst '${CI_ARCHIVE_KEY} ${NEXTEST_PARTITION} ${JOB_SUFFIX}' < "$here/job.yaml" | $KUBECTL apply -f -
+
+job="job/b00t-ci-test-$JOB_SUFFIX"
+echo "--- waiting (Complete or Failed) ---"
+$KUBECTL -n b00t-ci wait "$job" --for=condition=Complete --timeout=2400s &
+w1=$!
+$KUBECTL -n b00t-ci wait "$job" --for=condition=Failed --timeout=2400s &
+w2=$!
+wait -n "$w1" "$w2" || true
+kill "$w1" "$w2" 2>/dev/null || true
+
+$KUBECTL -n b00t-ci logs "$job" --all-containers --tail=-1 || true
+echo "--- status ---"
+$KUBECTL -n b00t-ci get "$job" -o jsonpath='{.status.conditions[*].type}{"\n"}'


### PR DESCRIPTION
b00t task **#193**. `dstack apply` can't run the identity-carrying compile-free partition (dstack 0.21.5's kubernetes backend has **no pod-spec injection** — no init/sidecar, no `csi.spiffe.io` inline volume, no `serviceAccountName`). `dev-env/k0s-ci-test.task.yaml` points here for the kubectl/Dagster path.

## `deploy/k0s-ci-test/`

| File | |
|---|---|
| `configmap.yaml` | `b00t-ci-test-src` — spiffe-helper `helper.conf` + the `external_account` `credential-configuration.json` (same audience + impersonated SA `b00t-buildplane-ci` as `deploy/k0s-waker`, decoupled) |
| `job.yaml` | Job (SA `b00t-ci`) — spiffe-helper **native sidecar** (k8s ≥1.28) + `csi.spiffe.io` ephemeral volume + `b00t-build` image running `gcs-obj.sh get` (keyless) then `cargo nextest run --archive-file --partition`. vultr1-sized (2 vCPU / ~3.7 GiB). No startup probe — the spiffe-helper image is distroless; the run script polls for the SVID |
| `run.sh` | `$`-subst + apply + wait + stream logs; `kubectl` over the tailnet |
| `README.md`, `kustomization.yaml` | |

## Verified live on vultr1 (against `ci-archives/34428356633-1`)

```
SVID present (794 bytes) after 1s
get gs://…/src.tar.zst     -> 55.6 MB     ← keyless: external_account → STS →
get gs://…/nextest.tar.zst -> 544.9 MB       impersonate b00t-buildplane-ci
--- nextest run (partition 1/16) --- Extracting 149 binaries …   ← compile-free
```

Identity + keyless-GCS + compile-free-archive all confirmed. Test pass/fail on the current `:latest` image is #202's concern (just/nats-server not yet baked). A Dagster op wrapping `run.sh` is the natural follow-up so `ci_build_plane` can route the identity-bearing partition through k0s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cj7a4Bkh8pRQuzcErD1j2E