### PR TITLE
chore(hooks): commit-hook blocks direct commits to main

### DIFF
--- a/justfile
+++ b/justfile
@@ -676,6 +676,17 @@ version:
 commit-hook:
     #!/bin/bash
     set -euo pipefail
+    # Block direct commits to main — always work on a branch + PR (task #211).
+    CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+    if [[ "${CURRENT_BRANCH}" == "main" ]]; then
+        if [[ -f ".b00t/allow-main-commit" ]]; then
+            echo "⚠️  Committing directly to main (allow-main-commit present) — confirm intentional."
+        else
+            echo "❌ Direct commits to main are blocked. Create a branch: git checkout -b <name>"
+            echo "   To bypass once: touch .b00t/allow-main-commit (not recommended, remove after)"
+            exit 1
+        fi
+    fi
     # If strict-review flag exists, run the blocking reviewer gate
     if [[ -f ".b00t/strict-review" ]]; then
         echo "🛡️  strict-review gate active — validating staged changes..."


### PR DESCRIPTION
## Summary
- Adds a branch guard to the `commit-hook` justfile recipe (wired via `.git/hooks/pre-commit`) that blocks committing directly to `main`.
- Same style as the existing gates in that recipe (strict-review, gate-schema, datum-graph coherence): check → block with `exit 1` and a clear message → documented `.b00t/<flag-file>` bypass.
- Closes b00t task #211.

Motivated by a live incident this session: a design-doc commit landed on local `main` by mistake (should have gone straight to a feature branch) and had to be manually cherry-picked off and `main` reset back to `origin/main`. This hook would have caught it automatically.

## Test plan
- [x] Verified the guard logic in isolation: blocks with exit 1 when `CURRENT_BRANCH=main` and no bypass flag present; passes through cleanly on a feature branch.
- [x] `pre-push` gate passed on this branch (no Rust packages affected).
- [ ] Reviewer: confirm the `.b00t/allow-main-commit` bypass convention matches existing usage elsewhere.