### PR TITLE
fix(ci-build-plane): add archive validation + verbose output to ci-test (#1304)

### DIFF
--- a/dev-env/ci-test.task.yaml
+++ b/dev-env/ci-test.task.yaml
@@ -60,9 +60,25 @@ commands:
   - tar -I zstd -xf /data/src.tar.zst -C /data/src
   - du -sh /data/src /data/nextest.tar.zst
 
+  # --- validate the archive before running (gh #1304) ---
+  # If listing fails here, the archive is bad or the remap is wrong — no
+  # point running partitions. If it succeeds, we know the archive format,
+  # test discovery, and workspace structure are all correct; a subsequent
+  # run failure is then isolated to binary execution (linking, resources,
+  # file-descriptor limits, etc.).
+  - echo "=== test listing (partition ${NEXTEST_PARTITION}) ==="
+  - cargo nextest list
+      --archive-file /data/nextest.tar.zst
+      --workspace-remap /data/src
+      --partition "count:${NEXTEST_PARTITION}"
+      -T human-verbose 2>&1 | tail -5
+
   # Run the partition from the archive, remapped onto the downloaded source
   # tree (tests that read workspace-relative fixture files need it).
+  # --failure-output final ensures per-test failure detail reaches dstack
+  # logs even if nextest own stdout buffering drops it mid-stream.
   - cargo nextest run
       --archive-file /data/nextest.tar.zst
       --workspace-remap /data/src
       --partition "count:${NEXTEST_PARTITION}"
+      --failure-output final


### PR DESCRIPTION
## What

Adds a `cargo nextest list --archive-file` validation step **before** the run step in `ci-test.task.yaml`. Also adds `--failure-output final` to the run command for better error visibility in dstack logs.

## Why

Issue #1304: the test-matrix stage fails uniformly across all 4 partitions with zero per-test detail. The failure happens ~11s after archive extraction — too fast for real test execution, suggesting the test binaries crash on startup before nextest can capture per-test output.

## How this helps

- **If listing fails**: the archive format or workspace-remap is broken — we know the archive can't be read at all.
- **If listing succeeds but running fails**: the issue is isolated to binary execution (dynamic linking, file descriptor limits, SYS_RESOURCE capability, etc.).
- **`--failure-output final`**: ensures per-test failure detail reaches dstack logs even if nextest's stdout buffering drops it mid-stream.

Closes #1304 once the root cause is identified from the new diagnostics.